### PR TITLE
#409 Added LICENSE file and test for bpmn-io license

### DIFF
--- a/src/licensedcode/data/licenses/bpmn-io.LICENSE
+++ b/src/licensedcode/data/licenses/bpmn-io.LICENSE
@@ -1,0 +1,21 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The source code responsible for displaying the bpmn.io logo (two green cogwheels in
+a box) that links back to http://bpmn.io as part of rendered diagrams MUST NOT be
+removed or changed. When this software is being used in a website or application,
+the logo must stay fully visible and not visually overlapped by other elements.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/licensedcode/data/licenses/bpmn-io.yml
+++ b/src/licensedcode/data/licenses/bpmn-io.yml
@@ -1,0 +1,6 @@
+key: bpmn-io
+short_name: bpmn.io License
+name: bpmn.io License
+category: Permissive
+owner: bpmn.io
+homepage_url: http://bpmn.io

--- a/tests/licensedcode/data/licenses/bpmn-io.txt
+++ b/tests/licensedcode/data/licenses/bpmn-io.txt
@@ -1,0 +1,23 @@
+Copyright (c) 2014-2016 camunda services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The source code responsible for displaying the bpmn.io logo (two green cogwheels in
+a box) that links back to http://bpmn.io as part of rendered diagrams MUST NOT be
+removed or changed. When this software is being used in a website or application,
+the logo must stay fully visible and not visually overlapped by other elements.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tests/licensedcode/data/licenses/bpmn-io.yml
+++ b/tests/licensedcode/data/licenses/bpmn-io.yml
@@ -1,0 +1,2 @@
+licenses:
+    - bpmn-io


### PR DESCRIPTION
The bpmn.io license was not being detected at all, despite similarities with the MIT license. A new LICENSE file and test were created to detect the bpmn.io license. 