### PR TITLE
#281: added explicit test cases for npm package scanning

### DIFF
--- a/tests/scancode/data/package/package.json
+++ b/tests/scancode/data/package/package.json
@@ -1,0 +1,96 @@
+{
+  "name": "async",
+  "description": "Higher-order functions and common patterns for asynchronous code",
+  "main": "lib/async.js",
+  "author": {
+    "name": "Caolan McMahon"
+  },
+  "version": "1.2.1",
+  "keywords": [
+    "async",
+    "callback",
+    "utility",
+    "module"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/caolan/async.git"
+  },
+  "bugs": {
+    "url": "https://github.com/caolan/async/issues"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "benchmark": "github:bestiejs/benchmark.js",
+    "coveralls": "^2.11.2",
+    "jshint": "~2.7.0",
+    "lodash": ">=2.4.1",
+    "mkdirp": "~0.5.1",
+    "nodeunit": ">0.0.0",
+    "nyc": "^2.1.0",
+    "uglify-js": "1.2.x",
+    "yargs": "~3.9.1"
+  },
+  "jam": {
+    "main": "lib/async.js",
+    "include": [
+      "lib/async.js",
+      "README.md",
+      "LICENSE"
+    ],
+    "categories": [
+      "Utilities"
+    ]
+  },
+  "scripts": {
+    "test": "npm run-script lint && nodeunit test/test-async.js",
+    "lint": "jshint lib/*.js test/*.js perf/*.js",
+    "coverage": "nyc npm test && nyc report",
+    "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
+  },
+  "spm": {
+    "main": "lib/async.js"
+  },
+  "volo": {
+    "main": "lib/async.js",
+    "ignore": [
+      "**/.*",
+      "node_modules",
+      "bower_components",
+      "test",
+      "tests"
+    ]
+  },
+  "gitHead": "b66e85d1cca8c8056313253f22d18f571e7001d2",
+  "homepage": "https://github.com/caolan/async#readme",
+  "_id": "async@1.2.1",
+  "_shasum": "a4816a17cd5ff516dfa2c7698a453369b9790de0",
+  "_from": "async@*",
+  "_npmVersion": "2.9.0",
+  "_nodeVersion": "2.0.2",
+  "_npmUser": {
+    "name": "aearly",
+    "email": "alexander.early@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "caolan",
+      "email": "caolan.mcmahon@gmail.com"
+    },
+    {
+      "name": "beaugunderson",
+      "email": "beau@beaugunderson.com"
+    },
+    {
+      "name": "aearly",
+      "email": "alexander.early@gmail.com"
+    }
+  ],
+  "dist": {
+    "shasum": "a4816a17cd5ff516dfa2c7698a453369b9790de0",
+    "tarball": "http://registry.npmjs.org/async/-/async-1.2.1.tgz"
+  },
+  "directories": {},
+  "_resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
+  "readme": "ERROR: No README data found!"
+}

--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -87,6 +87,32 @@ def _load_json_result(result_file, test_dir):
     return scan_result
 
 
+def test_package_option_detects_packages(monkeypatch):
+    monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
+    test_dir = test_env.get_test_loc('package', copy=True)
+    runner = CliRunner()
+    result_file = test_env.get_temp_file('json')
+    result = runner.invoke(cli.scancode, ['--package', test_dir, result_file])
+    assert result.exit_code == 0
+    assert 'Scanning done' in result.output
+    assert 'package.json' in result.output
+    assert os.path.exists(result_file)
+    assert len(open(result_file).read()) > 10
+
+
+def test_verbose_option_with_packages(monkeypatch):
+    monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
+    test_dir = test_env.get_test_loc('package', copy=True)
+    runner = CliRunner()
+    result_file = test_env.get_temp_file('json')
+    result = runner.invoke(cli.scancode, ['--package', '--verbose', test_dir, result_file])
+    assert result.exit_code == 0
+    assert 'Scanning done' in result.output
+    assert 'package.json' in result.output
+    assert os.path.exists(result_file)
+    assert len(open(result_file).read()) > 10
+    
+
 def test_copyright_option_detects_copyrights(monkeypatch):
     monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
     test_dir = test_env.get_test_loc('copyright', copy=True)


### PR DESCRIPTION
Added two test cases for `--package` flag scanning, specifically for an `npm` package. Feedback appreciated. 