### PR TITLE
#416 New production rule for copyrights in the order of copyright-year range-dash-noun

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -186,7 +186,7 @@ patterns = [
     (r'[Cc]ommitters\.??', 'COMMIT'),
     # same for maintainers.
     (r'^([Mm]aintainers?\.?|[Dd]evelopers?\.?)$', 'MAINT'),
-    
+
     # same for developed, etc...
     (r'^(([Rr]e)?[Cc]oded|[Mm]odified|[Mm]ai?nt[ea]ine(d|r)|[Ww]ritten|[Dd]eveloped)$', 'AUTH2'),
     # author
@@ -213,7 +213,7 @@ patterns = [
 
     # Portions copyright .... are worth keeping
     (r'[Pp]ortions?', 'PORTIONS'),
-    
+
     # in dutch/german names, like Marco van Basten, or Klemens von Metternich
     # and Spanish/French Da Siva and De Gaulle
     (r'^(([Vv][ao]n)|[Dd][aeu])$', 'VAN'),
@@ -280,7 +280,7 @@ patterns = [
 ]
 
 # Comments in the Grammar are lines that start with #
-grammar = """   
+grammar = """
     COPY: {<COPY>}
     YR-RANGE: {<YR>+ <CC>+ <YR>}
     YR-RANGE: {<YR> <DASH>* <YR|CD>+}
@@ -425,6 +425,10 @@ grammar = """
     COPYRIGHT2: {<COPY> <COPY> <YR-RANGE> <NN> <NNP> <ANDCO>}
 
     COPYRIGHT2: {<COPY> <COPY> <YR-RANGE> <NN> <AUTH>}
+
+    # Copyright 1999, 2000 - D.T.Shield.
+    # Copyright (c) 1999, 2000 - D.T.Shield.
+    COPYRIGHT2: {<COPY> <COPY>? <YR-RANGE> <DASH> <NN>}
 
     COPYRIGHT2: {<COPY> <COPY> <YR-RANGE> <BY> <NN> <NN> <NAME>}
     COPYRIGHT2: {<COPY> <YR-RANGE> <BY> <NN> <NN> <NAME>}

--- a/tests/cluecode/test_copyrights.py
+++ b/tests/cluecode/test_copyrights.py
@@ -3971,3 +3971,13 @@ class TestCopyrightDetection(FileBasedTesting):
         test_file = self.get_test_loc('copyrights/bv.txt')
         expected = [u'Copyright (c) 2016 HERE Europe B.V.', u'(c) HERE 2016']
         check_detection(expected, test_file)
+
+    def test_copyright_with_dash_and_dotted_name(self):
+        test_lines = [u'Copyright 1999, 2000 - D.T.Shield.']
+        expected = [u'Copyright 1999, 2000 - D.T.Shield.']
+        check_detection(expected, test_lines)
+
+    def test_copyright_with_sign_dash_and_dotted_name(self):
+        test_lines = [u'Copyright (c) 1999, 2000 - D.T.Shield.']
+        expected = [u'Copyright (c) 1999, 2000 - D.T.Shield.']
+        check_detection(expected, test_lines)


### PR DESCRIPTION
A new production rule and test for copyright detection has been added to handle the case of `Copyright 1999, 2000 - D.T.Shield.`