### PR TITLE
Ignore the generated top-level "tcl" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ docs/_build
 !/tests/typecode/data/contenttype/compiled/win/*
 !/tests/typecode/data/contenttype/package/*
 
-/share/
 /local/
+/share/
+/tcl/


### PR DESCRIPTION
This gets created during activation and should be ignored.