### PR TITLE
Issue 12 add css to html

### DIFF
--- a/src/scancode/templates/html/template.html
+++ b/src/scancode/templates/html/template.html
@@ -33,18 +33,18 @@
     <meta charset="utf-8">
     <title>ScanCode results</title>
     <style type="text/css">
-      .tb  {
+      table  {
         border-collapse:collapse;
         border: 1px solid gray;
         margin-bottom: 20px;
       }
-      .tb td{
+      td{
         padding: 5px 5px;
         border-style: solid;
         border-width: 1px;
         overflow: hidden;
       }
-      .tb th{
+      th{
         padding:10px 5px;
         border-style: solid;
         border-width: 1px;
@@ -64,7 +64,7 @@
     </style>
   </head>
   <body>
-    <table class="tb">
+    <table>
       <thead>
         <tr>
           <th>location</th>
@@ -94,7 +94,7 @@
     </table>
 
     {% if licenses %}
-    <table class="tb">
+    <table>
       <caption>Licenses</caption>
       <thead>
         <tr>

--- a/src/scancode/templates/html/template.html
+++ b/src/scancode/templates/html/template.html
@@ -64,7 +64,7 @@
     </style>
   </head>
   <body>
-    <table>
+    <table class="tb">
       <thead>
         <tr>
           <th>location</th>
@@ -94,7 +94,7 @@
     </table>
 
     {% if licenses %}
-    <table>
+    <table class="tb">
       <caption>Licenses</caption>
       <thead>
         <tr>

--- a/src/scancode/templates/html/template.html
+++ b/src/scancode/templates/html/template.html
@@ -33,8 +33,34 @@
     <meta charset="utf-8">
     <title>ScanCode results</title>
     <style type="text/css">
-      table, td, th { border: 1px solid gray }
-      table { margin-bottom: 20px }
+      .tb  {
+        border-collapse:collapse;
+        border: 1px solid gray;
+        margin-bottom: 20px;
+      }
+      .tb td{
+        padding: 5px 5px;
+        border-style: solid;
+        border-width: 1px;
+        overflow: hidden;
+      }
+      .tb th{
+        padding:10px 5px;
+        border-style: solid;
+        border-width: 1px;
+        overflow: hidden;
+        border-color: gray;
+        color: #fff;
+        background-color: #5E81B7;
+      }
+      tr:nth-child(even)  { background-color:#FFFFFF; }
+      tr:nth-child(odd) { background-color:#F9F9F9; }
+      tr:hover {background-color: #EEEEEE;}
+      * {
+        font-family: Helvetica, Arial, sans-serif;
+        font-weight: normal;
+        font-size: 12px;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
Referencing issue #12 

My attempt at some low-hanging fruit, Ive added some minimal inline css styling to the plain html output for scancode. Color schemes are loosely modeled after DejaCode and can be changed easily.

ran scancode using: `./scancode --format html samples ~/Desktop/samples.html`

output html: https://gist.github.com/597660fc489e3a53096d.git or https://gist.github.com/majurg/597660fc489e3a53096d