### PR TITLE
Use SPDX NOASSERTION for unknown licenses

### DIFF
--- a/src/licensedcode/data/licenses/unknown.yml
+++ b/src/licensedcode/data/licenses/unknown.yml
@@ -2,3 +2,4 @@ key: unknown
 short_name: unknown
 name: Unknown license detected, but not recognized
 category: Unknown License
+spdx_license_key: NOASSERTION


### PR DESCRIPTION
The spec says that NOASSERTION should be used if "the SPDX file creator
has intentionally provided no information (no meaning should be implied
by doing so)".