### PR TITLE
Be consistent about when to sort the SPDX list of licenses / copyrights

### DIFF
--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -687,6 +687,8 @@ def save_results(scanners, only_findings, files_count, scanned_files, format, in
         doc.creation_info.set_created_now()
 
         doc.package = Package(os.path.basename(input_path), NoAssert())
+
+        # Use a set of unique copyrights for the package.
         doc.package.cr_text = set()
 
         all_files_have_no_license = True
@@ -722,6 +724,8 @@ def save_results(scanners, only_findings, files_count, scanned_files, format, in
                         license_key = 'LicenseRef-' + file_license.get('key')
                         spdx_license = License(file_license.get('short_name'), license_key)
 
+                    # Add licenses in the order they appear in the file. Maintaining the order
+                    # might be useful for provenance purposes.
                     file_entry.add_lics(spdx_license)
                     doc.package.add_lics_from_file(spdx_license)
             else:
@@ -738,11 +742,14 @@ def save_results(scanners, only_findings, files_count, scanned_files, format, in
             file_copyrights = file_data.get('copyrights')
             if file_copyrights:
                 all_files_have_no_copyright = False
-                file_entry.copyright = set()
+                file_entry.copyright = []
                 for file_copyright in file_copyrights:
-                    file_entry.copyright.update(file_copyright.get('statements'))
+                    file_entry.copyright.extend(file_copyright.get('statements'))
 
                 doc.package.cr_text.update(file_entry.copyright)
+
+                # Create a text of copyright statements in the order they appear in the file.
+                # Maintaining the order might be useful for provenance purposes.
                 file_entry.copyright = '\n'.join(file_entry.copyright) + '\n'
             else:
                 if file_copyrights == None:
@@ -762,7 +769,7 @@ def save_results(scanners, only_findings, files_count, scanned_files, format, in
                 output_file.write("<!-- No results for package '{}'. -->\n".format(doc.package.name))
             return
 
-        # Remove duplicate licenses from the list.
+        # Remove duplicate licenses from the list for the package.
         unique_licenses = set(doc.package.licenses_from_files)
         if len(doc.package.licenses_from_files) == 0:
             if all_files_have_no_license:
@@ -770,6 +777,7 @@ def save_results(scanners, only_findings, files_count, scanned_files, format, in
             else:
                 doc.package.licenses_from_files = [NoAssert()]
         else:
+            # List license identifiers alphabetically for the package.
             doc.package.licenses_from_files = sorted(unique_licenses, key = lambda x : x.identifier)
 
         if len(doc.package.cr_text) == 0:
@@ -778,7 +786,8 @@ def save_results(scanners, only_findings, files_count, scanned_files, format, in
             else:
                 doc.package.cr_text = NoAssert()
         else:
-            doc.package.cr_text = '\n'.join(doc.package.cr_text) + '\n'
+            # Create a text of alphabetically sorted copyright statements for the package.
+            doc.package.cr_text = '\n'.join(sorted(doc.package.cr_text)) + '\n'
 
         doc.package.verif_code = doc.package.calc_verif_code()
         doc.package.license_declared = NoAssert()


### PR DESCRIPTION
Do not sort or deduplicate findings on the file level as maintaining the
original order might be useful for provenance analysis. On the package level,
we anyway do not know from which file a particular finding originates, so sort
the list of unique findings to get a better overview.