### PR TITLE
#194 adding a new rule to detect GPL license with no version

### DIFF
--- a/src/licensedcode/data/rules/gpl_48.RULE
+++ b/src/licensedcode/data/rules/gpl_48.RULE
@@ -1,0 +1,1 @@
+is licensed under the GPL

--- a/src/licensedcode/data/rules/gpl_48.yml
+++ b/src/licensedcode/data/rules/gpl_48.yml
@@ -1,0 +1,2 @@
+licenses:
+    - gpl

--- a/tests/licensedcode/data/licenses/adobe-air-sdk.yml
+++ b/tests/licensedcode/data/licenses/adobe-air-sdk.yml
@@ -1,2 +1,3 @@
 licenses:
     - adobe-air-sdk
+    - gpl

--- a/tests/licensedcode/data/licenses/bsd-new_53.yml
+++ b/tests/licensedcode/data/licenses/bsd-new_53.yml
@@ -1,2 +1,3 @@
 licenses:
     - bsd-new
+    - gpl

--- a/tests/licensedcode/data/licenses/gpl-2.0-plus_and_gpl-2.0-plus_and_lgpl-2.1-plus_and_mpl-1.1_and_other.yml
+++ b/tests/licensedcode/data/licenses/gpl-2.0-plus_and_gpl-2.0-plus_and_lgpl-2.1-plus_and_mpl-1.1_and_other.yml
@@ -3,3 +3,4 @@ licenses:
     - gpl-2.0-plus
     - lgpl-2.1-plus
     - mpl-1.1
+    - gpl

--- a/tests/licensedcode/data/licenses/gpl_66.txt
+++ b/tests/licensedcode/data/licenses/gpl_66.txt
@@ -1,0 +1,3 @@
+  // The code in this file is loosly based on main.js, part of Natural Docs,
+// which is Copyright (C) 2003-2008 Greg Valure
+// Natural Docs is licensed under the GPL.

--- a/tests/licensedcode/data/licenses/gpl_66.yml
+++ b/tests/licensedcode/data/licenses/gpl_66.yml
@@ -1,0 +1,2 @@
+licenses:
+    - gpl


### PR DESCRIPTION
New rule to detect the license `GPL` with no version is added. Added this license to a few tests which has the same text.