### PR TITLE
#173 new rules added to detect GPL 3.0 or later version

### DIFF
--- a/src/licensedcode/data/rules/gpl-3.0_19.RULE
+++ b/src/licensedcode/data/rules/gpl-3.0_19.RULE
@@ -1,0 +1,15 @@
+-- you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  {{5 GNAT}} is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --

--- a/src/licensedcode/data/rules/gpl-3.0_19.yml
+++ b/src/licensedcode/data/rules/gpl-3.0_19.yml
@@ -1,0 +1,3 @@
+licenses:
+    - gpl-3.0
+template: yes

--- a/src/licensedcode/data/rules/gpl-3.0_19.yml
+++ b/src/licensedcode/data/rules/gpl-3.0_19.yml
@@ -1,3 +1,4 @@
 licenses:
     - gpl-3.0
+    - gpl-3.0-gcc
 template: yes

--- a/src/licensedcode/data/rules/gpl-3.0_20.RULE
+++ b/src/licensedcode/data/rules/gpl-3.0_20.RULE
@@ -1,0 +1,15 @@
+-- you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Software --
+-- Foundation;  either version 3,  or (at your option) any later version. --
+-- {{5 GNAT}} is distributed in the hope that it will be useful, but WITHOUT --
+-- ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --

--- a/src/licensedcode/data/rules/gpl-3.0_20.yml
+++ b/src/licensedcode/data/rules/gpl-3.0_20.yml
@@ -1,0 +1,2 @@
+licenses:
+    - gpl-3.0

--- a/src/licensedcode/data/rules/gpl-3.0_20.yml
+++ b/src/licensedcode/data/rules/gpl-3.0_20.yml
@@ -1,2 +1,4 @@
 licenses:
     - gpl-3.0
+    - gpl-3.0-gcc
+template: yes

--- a/tests/licensedcode/data/licenses/gpl-3.0_5.txt
+++ b/tests/licensedcode/data/licenses/gpl-3.0_5.txt
@@ -1,0 +1,28 @@
+                         GNAT COMPILER COMPONENTS                         
+                                                                          
+                       S Y S T E M . V A L _ L L U                        
+                                                                          
+                                 S p e c                                  
+                                                                          
+          Copyright (C) 1992-2009, Free Software Foundation, Inc.         
+                                                                          
+ GNAT is free software;  you can  redistribute it  and/or modify it under 
+ terms of the  GNU General Public License as published  by the Free Soft- 
+ ware  Foundation;  either version 3,  or (at your option) any later ver- 
+ sion.  GNAT is distributed in the hope that it will be useful, but WITH- 
+ OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY 
+ or FITNESS FOR A PARTICULAR PURPOSE.                                     
+                                                                          
+ As a special exception under Section 7 of GPL version 3, you are granted 
+ additional permissions described in the GCC Runtime Library Exception,   
+ version 3.1, as published by the Free Software Foundation.               
+                                                                          
+ You should have received a copy of the GNU General Public License and    
+ a copy of the GCC Runtime Library Exception along with this program;     
+ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    
+ <http://www.gnu.org/licenses/>.                                          
+                                                                          
+ GNAT was originally developed  by the GNAT team at  New York University. 
+ Extensive contributions were provided by Ada Core Technologies Inc.      
+                                                                          
+

--- a/tests/licensedcode/data/licenses/gpl-3.0_5.yml
+++ b/tests/licensedcode/data/licenses/gpl-3.0_5.yml
@@ -1,0 +1,3 @@
+licenses:
+    - gpl-3.0
+template: yes

--- a/tests/licensedcode/data/licenses/gpl-3.0_5.yml
+++ b/tests/licensedcode/data/licenses/gpl-3.0_5.yml
@@ -1,3 +1,3 @@
 licenses:
     - gpl-3.0
-template: yes
+    - gpl-3.0-gcc

--- a/tests/licensedcode/data/licenses/gpl-3.0_6.txt
+++ b/tests/licensedcode/data/licenses/gpl-3.0_6.txt
@@ -1,0 +1,13 @@
+  GNAT is free software; you can  redistribute it  and/or modify it under 
+ terms of the  GNU General Public License as published  by the Free Software 
+ Foundation;  either version 3,  or (at your option) any later version. 
+ {{5 GNAT}} is distributed in the hope that it will be useful, but WITHOUT 
+ ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY 
+ or FITNESS FOR A PARTICULAR PURPOSE.     As a special exception under Section 7 of GPL version 3, you are granted 
+ additional permissions described in the GCC Runtime Library Exception,   
+ version 3.1, as published by the Free Software Foundation.               
+                                                                          
+ You should have received a copy of the GNU General Public License and    
+ a copy of the GCC Runtime Library Exception along with this program;     
+ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    
+ <http://www.gnu.org/licenses/>.           

--- a/tests/licensedcode/data/licenses/gpl-3.0_6.yml
+++ b/tests/licensedcode/data/licenses/gpl-3.0_6.yml
@@ -1,0 +1,3 @@
+licenses:
+    - gpl-3.0
+template: yes

--- a/tests/licensedcode/data/licenses/gpl-3.0_6.yml
+++ b/tests/licensedcode/data/licenses/gpl-3.0_6.yml
@@ -1,3 +1,3 @@
 licenses:
     - gpl-3.0
-template: yes
+    - gpl-3.0-gcc


### PR DESCRIPTION
New rules to detect `GPL 3.0 or later` version of licenses are added