### PR TITLE
#484 New implementation of a killable thread with a process pool

### DIFF
--- a/src/scancode/interrupt.py
+++ b/src/scancode/interrupt.py
@@ -1,122 +1,63 @@
+#
+# Copyright (c) 2017 nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/scancode-toolkit/
+# The ScanCode software is licensed under the Apache License version 2.0.
+# Data generated with ScanCode require an acknowledgment.
+# ScanCode is a trademark of nexB Inc.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with ScanCode or any ScanCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  ScanCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  ScanCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/scancode-toolkit/ for support and download.
 
-"""
-Originally based on:
-http://stackoverflow.com/questions/29494001/how-can-i-abort-a-task-in-a-multiprocessing-pool-after-a-timeout/29495039#29495039
-By dano "Dan O'Reilly" : http://stackoverflow.com/users/2073595/dano
-license: public-domain
+from __future__ import print_function
+from __future__ import absolute_import
 
-On 2016-11-11 the Dan O'Reilly provided this feedback:
-@dano what would be the license for this code beside the standard CC-BY-SA?
-    -Philippe Ombredanne 1 hour ago
-@PhilippeOmbredanne Public Domain, as far as I'm concerned.
-- dano 1 hour ago
-
-The code was heavily modified to support both a timeout and memory quota:
-
-We use a pool of two threads that will race against each other to finish first:
-- one will run the requested function proper
-- one will run a loop until a timeout to check for memory usage and return when it
-  exceeds max_memory or timeout expires.
-
-The first thread to complete will return its result and win. e.g if the function
-completes within timeout and does not exceeds RAM, it will return first. Otherwise if
-the memory check and timeout thread completes first, the main function will be
-killed and some error will be returned instead.
-"""
-
-from __future__ import print_function, absolute_import
-
-###########################################################################
-# Monkeypatch Pool iterators so that Ctrl-C interrupts everything properly
-# derived from https://gist.github.com/aljungberg/626518
-# FIXME: unknown license
-###########################################################################
-from multiprocessing.pool import IMapIterator, IMapUnorderedIterator
-
-def wrapped(func):
-    # ensure that we do not double wrap
-    if func.func_name != 'wrap':
-        def wrap(self, timeout=None):
-            return func(self, timeout=timeout or 1e10)
-        return wrap
-    else:
-        return func
-
-IMapIterator.next = wrapped(IMapIterator.next)
-IMapIterator.__next__ = IMapIterator.next
-IMapUnorderedIterator.next = wrapped(IMapUnorderedIterator.next)
-IMapUnorderedIterator.__next__ = IMapUnorderedIterator.next
-###########################################################################
-
-###########################################################################
-# Monkeypatch/subclass multiprocessing Process and ThreadPool to
-# apply fix for bug https://bugs.python.org/issue14881
-# In Python before 2.7.6 this happens at times. For intance on Ubuntu 12.04
-# This is the fix applied in https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz
-# We only apply this fix to Python versions before 2.7.6
-###########################################################################
-
-import multiprocessing
-import sys
-
-
-py_before_276 = (sys.version_info[0] == 2 and sys.version_info[1] == 7 and (sys.version_info[2] < 6))
-
-if py_before_276:
-    import threading
-    from multiprocessing.dummy import Process as StandardProcess
-    from multiprocessing.dummy import current_process
-    from multiprocessing.pool import ThreadPool as StandardThreadPool
-
-    class PatchedProcess(StandardProcess):
-        """
-        dummy.Process subclass with patched start method for bug https://bugs.python.org/issue14881
-        """
-        def start(self):
-            assert self._parent is current_process()
-            self._start_called = True
-            if hasattr(self._parent, '_children'):
-                self._parent._children[self] = None
-            threading.Thread.start(self)
-
-    class ThreadPool(StandardThreadPool):
-        """
-        ThreadPool subclass using patched Process
-        """
-        Process = PatchedProcess
-
-else:
-    from multiprocessing.pool import ThreadPool
-
-###########################################################################
-
-from time import sleep
-import traceback
+import os
+import Queue
+import thread
 
 import psutil
 
+from scancode.thread2 import async_raise
+
 
 DEFAULT_TIMEOUT = 120  # seconds
-RUNTIME_EXCEEDED = 1
+DEFAULT_MAX_MEMORY = 1000  # in megabytes. 0 is unlimited.
 
-DEFAULT_MAX_MEMORY = 1000  # megabytes
-MEMORY_EXCEEDED = 2
+"""
+Run a function in an interruptible thread with a timeout and memory quota.
+Based on an idea of dano "Dan O'Reilly"  http://stackoverflow.com/users/2073595/dano
+But not code has been reused from this post.
+"""
 
-
-def interruptible(func, *args, **kwargs):
+def interruptible(func, args=(), kwargs={},
+                  timeout=DEFAULT_TIMEOUT, max_memory=DEFAULT_MAX_MEMORY):
     """
-    Call `func` function with `args` arguments and return a tuple of (success, return
-    value). `func` is invoked through a wrapper and will be interrupted if it does
-    not return within `timeout` seconds of execution or uses more than 'max_memory`
-    MEGABYTES of memory. `func` returned results should be pickable.
+    Call `func` function with `args` and `kwargs` arguments and return a tuple of
+    (success, return value). `func` is invoked through a wrapper in a thread and
+    will be interrupted if it does not return within `timeout` seconds of execution
+    or uses more than 'max_memory` MEGABYTES of memory.
 
-    `timeout` in seconds should be provided as a keyword argument.
-    MIN_TIMEOUT is always enforced even if no timeout keyword is present.
+    `func` returned results must be pickable.
+    `timeout` in seconds defaults to DEFAULT_TIMEOUT.
 
-    `max_memory` in megabytes should be provided as a keyword argument.
-    If not present a memory quota is not enforced.
+    `max_memory` is the memory quota in megabytes and defaults to DEFAULT_MAX_MEMORY.
+    If zero, then no memory quota is enforced.
 
-    Only `args` are passed to `func`, not any `kwargs`.
+    `args` and `kwargs` are passed to `func` as *args and **kwargs.
 
     In the returned tuple of (success, value), success is True or False.
     If success is True, the call was successful and the second item in the tuple is
@@ -125,83 +66,40 @@ def interruptible(func, *args, **kwargs):
     exceeded `max_memory` memory usage and was interrupted. In this case, the second
     item in the tuple is an error message string.
     """
+    # We run `func` in a thread and run a loop until timeout to check memory
+    # usage of the runner
+    results = Queue.Queue()
 
-    timeout = kwargs.pop('timeout', DEFAULT_TIMEOUT)
-    max_memory = kwargs.pop('max_memory', DEFAULT_MAX_MEMORY) * 1024 * 1024
+    def _runner():
+        res = func(*args, **kwargs)
+        results.put(res)
 
-    # We use a pool of two threads that race to finish against each other:
-    # - one runs the func proper
-    # - one runs a loop until a timeout to check memory usage and return when it
-    #   exceeds max_memory or the timeout
-    # The first thread to complete return its result. The other thread is terminated.
+    tid = thread.start_new_thread(_runner, ())
 
-    pool = ThreadPool(2)
-    execution_units = [(func, args,), (time_and_memory_guard, [max_memory, timeout],)]
+    # only check for memory if asked for a quota
+    max_bytes = max_memory * 1024 * 1024
+    get_memory_in_use = None
+    if max_bytes:
+        get_memory_in_use = psutil.Process(os.getpid()).memory_info
 
-    # run our threads: whichever finishes first thanks to imap_unordered will be
-    # returned by the single call to next()
-    threads = pool.imap_unordered(runner, execution_units, chunksize=1)
-    pool.close()
+    interval = 0.5  # second
     try:
-        result = threads.next(timeout)
-        if result == MEMORY_EXCEEDED:
-            max_mb = megabytes(max_memory)
-            return False, 'ERROR: Processing interrupted: excessive memory usage of more than %(max_mb)s.' % locals()
-        elif result == RUNTIME_EXCEEDED:
-            return False, 'ERROR: Processing interrupted: timeout after %(timeout)d seconds.' % locals()
-        else:
-            # we succeeded with quotas: return expected results
-            return True, result
+        while timeout > 0:
+            try:
+                # blocking get for interval which is a slice of the timeout
+                res = results.get(timeout=interval)
+                return True, res
+            except Queue.Empty:
+                timeout -= interval
 
-    except multiprocessing.TimeoutError:
-        return False, 'ERROR: Processing interrupted: timeout after %(timeout)d seconds.' % locals()
+            if max_bytes and get_memory_in_use().rss > max_bytes:
+                return False, ('ERROR: Processing interrupted: excessive memory usage '
+                               'of more than %(max_memory)dMB.' % locals())
 
-    except KeyboardInterrupt:
-        return False, 'ERROR: Processing interrupted with Ctrl-C.'
-
-    except Exception:
-        return False, 'ERROR: ' + traceback.format_exc()
-
+        return False, ('ERROR: Processing interrupted: timeout after '
+                       '%(timeout)d seconds.' % locals())
     finally:
-        # stop processing
-        pool.terminate()
-
-
-def runner(func_args):
-    """
-    Given a `func_args` tuple of (func, args) run the func callable with args and
-    return func's returned value. This is a wrapper to allow using in a map-like
-    call.
-    """
-    func, args = func_args
-    return func(*args)
-
-
-def time_and_memory_guard(max_memory=DEFAULT_MAX_MEMORY, timeout=DEFAULT_TIMEOUT, interval=2):
-    """
-    Return when max_memory bytes has been used or when a timeout has expired.
-    Check memory usage every `interval` seconds during up to `timeout` seconds. Run
-    until the memory usage in the current process exceeds `max_memory` bytes. If it
-    does, return `MEMORY_EXCEEDED`. If the memory usage does not go over `max_memory`
-    bytes within `timeout` seconds, return RUNTIME_EXCEEDED.
-    """
-    process = psutil.Process()
-    memory_info = process.memory_info
-    while timeout > 0:
         try:
-            if memory_info().rss > max_memory:
-                return MEMORY_EXCEEDED
-            sleep(interval)
-            timeout -= interval
-        except:
-            # How could this happen? Some psutil error?
-            return MEMORY_EXCEEDED
-    return RUNTIME_EXCEEDED
-
-
-def megabytes(n):
-    """
-    Return a megabytes string representation of an `n` number of bytes.
-    """
-    mega = 1024 * 1024
-    return '%dMB' % (n // mega)
+            async_raise(tid, Exception)
+        except (SystemExit, ValueError, Exception):
+            pass

--- a/src/scancode/pool.py
+++ b/src/scancode/pool.py
@@ -1,0 +1,62 @@
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+"""
+Utilities and patches to create multiprocessing Process and Thread pools.
+Apply proper monkeypatch to work around some bugs or limitations.
+"""
+
+
+"""
+Monkeypatch Pool iterators so that Ctrl-C interrupts everything properly
+derived from https://gist.github.com/aljungberg/626518
+
+Copyright (c) Alexander Ljungberg. All rights reserved.
+Modifications Copyright (c) 2017 nexB Inc. and others. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from multiprocessing import pool
+
+
+def wrapped(func):
+    # ensure that we do not double wrap
+    if func.func_name != 'wrap':
+        def wrap(self, timeout=None):
+            return func(self, timeout=timeout or 1e10)
+        return wrap
+    else:
+        return func
+
+pool.IMapIterator.next = wrapped(pool.IMapIterator.next)
+pool.IMapIterator.__next__ = pool.IMapIterator.next
+pool.IMapUnorderedIterator.next = wrapped(pool.IMapUnorderedIterator.next)
+pool.IMapUnorderedIterator.__next__ = pool.IMapUnorderedIterator.next
+
+
+def get_pool(processes=None, initializer=None, initargs=(), maxtasksperchild=None):
+    """
+    Return a properly patched multiprocessing Pool.
+    """
+    return pool.Pool(processes, initializer, initargs, maxtasksperchild)

--- a/src/scancode/pool.py.ABOUT
+++ b/src/scancode/pool.py.ABOUT
@@ -1,0 +1,24 @@
+about_resource: pool.py
+name: pool
+version: 2017-02
+
+download_url: https://gist.github.com/aljungberg/626518
+
+notes: >
+    Monkeypatch Pool iterators so that Ctrl-C interrupts everything properly
+    derived from https://gist.github.com/aljungberg/626518
+    based on a private email exchange:
+    On 11 February 2017 at 11:58:47, Philippe Ombredanne (pombredanne@nexb.com) wrote:
+    > Alexander:
+    > [...] Therefore, I would need to know what is the license for your gist?
+    On Mon, Feb 13, 2017 at 12:55 PM, Alexander Ljungberg <aljungberg@slevenbits.com> wrote:
+    > Wow I barely even remember publishing that snippet. Glad you found it
+    > useful.
+    >
+    > Let’s go with MIT license.
+    > Alexander
+
+copyright: Copyright (c) Alexander Ljungberg. All rights reserved.
+
+license: mit
+license_text_file: pool.py.LICENSE

--- a/src/scancode/pool.py.LICENSE
+++ b/src/scancode/pool.py.LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) Alexander Ljungberg. All rights reserved.
+Modifications Copyright (c) 2017 nexB Inc. and others. All rights reserved.
+ 
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/scancode/thread2.ABOUT
+++ b/src/scancode/thread2.ABOUT
@@ -1,0 +1,7 @@
+about_resource: thread2.py
+author: Tomer Filiba
+homepage_url: http://tomerfiliba.com/recipes/Thread2/
+license: public-domain
+notes: Per http://tomerfiliba.com/recipes/
+ All of the following are published as "public domain", or, if you prefer, 
+ under the MIT license.

--- a/src/scancode/thread2.README
+++ b/src/scancode/thread2.README
@@ -1,0 +1,111 @@
+Killable Threads
+August 13, 2006
+By Tomer Filiba
+
+from http://tomerfiliba.com/recipes/Thread2/
+
+Per http://tomerfiliba.com/recipes/ 
+
+> All of the following are published as "public domain", or, if you prefer, 
+under the MIT license.
+
+# Killable Threads
+
+The `thread2` module is an extension of the standard `threading` module, and provides
+the means to raise exceptions at the context of the given thread. You can use
+`raise_exc()` to raise an arbitrary exception, or call `terminate()` to raise
+`SystemExit` automatically.
+
+It uses the unexposed `PyThreadState_SetAsyncExc` function (via `ctypes`) to raise an
+exception in the context of the given thread. Inspired by the code of Antoon Pardon
+at http://mail.python.org/pipermail/python-list/2005-December/316143.html
+
+### Issues
+
+* The exception will be raised only when executing python bytecode. If your thread
+calls a native/built-in blocking function, the exception will be raised only when
+execution returns to the python code.
+
+ * There is also an issue if the built-in function internally calls `PyErr_Clear()`,
+which would effectively cancel your pending exception. You can try to raise it again.
+
+* Only exception **types** can be raised safely. Exception instances are likely to
+cause unexpected behavior, and are thus restricted.
+
+ * For example: `t1.raise_exc(TypeError)` and not `t1.raise_exc(TypeError("blah"))`.
+ * IMHO it's a bug, and I reported it as one. For more info 
+   http://mail.python.org/pipermail/python-dev/2006-August/068158.html
+
+* I asked to expose this function in the built-in `thread` module, but since `ctypes`
+has become a standard library (as of 2.5), and this feature is not likely to be
+implementation-agnostic, it may be kept unexposed.
+
+## Code
+
+    import threading
+    import inspect
+    import ctypes
+
+    def _async_raise(tid, exctype):
+        """raises the exception, performs cleanup if needed"""
+        if not inspect.isclass(exctype):
+            raise TypeError("Only types can be raised (not instances)")
+        res = ctypes.pythonapi.PyThreadState_SetAsyncExc(tid, ctypes.py_object(exctype))
+        if res == 0:
+            raise ValueError("invalid thread id")
+        elif res != 1:
+            # """if it returns a number greater than one, you're in trouble, 
+            # and you should call it again with exc=NULL to revert the effect"""
+            ctypes.pythonapi.PyThreadState_SetAsyncExc(tid, 0)
+            raise SystemError("PyThreadState_SetAsyncExc failed")
+
+    class Thread(threading.Thread):
+        def _get_my_tid(self):
+            """determines this (self's) thread id"""
+            if not self.isAlive():
+                raise threading.ThreadError("the thread is not active")
+
+            # do we have it cached?
+            if hasattr(self, "_thread_id"):
+                return self._thread_id
+
+            # no, look for it in the _active dict
+            for tid, tobj in threading._active.items():
+                if tobj is self:
+                    self._thread_id = tid
+                    return tid
+
+            raise AssertionError("could not determine the thread's id")
+
+        def raise_exc(self, exctype):
+            """raises the given exception type in the context of this thread"""
+            _async_raise(self._get_my_tid(), exctype)
+
+        def terminate(self):
+            """raises SystemExit in the context of the given thread, which should 
+            cause the thread to exit silently (unless caught)"""
+            self.raise_exc(SystemExit)
+
+
+## Example
+
+
+    >>> import time
+    >>> from thread2 import Thread
+    >>>
+    >>> def f():
+    ...     try:
+    ...         while True:
+    ...             time.sleep(0.1)
+    ...     finally:
+    ...         print "outta here"
+    ...
+    >>> t = Thread(target = f)
+    >>> t.start()
+    >>> t.isAlive()
+    True
+    >>> t.terminate()
+    >>> t.join()
+    outta here
+    >>> t.isAlive()
+    False

--- a/src/scancode/thread2.py
+++ b/src/scancode/thread2.py
@@ -1,0 +1,29 @@
+
+
+"""
+Based on Killable Threads By Tomer Filiba
+from http://tomerfiliba.com/recipes/Thread2/
+public domain.
+"""
+
+from __future__ import absolute_import
+import ctypes
+
+
+def async_raise(tid, exctype):
+    """
+    Raise the exception `exctype` in the Thread with id `tid`. Perform cleanup if
+    needed
+    """
+    assert isinstance(tid, int), 'Invalid  thread id: must an integer'
+    assert isinstance(exctype, type), 'Only types can be raised (not instances)'
+
+    res = ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(tid),
+                                                     ctypes.py_object(exctype))
+    if res == 0:
+        raise ValueError('Invalid thread id.')
+    elif res != 1:
+        # if it returns a number greater than one, you're in trouble,
+        # and you should call it again with exc=NULL to revert the effect
+        ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(tid), 0)
+        raise SystemError('PyThreadState_SetAsyncExc failed.')

--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -281,9 +281,9 @@ def test_scan_works_with_multiple_processes_and_timeouts(monkeypatch):
     assert result.exit_code == 0
     assert 'Scanning done' in result.output
     expected = [
-        {u'path': u'test1.txt', u'scan_errors': [u'ERROR: Processing interrupted: timeout after 1 seconds.']},
-        {u'path': u'test2.txt', u'scan_errors': [u'ERROR: Processing interrupted: timeout after 1 seconds.']},
-        {u'path': u'test3.txt', u'scan_errors': [u'ERROR: Processing interrupted: timeout after 1 seconds.']}
+        {u'path': u'test1.txt', u'scan_errors': [u'ERROR: Processing interrupted: timeout after 0 seconds.']},
+        {u'path': u'test2.txt', u'scan_errors': [u'ERROR: Processing interrupted: timeout after 0 seconds.']},
+        {u'path': u'test3.txt', u'scan_errors': [u'ERROR: Processing interrupted: timeout after 0 seconds.']}
     ]
 
     result_json = json.loads(open(result_file).read())


### PR DESCRIPTION
 * pool.py implements a get_pool to obtain a patched pools of processes.
 * thread2.py has a utility function to kill threads.
 * interrupt.py "interruptible" has been updated to work with
   a single runner thread and a timeout and memory guard loop.
   This new implementation is vastly simplified with fewer moving parts
   and possibly slightly faster.
 * cli.py now uses an outer pool of processes and a thread-based
   interruptible. It should leak no of few threads since they are
   now killed alright. Leakage is verified in the "interruptible" tests.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>