### PR TITLE
Reading files in blocks of 1 MB size

### DIFF
--- a/src/extractcode/uncompress.py
+++ b/src/extractcode/uncompress.py
@@ -63,7 +63,7 @@ def uncompress(location, target_dir, decompressor, suffix=EXTRACT_SUFFIX):
     with decompressor(location, 'rb') as compressed:
         with open(target_location, 'wb') as uncompressed:
             while True:
-                chunk = compressed.read(1024 * 1024)
+                chunk = compressed.read(8 * 1024 * 1024)
                 if not chunk:
                     break
                 uncompressed.write(chunk)

--- a/src/extractcode/uncompress.py
+++ b/src/extractcode/uncompress.py
@@ -62,8 +62,11 @@ def uncompress(location, target_dir, decompressor, suffix=EXTRACT_SUFFIX):
     target_location = os.path.join(target_dir, os.path.basename(location) + suffix)
     with decompressor(location, 'rb') as compressed:
         with open(target_location, 'wb') as uncompressed:
-            chunk = compressed.read()
-            uncompressed.write(chunk)
+            while True:
+                chunk = compressed.read(1024 * 1024)
+                if not chunk:
+                    break
+                uncompressed.write(chunk)
         if getattr(decompressor, 'has_trailing_garbage', False):
             warnings.append(location +': Trailing garbage found and ignored.')
     return warnings

--- a/src/extractcode/uncompress.py
+++ b/src/extractcode/uncompress.py
@@ -62,8 +62,9 @@ def uncompress(location, target_dir, decompressor, suffix=EXTRACT_SUFFIX):
     target_location = os.path.join(target_dir, os.path.basename(location) + suffix)
     with decompressor(location, 'rb') as compressed:
         with open(target_location, 'wb') as uncompressed:
+            EIGHT_MB = 8 * 1024 * 1024
             while True:
-                chunk = compressed.read(8 * 1024 * 1024)
+                chunk = compressed.read(EIGHT_MB)
                 if not chunk:
                     break
                 uncompressed.write(chunk)


### PR DESCRIPTION
The following code snippet is added to `uncompress` module in the `extractcode` to perform extraction for large archives. This is a fix for #158

```
 with open(target_location, 'wb') as uncompressed:
            while True:
                chunk = compressed.read(1024*1024)
                if not chunk:
                    break
                uncompressed.write(chunk)
```