### PR TITLE
#175 new rule to detect gpl-2.0 license

### DIFF
--- a/src/licensedcode/data/rules/gpl-2.0_63.RULE
+++ b/src/licensedcode/data/rules/gpl-2.0_63.RULE
@@ -1,0 +1,1 @@
+See the file COPYING (GNU General Public License) for license conditions

--- a/src/licensedcode/data/rules/gpl-2.0_63.yml
+++ b/src/licensedcode/data/rules/gpl-2.0_63.yml
@@ -1,0 +1,2 @@
+licenses:
+    - gpl-2.0

--- a/tests/licensedcode/data/licenses/gpl-2.0_42.txt
+++ b/tests/licensedcode/data/licenses/gpl-2.0_42.txt
@@ -1,0 +1,6 @@
+StartFontMetrics 3.0
+Comment Copyright URW Software, Copyright 1997 by URW
+Comment Creation Date: 10/19/1999
+Comment See the file COPYING (GNU General Public License) for license conditions.
+FontName Dingbats
+FullName Dingbats 

--- a/tests/licensedcode/data/licenses/gpl-2.0_42.yml
+++ b/tests/licensedcode/data/licenses/gpl-2.0_42.yml
@@ -1,0 +1,2 @@
+licenses:
+    - gpl-2.0


### PR DESCRIPTION
New rule to detect `General Public License version 2.0` is added. 