### PR TITLE
#380 Test to ensure 'Byten ( c ) Exactly' is not detected as a copyright statement  

### DIFF
--- a/tests/cluecode/test_copyrights.py
+++ b/tests/cluecode/test_copyrights.py
@@ -4001,3 +4001,8 @@ class TestCopyrightDetection(FileBasedTesting):
         test_lines = [u'Copyright (c) 2007-2010 the original author or authors.']
         expected = [u'Copyright (c) 2007-2010 the original author or authors.']
         check_detection(expected, test_lines)
+
+    def test_copyright_byten_c_exactly(self):
+        test_lines = [u'... don’t fit into your fixed-size buffer.\nByten ( c )\nExactly n bytes. If the']
+        expected = []
+        check_detection(expected, test_lines)


### PR DESCRIPTION
A new test has been created to ensure that no copyright statement is detected in 
```
... don’t fit into your fixed-size buffer.
Byten ( c )
Exactly n bytes. If the
```