### PR TITLE
#497 Create new rule and test to correct erroneous Apache 2.0 detection

### DIFF
--- a/src/licensedcode/data/rules/mit_not_apache-2.0.RULE
+++ b/src/licensedcode/data/rules/mit_not_apache-2.0.RULE
@@ -1,0 +1,9 @@
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed 
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+specific language governing permissions and limitations under the License.

--- a/src/licensedcode/data/rules/mit_not_apache-2.0.yml
+++ b/src/licensedcode/data/rules/mit_not_apache-2.0.yml
@@ -1,0 +1,3 @@
+licenses:
+    - mit
+notes: appears to use an Apache 2.0 template, replacing Apache references with MIT references

--- a/tests/licensedcode/data/licenses/mit_not_apache-2.0.txt
+++ b/tests/licensedcode/data/licenses/mit_not_apache-2.0.txt
@@ -1,0 +1,9 @@
+Licensed under the MIT License (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://opensource.org/licenses/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed 
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+specific language governing permissions and limitations under the License.

--- a/tests/licensedcode/data/licenses/mit_not_apache-2.0.yml
+++ b/tests/licensedcode/data/licenses/mit_not_apache-2.0.yml
@@ -1,0 +1,2 @@
+licenses:
+    - mit


### PR DESCRIPTION
This set of commits adds a new rule and related tests/files to address the erroneous detection of a non-standard MIT license as Apache 2.0 (found in rapidjson 1.1.0 from https://github.com/miloyip/rapidjson/archive/v1.1.0.zip).