### PR TITLE
#386 Add new rule and test for OpenSSL license from OpenSSL-1.1.0c

### DIFF
--- a/src/licensedcode/data/rules/openssl_8.RULE
+++ b/src/licensedcode/data/rules/openssl_8.RULE
@@ -1,0 +1,4 @@
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html

--- a/src/licensedcode/data/rules/openssl_8.yml
+++ b/src/licensedcode/data/rules/openssl_8.yml
@@ -1,0 +1,3 @@
+licenses:
+    - openssl
+notes: Sample from OpenSSL crypto/aes/aes_cbc.c

--- a/tests/licensedcode/data/licenses/openssl_4.txt
+++ b/tests/licensedcode/data/licenses/openssl_4.txt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2002-2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+ 

--- a/tests/licensedcode/data/licenses/openssl_4.yml
+++ b/tests/licensedcode/data/licenses/openssl_4.yml
@@ -1,0 +1,2 @@
+licenses:
+    - openssl


### PR DESCRIPTION
I created a new rule and test for the OpenSSL license to fix incorrect detection of the Apache 2.0 license when scanning the OpenSSL 1.1.0c release. 