### PR TITLE
#405 Rule to capture \`Copyright 2007-2010 the original auth…

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -430,6 +430,10 @@ grammar = """
     # Copyright (c) 1999, 2000 - D.T.Shield.
     COPYRIGHT2: {<COPY> <COPY>? <YR-RANGE> <DASH> <NN>}
 
+    # Copyright 2007-2010 the original author or authors.
+    # Copyright (c) 2007-2010 the original author or authors.
+    COPYRIGHT2: {<COPY> <COPY>? <YR-RANGE> <NN> <JUNK> <AUTH> <NN> <AUTH>}
+
     COPYRIGHT2: {<COPY> <COPY> <YR-RANGE> <BY> <NN> <NN> <NAME>}
     COPYRIGHT2: {<COPY> <YR-RANGE> <BY> <NN> <NN> <NAME>}
 

--- a/tests/cluecode/test_copyrights.py
+++ b/tests/cluecode/test_copyrights.py
@@ -3991,3 +3991,13 @@ class TestCopyrightDetection(FileBasedTesting):
         test_lines = [u'Copyright 2012-2016, Project contributors']
         expected = [u'Copyright 2012-2016, Project contributors']
         check_detection(expected, test_lines)
+
+    def test_copyright_with_year_noun_junk_auth_noun_and_auth(self):
+        test_lines = [u'Copyright 2007-2010 the original author or authors.']
+        expected = [u'Copyright 2007-2010 the original author or authors.']
+        check_detection(expected, test_lines)
+
+    def test_copyright_with_sign_year_noun_junk_auth_noun_and_auth(self):
+        test_lines = [u'Copyright (c) 2007-2010 the original author or authors.']
+        expected = [u'Copyright (c) 2007-2010 the original author or authors.']
+        check_detection(expected, test_lines)


### PR DESCRIPTION
A new rule has been added to capture `Copyright 2007-2010 the original author or authors.`.