### PR TITLE
#179 new rule to detect dual license choice of bsd-new or  apache-2.0

### DIFF
--- a/src/licensedcode/data/rules/bsd-new_and_apache.RULE
+++ b/src/licensedcode/data/rules/bsd-new_and_apache.RULE
@@ -1,0 +1,2 @@
+dual licensed under the terms of the Apache License, Version
+2.0, and the BSD License

--- a/src/licensedcode/data/rules/bsd-new_and_apache.yml
+++ b/src/licensedcode/data/rules/bsd-new_and_apache.yml
@@ -1,0 +1,3 @@
+licenses:
+    - bsd-new
+    - apache-2.0

--- a/src/licensedcode/data/rules/bsd-new_and_apache.yml
+++ b/src/licensedcode/data/rules/bsd-new_and_apache.yml
@@ -1,3 +1,4 @@
 licenses:
     - bsd-new
     - apache-2.0
+license_choice: yes

--- a/tests/licensedcode/data/licenses/bsd-new_and-apache.txt
+++ b/tests/licensedcode/data/licenses/bsd-new_and-apache.txt
@@ -1,0 +1,3 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this
+// repository for complete details.

--- a/tests/licensedcode/data/licenses/bsd-new_and-apache.yml
+++ b/tests/licensedcode/data/licenses/bsd-new_and-apache.yml
@@ -1,0 +1,3 @@
+licenses:
+    - bsd-new
+    - apache-2.0


### PR DESCRIPTION
Adding a new rule to detect dual licenses `bsd-new` and `apache-2.0`