### PR TITLE
478 Fix license-detection errors from scan of Fuse codebase

### DIFF
--- a/src/licensedcode/data/rules/gpl-2.0_or_bsd-simplified.RULE
+++ b/src/licensedcode/data/rules/gpl-2.0_or_bsd-simplified.RULE
@@ -1,0 +1,29 @@
+    This file defines the kernel interface of FUSE
+
+    This program can be distributed under the terms of the GNU GPL.
+    See the file COPYING.
+
+    This -- and only this -- header file may also be distributed under
+    the terms of the BSD Licence as follows:
+
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.

--- a/src/licensedcode/data/rules/gpl-2.0_or_bsd-simplified.yml
+++ b/src/licensedcode/data/rules/gpl-2.0_or_bsd-simplified.yml
@@ -1,0 +1,5 @@
+licenses:
+    - gpl-2.0
+    - bsd-simplified
+license_choice: yes
+license: gpl-2.0 or bsd-simplified

--- a/src/licensedcode/data/rules/lgpl-2.0_not_gpl.RULE
+++ b/src/licensedcode/data/rules/lgpl-2.0_not_gpl.RULE
@@ -1,0 +1,2 @@
+This program can be distributed under the terms of the GNU LGPLv2.
+See the file COPYING.LIB

--- a/src/licensedcode/data/rules/lgpl-2.0_not_gpl.yml
+++ b/src/licensedcode/data/rules/lgpl-2.0_not_gpl.yml
@@ -1,0 +1,2 @@
+licenses:
+    - lgpl-2.0

--- a/tests/licensedcode/data/licenses/gpl-2.0_or_bsd-simplified.txt
+++ b/tests/licensedcode/data/licenses/gpl-2.0_or_bsd-simplified.txt
@@ -1,0 +1,29 @@
+    This file defines the kernel interface of FUSE
+
+    This program can be distributed under the terms of the GNU GPL.
+    See the file COPYING.
+
+    This -- and only this -- header file may also be distributed under
+    the terms of the BSD Licence as follows:
+
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.

--- a/tests/licensedcode/data/licenses/gpl-2.0_or_bsd-simplified.yml
+++ b/tests/licensedcode/data/licenses/gpl-2.0_or_bsd-simplified.yml
@@ -1,0 +1,3 @@
+licenses:
+    - gpl-2.0
+    - bsd-simplified

--- a/tests/licensedcode/data/licenses/lgpl-2.0_not_gpl.txt
+++ b/tests/licensedcode/data/licenses/lgpl-2.0_not_gpl.txt
@@ -1,0 +1,2 @@
+This program can be distributed under the terms of the GNU LGPLv2.
+See the file COPYING.LIB

--- a/tests/licensedcode/data/licenses/lgpl-2.0_not_gpl.yml
+++ b/tests/licensedcode/data/licenses/lgpl-2.0_not_gpl.yml
@@ -1,0 +1,2 @@
+licenses:
+    - lgpl-2.0


### PR DESCRIPTION
This set of commits adds two new rules and related files to address the license-detection issues in #478.