### PR TITLE
#534 Adjust license score for 100% non-contiguous match

### DIFF
--- a/src/licensedcode/match.py
+++ b/src/licensedcode/match.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016 nexB Inc. and others. All rights reserved.
+# Copyright (c) 2017 nexB Inc. and others. All rights reserved.
 # http://nexb.com and https://github.com/nexB/scancode-toolkit/
 # The ScanCode software is licensed under the Apache License version 2.0.
 # Data generated with ScanCode require an acknowledgment.
@@ -276,7 +276,19 @@ class LicenseMatch(object):
         if not coverage or not relevance:
             return 0
 
-        return round(coverage * relevance * 100, 2)
+        score = coverage * relevance
+        if score == 1:
+            # Is the match a contiguous match or not? If not, recompute the score
+            # with an alternative approach to avoid the case where a 100% match that
+            # is not covering ALL of the query side region (e.g. a non-contiguous
+            # match) can contain extra misleading words.
+            # see https://github.com/nexB/scancode-toolkit/issues/534
+            matched_and_unmatched = self.qspan.magnitude()
+            matched = self.qlen()
+            if matched != matched_and_unmatched:
+                score = matched / matched_and_unmatched
+
+        return  round(score * 100, 2)
 
     def surround(self, other):
         """

--- a/tests/licensedcode/test_match.py
+++ b/tests/licensedcode/test_match.py
@@ -619,6 +619,21 @@ class TestLicenseMatchScore(FileBasedTesting):
         m1 = LicenseMatch(rule=r1, qspan=Span(0, 2), ispan=Span(0, 2))
         assert m1.score() == 0
 
+    def test_LicenseMatch_score_100_contiguous(self):
+        r1 = Rule(text_file='r1', licenses=['apache-2.0'])
+        r1.relevance = 100
+        r1.length = 42
+
+        m1 = LicenseMatch(rule=r1, qspan=Span(0, 41), ispan=Span(0, 41))
+        assert m1.score() == 100
+
+    def test_LicenseMatch_score_100_non_contiguous(self):
+        r1 = Rule(text_file='r1', licenses=['apache-2.0'])
+        r1.relevance = 100
+        r1.length = 42
+
+        m1 = LicenseMatch(rule=r1, qspan=Span(0, 19) | Span(30, 51), ispan=Span(0, 41))
+        assert m1.score() == 80.77
 
 class TestCollectLicenseMatchTexts(FileBasedTesting):
     test_data_dir = TEST_DATA_DIR


### PR DESCRIPTION
 * the score is computed as (matched/matched+unmatched) for 100%
   matches that are non-contiguous. e.g. matches that have a query
   length that is smaller than the matched query span magnitude.
 * this fixes #534

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>