### PR TITLE
#406 New rule to capture 'Copyright (c) 2012-2016, Project contributors'

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -442,6 +442,9 @@ grammar = """
 
     COPYRIGHT2: {<COPY> <COPY>? <YR-RANGE> <NNP> <NAME>}
 
+    # Copyright (c) 2012-2016, Project contributors
+    COPYRIGHT2: {<COPY> <COPY>? <YR-RANGE> <COMP> <AUTH>}
+
     COPYRIGHT2: {<NAME> <COPY> <YR-RANGE>}
 
     COPYRIGHT2: {<COPY> <COPY>? <NN|CAPS>? <YR-RANGE>+ <NN|CAPS>*}

--- a/tests/cluecode/test_copyrights.py
+++ b/tests/cluecode/test_copyrights.py
@@ -3981,3 +3981,13 @@ class TestCopyrightDetection(FileBasedTesting):
         test_lines = [u'Copyright (c) 1999, 2000 - D.T.Shield.']
         expected = [u'Copyright (c) 1999, 2000 - D.T.Shield.']
         check_detection(expected, test_lines)
+
+    def test_copyright_with_sign_year_comp_and_auth(self):
+        test_lines = [u'Copyright (c) 2012-2016, Project contributors']
+        expected = [u'Copyright (c) 2012-2016, Project contributors']
+        check_detection(expected, test_lines)
+
+    def test_copyright_with_year_comp_and_auth(self):
+        test_lines = [u'Copyright 2012-2016, Project contributors']
+        expected = [u'Copyright 2012-2016, Project contributors']
+        check_detection(expected, test_lines)


### PR DESCRIPTION
A rule and test for statements in the order of copy-copy?-year range-company-author has been added to capture `Copyright (c) 2012-2016, Project contributors`.