### PR TITLE
Add SPDX keys even for (L)GPL licenses that do not specify a version

### DIFF
--- a/src/licensedcode/data/licenses/gpl.yml
+++ b/src/licensedcode/data/licenses/gpl.yml
@@ -3,3 +3,4 @@ short_name: GPL
 name: GPL, no version
 category: Copyleft
 owner: Free Software Foundation (FSF)
+spdx_license_key: GPL-1.0+

--- a/src/licensedcode/data/licenses/lgpl.yml
+++ b/src/licensedcode/data/licenses/lgpl.yml
@@ -3,3 +3,4 @@ short_name: LGPL
 name: LGPL, no version
 category: Copyleft Limited
 owner: Free Software Foundation (FSF)
+spdx_license_key: LGPL-2.0+


### PR DESCRIPTION
In that case, choose the minimal applicable version including the "+"
modifier denoting "this or a later version".