### PR TITLE
#364 file level errors

### DIFF
--- a/src/scancode/templates/html-app/assets/scancode_datatable.js
+++ b/src/scancode/templates/html-app/assets/scancode_datatable.js
@@ -155,14 +155,14 @@ function ScancodeDataTable(tagId, data){
         return $.map(jsonData, function(x){
             // Add all license columns here
             licenseData = [];
-            if('licenses' in x) {
+            if('licenses' in x && x.licenses != []) {
                 licenseData = $.map(x.licenses, function(y){
                     return [$.extend(y, {
                         "path" : x.path,
                         "what": "License",
-                        "start_line": y.start_line,
-                        "end_line": y.end_line,
-                        "info": y.short_name,
+                        "start_line": y.start_line || "",
+                        "end_line": y.end_line || "",
+                        "info": y.short_name || "",
                         "type" : "",
                         "name" : "",
                         "extension": "",
@@ -187,14 +187,14 @@ function ScancodeDataTable(tagId, data){
                 })};
             // Add all copyright columns here
             copyrightData = [];
-            if('copyrights' in x) {
+            if('copyrights' in x && x.copyrights != []) {
                 copyrightData = $.map(x.copyrights, function(y){
                     return [$.extend(y, {
                         "path" : x.path,
                         "what": "Copyright",
-                        "start_line": y.start_line,
-                        "end_line": y.end_line,
-                        "info": y.statements.join("</br>"),
+                        "start_line": y.start_line || "",
+                        "end_line": y.end_line || "",
+                        "info": (y.statements && y.statements.join("</br>")) || "",
                         "type" : "",
                         "name" : "",
                         "extension": "",
@@ -218,14 +218,14 @@ function ScancodeDataTable(tagId, data){
                     })];
                 })};
             emailData = [];
-            if('emails' in x) {
+            if('emails' in x && x.emails != []) {
                 emailData = $.map(x.emails, function(y){
                     return [$.extend(y, {
                         "path" : x.path,
                         "what": "Email",
-                        "start_line": y.start_line,
-                        "end_line": y.end_line,
-                        "info": y.email,
+                        "start_line": y.start_line || "",
+                        "end_line": y.end_line || "",
+                        "info": y.email || "",
                         "type" : "",
                         "name" : "",
                         "extension": "",
@@ -249,14 +249,14 @@ function ScancodeDataTable(tagId, data){
                     })];
                 })};
             urlData = [];
-            if('urls' in x) {
+            if('urls' in x && x.urls != []) {
                 urlData = $.map(x.urls, function(y){
                     return [$.extend(y, {
                         "path" : x.path,
                         "what": "URL",
-                        "start_line": y.start_line,
-                        "end_line": y.end_line,
-                        "info": y.url,
+                        "start_line": y.start_line || "",
+                        "end_line": y.end_line || "",
+                        "info": y.url || "",
                         "type" : "",
                         "name" : "",
                         "extension": "",
@@ -294,23 +294,23 @@ function ScancodeDataTable(tagId, data){
                 "start_line": "",
                 "end_line": "",
                 "info": "",
-                "type" : x.type,
-                "name" : x.name,
-                "extension": x.extension,
-                "date" : x.date,
-                "size" : x.size,
-                "sha1" : x.sha1,
-                "md5" : x.md5,
-                "files_count" : x.files_count,
-                "mime_type" : x.mime_type,
-                "file_type" : x.file_type,
-                "programming_language" : x.programming_language,
-                "is_binary" : x.is_binary,
-                "is_text" : x.is_text,
-                "is_archive" : x.is_archive,
-                "is_media" : x.is_media,
-                "is_source" : x.is_source,
-                "is_script" : x.is_script,
+                "type" : x.type || "",
+                "name" : x.name || "",
+                "extension": x.extension || "",
+                "date" : x.date || "",
+                "size" : x.size || "",
+                "sha1" : x.sha1 || "",
+                "md5" : x.md5 || "",
+                "files_count" : x.files_count || "",
+                "mime_type" : x.mime_type || "",
+                "file_type" : x.file_type || "",
+                "programming_language" : x.programming_language || "",
+                "is_binary" : x.is_binary || "",
+                "is_text" : x.is_text || "",
+                "is_archive" : x.is_archive || "",
+                "is_media" : x.is_media || "",
+                "is_source" : x.is_source || "",
+                "is_script" : x.is_script || "",
                 "pkg_type" : "",
                 "pkg_packaging" : "",
                 "pkg_primary_language" : ""
@@ -322,7 +322,7 @@ function ScancodeDataTable(tagId, data){
     function toPkgInfoFormat(jsonData){
         return $.map(jsonData, function(x){
             packageInfoData = [];
-            if('packages' in x) {
+            if('packages' in x & x.packages != []) {
                 packageInfoData = $.map(x.packages, function(y){
                     return [$.extend(y, {
                         "path" : x.path,
@@ -347,9 +347,9 @@ function ScancodeDataTable(tagId, data){
                         "is_media" : "",
                         "is_source" : "",
                         "is_script" : "",
-                        "pkg_type" : y.type,
-                        "pkg_packaging" : y.packaging,
-                        "pkg_primary_language" : y.primary_language
+                        "pkg_type" : y.type || "",
+                        "pkg_packaging" : y.packaging || "",
+                        "pkg_primary_language" : y.primary_language  || ""
                     })];
                 })};
 

--- a/tests/scancode/data/failing/patchelf.expected.json
+++ b/tests/scancode/data/failing/patchelf.expected.json
@@ -3,10 +3,13 @@
   "files_count": 1, 
   "files": [
     {
+      "copyrights": [],
       "path": "", 
-      "copyrights": {
-        "errors": "unpack requires a string argument of length 8"
-      }
+      "scan_errors": [
+        {
+          "copyrights": "unpack requires a string argument of length 8"
+        }
+      ]
     }
   ]
 }

--- a/tests/scancode/data/info/all.expected.json
+++ b/tests/scancode/data/info/all.expected.json
@@ -21,6 +21,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "licenses": [], 
       "copyrights": []
     }, 
@@ -43,6 +44,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "licenses": [], 
       "copyrights": []
     }, 
@@ -65,6 +67,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "licenses": [], 
       "copyrights": []
     }, 
@@ -87,6 +90,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "licenses": [], 
       "copyrights": []
     }, 
@@ -109,6 +113,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "licenses": [], 
       "copyrights": []
     }, 
@@ -131,6 +136,7 @@
       "is_media": true, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "licenses": [], 
       "copyrights": []
     }, 
@@ -153,6 +159,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "licenses": [], 
       "copyrights": []
     }, 
@@ -175,6 +182,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "licenses": [], 
       "copyrights": []
     }, 
@@ -197,6 +205,7 @@
       "is_media": null, 
       "is_source": true, 
       "is_script": null, 
+      "scan_errors": [], 
       "licenses": [
         {
           "key": "bsd-original-uc", 
@@ -254,6 +263,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "licenses": [], 
       "copyrights": []
     }, 
@@ -276,6 +286,7 @@
       "is_media": null, 
       "is_source": true, 
       "is_script": null, 
+      "scan_errors": [], 
       "licenses": [
         {
           "key": "gpl-2.0", 

--- a/tests/scancode/data/info/basic.expected.json
+++ b/tests/scancode/data/info/basic.expected.json
@@ -20,7 +20,8 @@
       "is_archive": null, 
       "is_media": null, 
       "is_source": null, 
-      "is_script": null
+      "is_script": null, 
+      "scan_errors": []
     }, 
     {
       "path": "basic/dbase.fdt", 
@@ -40,7 +41,8 @@
       "is_archive": null, 
       "is_media": null, 
       "is_source": null, 
-      "is_script": null
+      "is_script": null, 
+      "scan_errors": []
     }, 
     {
       "path": "basic/dir", 
@@ -60,7 +62,8 @@
       "is_archive": null, 
       "is_media": null, 
       "is_source": null, 
-      "is_script": null
+      "is_script": null, 
+      "scan_errors": []
     }, 
     {
       "path": "basic/dir/e.tar", 
@@ -80,7 +83,8 @@
       "is_archive": true, 
       "is_media": null, 
       "is_source": null, 
-      "is_script": null
+      "is_script": null, 
+      "scan_errors": []
     }, 
     {
       "path": "basic/dir/subdir", 
@@ -100,7 +104,8 @@
       "is_archive": null, 
       "is_media": null, 
       "is_source": null, 
-      "is_script": null
+      "is_script": null, 
+      "scan_errors": []
     }, 
     {
       "path": "basic/dir/subdir/a.aif", 
@@ -120,7 +125,8 @@
       "is_archive": null, 
       "is_media": true, 
       "is_source": null, 
-      "is_script": null
+      "is_script": null, 
+      "scan_errors": []
     }, 
     {
       "path": "basic/dir2", 
@@ -140,7 +146,8 @@
       "is_archive": null, 
       "is_media": null, 
       "is_source": null, 
-      "is_script": null
+      "is_script": null, 
+      "scan_errors": []
     }, 
     {
       "path": "basic/dir2/subdir", 
@@ -160,7 +167,8 @@
       "is_archive": null, 
       "is_media": null, 
       "is_source": null, 
-      "is_script": null
+      "is_script": null, 
+      "scan_errors": []
     }, 
     {
       "path": "basic/dir2/subdir/bcopy.s", 
@@ -180,7 +188,8 @@
       "is_archive": null, 
       "is_media": null, 
       "is_source": true, 
-      "is_script": null
+      "is_script": null, 
+      "scan_errors": []
     }, 
     {
       "path": "basic/dir2/subdir/config.conf", 
@@ -200,7 +209,8 @@
       "is_archive": null, 
       "is_media": null, 
       "is_source": null, 
-      "is_script": null
+      "is_script": null, 
+      "scan_errors": []
     }, 
     {
       "path": "basic/main.c", 
@@ -220,7 +230,8 @@
       "is_archive": null, 
       "is_media": null, 
       "is_source": true, 
-      "is_script": null
+      "is_script": null, 
+      "scan_errors": []
     }
   ]
 }

--- a/tests/scancode/data/info/email_url_info.expected.json
+++ b/tests/scancode/data/info/email_url_info.expected.json
@@ -21,6 +21,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "emails": [], 
       "urls": []
     }, 
@@ -43,6 +44,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "emails": [], 
       "urls": []
     }, 
@@ -65,6 +67,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "emails": [], 
       "urls": []
     }, 
@@ -87,6 +90,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "emails": [], 
       "urls": []
     }, 
@@ -109,6 +113,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "emails": [], 
       "urls": []
     }, 
@@ -131,6 +136,7 @@
       "is_media": true, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "emails": [], 
       "urls": []
     }, 
@@ -153,6 +159,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "emails": [], 
       "urls": []
     }, 
@@ -175,6 +182,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "emails": [], 
       "urls": []
     }, 
@@ -197,6 +205,7 @@
       "is_media": null, 
       "is_source": true, 
       "is_script": null, 
+      "scan_errors": [], 
       "emails": [
         {
           "email": "ws@tools.de", 
@@ -231,6 +240,7 @@
       "is_media": null, 
       "is_source": null, 
       "is_script": null, 
+      "scan_errors": [], 
       "emails": [], 
       "urls": [
         {
@@ -259,6 +269,7 @@
       "is_media": null, 
       "is_source": true, 
       "is_script": null, 
+      "scan_errors": [], 
       "emails": [
         {
           "email": "j@w1.fi", 

--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -81,8 +81,19 @@ def _load_json_result(result_file, test_dir):
         loc = result['path']
         loc = as_posixpath(loc).replace(test_dir, '').strip('/')
         result['path'] = loc
+
+        # strip errors from full stack trace for testing
+        error_messages = []
+        for errors in result.get('scan_errors',[]):
+            for scan_name, messages in errors.items():
+                if isinstance(messages,(tuple, list,)):
+                    messages, _trace = messages
+                error_messages.append({scan_name: messages})
+        result['scan_errors'] = error_messages
+        
     if scan_result.get('scancode_version'):
         del scan_result['scancode_version']
+
     scan_result['files'].sort(key=lambda x: x['path'])
     return scan_result
 


### PR DESCRIPTION
This changes the API of the returned JSON to move any errors caught while scanning to a per-file "scan_errors" key containing a list of dicts, one per scan type. This is related to #362 