### PR TITLE
#411 Return an empty string for package license name values that are null

### DIFF
--- a/etc/scripts/json2csv.py
+++ b/etc/scripts/json2csv.py
@@ -163,7 +163,7 @@ def flatten_scan(scan):
                             pack[nk] = '\n'.join(val)
                         if k == 'asserted_licenses':
                             # All license names are to be joined in a multi-line cell
-                            licenses = [license_info['license'] for license_info in val]
+                            licenses = [license_info.get('license', '') or '' for license_info in val]
                             pack[nk] = '\n'.join(licenses)
                     else:
                         pack[nk] = ''

--- a/etc/scripts/json2csv.py
+++ b/etc/scripts/json2csv.py
@@ -163,7 +163,7 @@ def flatten_scan(scan):
                             pack[nk] = '\n'.join(val)
                         if k == 'asserted_licenses':
                             # All license names are to be joined in a multi-line cell
-                            licenses = [license_info.get('license', '') or '' for license_info in val]
+                            licenses = [license_info.get('license') or '' for license_info in val]
                             pack[nk] = '\n'.join(licenses)
                     else:
                         pack[nk] = ''

--- a/etc/scripts/test_json2csv.py
+++ b/etc/scripts/test_json2csv.py
@@ -156,3 +156,11 @@ class TestJson2CSV(FileBasedTesting):
         test_html = self.get_test_loc('json2csv/minimal_html_app_data.json')
         test_json = self.get_test_loc('json2csv/minimal.json')
         assert json2csv.load_scan(test_html) == json2csv.load_scan(test_json)
+
+    def test_can_process_package_license_when_license_value_is_null(self):
+        test_json = self.get_test_loc('json2csv/package_license_value_null.json')
+        scan = json2csv.load_scan(test_json)
+        result = list(json2csv.flatten_scan(scan))
+        expected = self.get_test_loc('json2csv/package_license_value_null.json-expected')
+        expected = json.load(open(expected), object_pairs_hook=OrderedDict)
+        assert expected == result

--- a/etc/scripts/testdata/json2csv/package_license_value_null.json
+++ b/etc/scripts/testdata/json2csv/package_license_value_null.json
@@ -1,0 +1,77 @@
+{
+  "scancode_notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+  "scancode_version": "2.0.0rc2",
+  "files_count": 3,
+  "files": [
+    {
+      "path": "srp_vfy.c",
+      "scan_errors": [],
+      "licenses": [
+        {
+          "key": "apache-2.0",
+          "score": 53.85,
+          "short_name": "Apache 2.0",
+          "category": "Attribution",
+          "owner": "Apache Software Foundation",
+          "homepage_url": "http://www.apache.org/licenses/",
+          "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+          "dejacode_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+          "spdx_license_key": "Apache-2.0",
+          "spdx_url": "http://spdx.org/licenses/Apache-2.0",
+          "start_line": 4,
+          "end_line": 5,
+          "matched_rule": {
+            "identifier": "apache-2.0_23.RULE",
+            "license_choice": false,
+            "licenses": [
+              "apache-2.0"
+            ]
+          }
+        },
+        {
+          "key": "openssl-ssleay",
+          "score": 10.0,
+          "short_name": "OpenSSL/SSLeay License",
+          "category": "Attribution",
+          "owner": "OpenSSL",
+          "homepage_url": "http://www.openssl.org/source/license.html",
+          "text_url": "",
+          "dejacode_url": "https://enterprise.dejacode.com/urn/urn:dje:license:openssl-ssleay",
+          "spdx_license_key": "OpenSSL",
+          "spdx_url": "http://spdx.org/licenses/OpenSSL",
+          "start_line": 4,
+          "end_line": 4,
+          "matched_rule": {
+            "identifier": "openssl-ssleay_2.RULE",
+            "license_choice": false,
+            "licenses": [
+              "openssl-ssleay"
+            ]
+          }
+        }
+      ],
+      "copyrights": [
+        {
+          "statements": [
+            "Copyright 2011-2016 The OpenSSL Project"
+          ],
+          "holders": [
+            "OpenSSL Project"
+          ],
+          "authors": [],
+          "start_line": 2,
+          "end_line": 2
+        }
+      ],
+      "packages": [
+          {
+            "asserted_licenses": [
+                {
+                    "license": null
+                }
+            ]
+          }
+      ]
+    }
+  ]
+}

--- a/etc/scripts/testdata/json2csv/package_license_value_null.json-expected
+++ b/etc/scripts/testdata/json2csv/package_license_value_null.json-expected
@@ -1,0 +1,52 @@
+[
+    {
+        "Resource": "/code/srp_vfy.c",
+        "scan_errors": ""
+    },
+    {
+        "Resource": "/code/srp_vfy.c",
+        "license__key": "apache-2.0",
+        "license__score": 53.85,
+        "license__short_name": "Apache 2.0",
+        "license__category": "Attribution",
+        "license__owner": "Apache Software Foundation",
+        "license__homepage_url": "http://www.apache.org/licenses/",
+        "license__text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+        "license__dejacode_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+        "license__spdx_license_key": "Apache-2.0",
+        "license__spdx_url": "http://spdx.org/licenses/Apache-2.0",
+        "start_line": 4,
+        "end_line": 5
+    },
+    {
+        "Resource": "/code/srp_vfy.c",
+        "license__key": "openssl-ssleay",
+        "license__score": 10.0,
+        "license__short_name": "OpenSSL/SSLeay License",
+        "license__category": "Attribution",
+        "license__owner": "OpenSSL",
+        "license__homepage_url": "http://www.openssl.org/source/license.html",
+        "license__text_url": "",
+        "license__dejacode_url": "https://enterprise.dejacode.com/urn/urn:dje:license:openssl-ssleay",
+        "license__spdx_license_key": "OpenSSL",
+        "license__spdx_url": "http://spdx.org/licenses/OpenSSL",
+        "start_line": 4,
+        "end_line": 4
+    },
+    {
+        "Resource": "/code/srp_vfy.c",
+        "copyright": "Copyright 2011-2016 The OpenSSL Project",
+        "start_line": 2,
+        "end_line": 2
+    },
+    {
+        "Resource": "/code/srp_vfy.c",
+        "copyright_holder": "OpenSSL Project",
+        "start_line": 2,
+        "end_line": 2
+    },
+    {
+        "Resource": "/code/srp_vfy.c",
+        "package__asserted_licenses": ""
+    }
+]


### PR DESCRIPTION
I have modified the list comprehension that collects the license names from a package's "asserted_licenses" key to return an empty string when a license's name is null. I have also created a new test for this issue.