### PR TITLE
updated README.rst to fix ubuntu 16.04 required packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,8 @@ ScanCode needs a Python 2.7 interpreter.
   for instructions to compile Python from sources on Centos.
 
   * On Ubuntu 16.04 and later, you will need to install these packages first: ``python-dev bzip2 xz-utils zlib1g libxml2-dev libxslt1-dev``
-  * On Debian 8 (Jessie), you will need to install these packages first: ``python-dev libbz2-1.0 xz-utils zlib1g libxml2-dev libxslt1-dev``
+  * On most Debian/Ubuntu distros, you will need to install these packages first: ``python-dev libbz2 xzutils zlib1g libxml2-dev libxslt1-dev``
+* On Debian 8 (Jessie), you will need to install these packages first: ``python-dev libbz2-1.0 xz-utils zlib1g libxml2-dev libxslt1-dev``
   * On RPM-based distros, you will need to install these packages first: ``python-devel zlib bzip2-libs xz-libs libxml2-devel libxslt-devel``
 
 - **On Windows**:

--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ ScanCode needs a Python 2.7 interpreter.
   For instance, visit https://github.com/dejacode/about-code-tool/wiki/BuildingPython27OnCentos6
   for instructions to compile Python from sources on Centos.
 
-  * On most Debian/Ubuntu distros, you will need to install these packages first: ``python-dev libbz2 xzutils zlib1g libxml2-dev libxslt1-dev``
+  * On Ubuntu 16.04 and later, you will need to install these packages first: ``python-dev bzip2 xz-utils zlib1g libxml2-dev libxslt1-dev``
   * On Debian 8 (Jessie), you will need to install these packages first: ``python-dev libbz2-1.0 xz-utils zlib1g libxml2-dev libxslt1-dev``
   * On RPM-based distros, you will need to install these packages first: ``python-devel zlib bzip2-libs xz-libs libxml2-devel libxslt-devel``
 


### PR DESCRIPTION
`libbz2` and `xzutils` no longer exist in the Ubuntu 16.04 package repos. They are instead referenced as `bzip2` and `xz-utils`, respectively. 

The ubuntu 16.04 packages listed in this README are confirmed to work, with `source configure` returning no errors. 