### PR TITLE
Implements extraction of Archives before Scanning

### DIFF
--- a/src/extractcode/extract_directory.py
+++ b/src/extractcode/extract_directory.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 nexB Inc. and others. All rights reserved.
+# Copyright (c) 2017 nexB Inc. and others. All rights reserved.
 # http://nexb.com and https://github.com/nexB/scancode-toolkit/
 # The ScanCode software is licensed under the Apache License version 2.0.
 # Data generated with ScanCode require an acknowledgment.
@@ -47,54 +47,6 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
 
-"""
-Extract archives and compressed files recursively to get the file content available for
-further processing. This the high level extraction entry point.
-
-This is NOT a general purpose un-archiver. The code tries hard to do the right
-thing, BUT the extracted files are not meant to be something that can be
-faithfully re-archived to get an equivalent archive. The purpose instead is
-to extract the content of the archives as faithfully and safely as possible to
-make this content available for scanning: some paths may be altered. Some files
-may be altered or skipped entirely.
-
-In particular:
-
- - Permissions and owners stored in archives are ignored entirely: The extracted
-   content is always owned and readable by the user who ran the extraction.
-
- - Special files are never extracted (such as FIFO, character devices, etc)
-
- - Symlinks may be replaced by plain file copies as if they were regular files.
-   Hardlinks may be recreated as regular files, not as hardlinks to the original
-   file.
-
- - Files and directories may be renamed when their name is a duplicate. And a
-   name may be considered a duplicate ignore upper and lower case mixes even
-   on case-sensitive file systems. In particular when an archive contains the
-   same file path several times, every paths will be extracted with different
-   files names, even though using a regular tool for extraction would have
-   overwritten previous paths with the last path.
-
- - Paths may be converted to a safe ASCII alternative that is portable across
-   OSes.
-
- - Symlinks, relative paths and absolute paths pointing outside of the archive
-   are replaced and renamed in such a way that all the extract content of an
-   archive exist under a single target extraction directory. This process
-   includes eventually creating "synthetic" or dummy paths that did not exist in
-   the original archive.
-"""
-
-
-"""
-An ExtractEvent contains data about an archive extraction progress:
- - `source` is the location of the archive being extracted
- - `target` is the target location where things are extracted
- - `done` is a boolean set to True when the extraction is done (even if failed).
- - `warnings` is a mapping of extracted paths to a list of warning messages.
- - `errors` is a list of error messages.
-"""
 def extract_directory(location, kinds=extractcode.default_kinds, recurse=False):
     """
     Walk and extract any archives found at `location` (either a file or
@@ -127,5 +79,5 @@ def extract_directory(location, kinds=extractcode.default_kinds, recurse=False):
         if archive.can_extract(file):
             #TODO : Implement Extraction of Files without printing to the Terminal
             for y in extract(file, kinds=default_kinds, recurse=True):
-                print (y)
+                # print (y)
                 pass

--- a/src/extractcode/extract_directory.py
+++ b/src/extractcode/extract_directory.py
@@ -47,7 +47,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
 
-def extract_directory(location, kinds=extractcode.default_kinds, recurse=False):
+def extract_directory(resources, kinds=extractcode.default_kinds, recurse=True):
     """
     Walk and extract any archives found at `location` (either a file or
     directory). Extract only archives of a kind listed in the `kinds` kind tuple.
@@ -70,14 +70,8 @@ def extract_directory(location, kinds=extractcode.default_kinds, recurse=False):
     if recurse and a nested archive is found, it is extracted to full depth
     first before resuming the file system walk.
     """
-    abs_input = fileutils.as_posixpath(os.path.abspath(os.path.expanduser(location)))
-    original_input = fileutils.as_posixpath(location)
-    abs_input = fileutils.as_posixpath(os.path.abspath(os.path.expanduser(location)))
-    ignored = partial(ignore.is_ignored, ignores=ignore.ignores_VCS, unignores={})
-    resources = fileutils.resource_iter(abs_input, ignored=ignored)
     for file in resources:
         if archive.can_extract(file):
             #TODO : Implement Extraction of Files without printing to the Terminal
-            for y in extract(file, kinds=default_kinds, recurse=True):
-                # print (y)
+            for y in extract(file, kinds=kinds, recurse=recurse):
                 pass

--- a/src/extractcode/extract_directory.py
+++ b/src/extractcode/extract_directory.py
@@ -65,13 +65,15 @@ def extract_directory(resources, kinds=extractcode.default_kinds, recurse=True):
     If `recurse` is True, extract recursively archives nested inside other
     archives If `recurse` is false, then do not extract further an already
     extracted archive identified by the corresponding extract suffix location.
-
+for y in
     Note that while the original file system is walked top-down, breadth-first,
     if recurse and a nested archive is found, it is extracted to full depth
     first before resuming the file system walk.
     """
     for file in resources:
         if archive.can_extract(file):
-            #TODO : Implement Extraction of Files without printing to the Terminal
             for y in extract(file, kinds=kinds, recurse=recurse):
                 pass
+            return extract_directory(file)
+		else:
+			yield file

--- a/src/extractcode/extract_directory.py
+++ b/src/extractcode/extract_directory.py
@@ -42,38 +42,35 @@ logger = logging.getLogger(__name__)
 TRACE = False
 
 if TRACE:
-    import sys
-    logging.basicConfig(stream=sys.stdout)
-    logger.setLevel(logging.DEBUG)
+	import sys
+	logging.basicConfig(stream=sys.stdout)
+	logger.setLevel(logging.DEBUG)
 
 
 def extract_directory(resources, kinds=extractcode.default_kinds, recurse=True):
-    """
-    Walk and extract any archives found at `location` (either a file or
-    directory). Extract only archives of a kind listed in the `kinds` kind tuple.
+	"""
+	Walk and extract any archives found at `location` (either a file or
+	directory). Extract only archives of a kind listed in the `kinds` kind tuple.
 
-    Return an iterable of ExtractEvent tuples for each extracted archive. This
-    can be used to track extraction progress:
+	Return an iterable of ExtractEvent tuples for each extracted archive. This
+	can be used to track extraction progress:
 
-     - one event is emitted just before extracting an archive. The ExtractEvent
-       warnings and errors are empty. The `done` flag is False.
+	 - one event is emitted just before extracting an archive. The ExtractEvent
+	   warnings and errors are empty. The `done` flag is False.
 
-     - one event is emitted right after extracting an archive. The ExtractEvent
-       warnings and errors contains warnings and errors if any. The `done` flag
-       is True.
+	 - one event is emitted right after extracting an archive. The ExtractEvent
+	   warnings and errors contains warnings and errors if any. The `done` flag
+	   is True.
 
-    If `recurse` is True, extract recursively archives nested inside other
-    archives If `recurse` is false, then do not extract further an already
-    extracted archive identified by the corresponding extract suffix location.
-for y in
-    Note that while the original file system is walked top-down, breadth-first,
-    if recurse and a nested archive is found, it is extracted to full depth
-    first before resuming the file system walk.
-    """
-    for file in resources:
-        if archive.can_extract(file):
-            for y in extract(file, kinds=kinds, recurse=recurse):
-                pass
-            return extract_directory(file)
-		else:
-			yield file
+	If `recurse` is True, extract recursively archives nested inside other
+	archives If `recurse` is false, then do not extract further an already
+	extracted archive identified by the corresponding extract suffix location.
+	Note that while the original file system is walked top-down, breadth-first,
+	if recurse and a nested archive is found, it is extracted to full depth
+	first before resuming the file system walk.
+	"""
+	for file in resources:
+		if archive.can_extract(file):
+			extract(file, kinds=kinds, recurse=recurse)
+			yield extract_directory(file)
+		yield file

--- a/src/extractcode/extract_directory.py
+++ b/src/extractcode/extract_directory.py
@@ -1,0 +1,131 @@
+#
+# Copyright (c) 2015 nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/scancode-toolkit/
+# The ScanCode software is licensed under the Apache License version 2.0.
+# Data generated with ScanCode require an acknowledgment.
+# ScanCode is a trademark of nexB Inc.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with ScanCode or any ScanCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  ScanCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  ScanCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/scancode-toolkit/ for support and download.
+
+from __future__ import print_function, absolute_import
+
+from collections import namedtuple
+from functools import partial
+import logging
+from os.path import abspath
+from os.path import expanduser
+from os.path import join
+
+from commoncode import fileutils
+from commoncode import ignore
+import extractcode
+from extractcode import archive
+from extractcode import extract
+import os
+
+logger = logging.getLogger(__name__)
+TRACE = False
+
+if TRACE:
+    import sys
+    logging.basicConfig(stream=sys.stdout)
+    logger.setLevel(logging.DEBUG)
+
+
+"""
+Extract archives and compressed files recursively to get the file content available for
+further processing. This the high level extraction entry point.
+
+This is NOT a general purpose un-archiver. The code tries hard to do the right
+thing, BUT the extracted files are not meant to be something that can be
+faithfully re-archived to get an equivalent archive. The purpose instead is
+to extract the content of the archives as faithfully and safely as possible to
+make this content available for scanning: some paths may be altered. Some files
+may be altered or skipped entirely.
+
+In particular:
+
+ - Permissions and owners stored in archives are ignored entirely: The extracted
+   content is always owned and readable by the user who ran the extraction.
+
+ - Special files are never extracted (such as FIFO, character devices, etc)
+
+ - Symlinks may be replaced by plain file copies as if they were regular files.
+   Hardlinks may be recreated as regular files, not as hardlinks to the original
+   file.
+
+ - Files and directories may be renamed when their name is a duplicate. And a
+   name may be considered a duplicate ignore upper and lower case mixes even
+   on case-sensitive file systems. In particular when an archive contains the
+   same file path several times, every paths will be extracted with different
+   files names, even though using a regular tool for extraction would have
+   overwritten previous paths with the last path.
+
+ - Paths may be converted to a safe ASCII alternative that is portable across
+   OSes.
+
+ - Symlinks, relative paths and absolute paths pointing outside of the archive
+   are replaced and renamed in such a way that all the extract content of an
+   archive exist under a single target extraction directory. This process
+   includes eventually creating "synthetic" or dummy paths that did not exist in
+   the original archive.
+"""
+
+
+"""
+An ExtractEvent contains data about an archive extraction progress:
+ - `source` is the location of the archive being extracted
+ - `target` is the target location where things are extracted
+ - `done` is a boolean set to True when the extraction is done (even if failed).
+ - `warnings` is a mapping of extracted paths to a list of warning messages.
+ - `errors` is a list of error messages.
+"""
+def extract_directory(location, kinds=extractcode.default_kinds, recurse=False):
+    """
+    Walk and extract any archives found at `location` (either a file or
+    directory). Extract only archives of a kind listed in the `kinds` kind tuple.
+
+    Return an iterable of ExtractEvent tuples for each extracted archive. This
+    can be used to track extraction progress:
+
+     - one event is emitted just before extracting an archive. The ExtractEvent
+       warnings and errors are empty. The `done` flag is False.
+
+     - one event is emitted right after extracting an archive. The ExtractEvent
+       warnings and errors contains warnings and errors if any. The `done` flag
+       is True.
+
+    If `recurse` is True, extract recursively archives nested inside other
+    archives If `recurse` is false, then do not extract further an already
+    extracted archive identified by the corresponding extract suffix location.
+
+    Note that while the original file system is walked top-down, breadth-first,
+    if recurse and a nested archive is found, it is extracted to full depth
+    first before resuming the file system walk.
+    """
+    abs_input = fileutils.as_posixpath(os.path.abspath(os.path.expanduser(location)))
+    original_input = fileutils.as_posixpath(location)
+    abs_input = fileutils.as_posixpath(os.path.abspath(os.path.expanduser(location)))
+    ignored = partial(ignore.is_ignored, ignores=ignore.ignores_VCS, unignores={})
+    resources = fileutils.resource_iter(abs_input, ignored=ignored)
+    for file in resources:
+        if archive.can_extract(file):
+            #TODO : Implement Extraction of Files without printing to the Terminal
+            for y in extract(file, kinds=default_kinds, recurse=True):
+                print (y)
+                pass

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -70,6 +70,10 @@ from scancode.interrupt import DEFAULT_MAX_MEMORY
 
 from scancode import utils
 
+from extractcode.extract import extract
+from extractcode import default_kinds
+from extractcode import archive
+
 echo_stderr = partial(click.secho, err=True)
 
 
@@ -280,6 +284,20 @@ def scancode(ctx,
     scans_cache_class = get_scans_cache_class()
 
     try:
+        #Search for archives recursively in the input path and extract them
+        #After extracting the archives, Scancode can also search for licenses within the files of archives as well
+        abs_input = fileutils.as_posixpath(os.path.abspath(os.path.expanduser(input)))
+        original_input = fileutils.as_posixpath(input)
+        abs_input = fileutils.as_posixpath(os.path.abspath(os.path.expanduser(input)))
+        ignored = partial(ignore.is_ignored, ignores=ignore.ignores_VCS, unignores={})
+        resources = fileutils.resource_iter(abs_input, ignored=ignored)
+        for x in resources:
+            if archive.can_extract(x):
+                #TODO : Implement Extraction of Files without printing to the Terminal
+                for y in extract(x, kinds=default_kinds, recurse=True):
+                    print(y)
+                #TODO : Implement Extraction at a temporary location, and then delete the extracted archives after scanning is complete
+
         files_count, results = scan(input_path=input,
                                     scanners=scanners,
                                     license_score=license_score,

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -285,8 +285,6 @@ def scancode(ctx,
     scans_cache_class = get_scans_cache_class()
 
     try:
-        #We could call the below function if required to first extract all the archives, and then start scanning
-
         '''
         abs_input = fileutils.as_posixpath(os.path.abspath(os.path.expanduser(location)))
         original_input = fileutils.as_posixpath(location)

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -70,6 +70,9 @@ from scancode.interrupt import DEFAULT_MAX_MEMORY
 
 from scancode import utils
 
+from extractcode.extract import extract
+from extractcode import default_kinds
+from extractcode import archive
 from extractcode.extract_directory import extract_directory
 
 echo_stderr = partial(click.secho, err=True)
@@ -284,8 +287,16 @@ def scancode(ctx,
     try:
         #We could call the below function if required to first extract all the archives, and then start scanning
 
+        '''
+        abs_input = fileutils.as_posixpath(os.path.abspath(os.path.expanduser(location)))
+        original_input = fileutils.as_posixpath(location)
+        abs_input = fileutils.as_posixpath(os.path.abspath(os.path.expanduser(location)))
+        ignored = partial(ignore.is_ignored, ignores=ignore.ignores_VCS, unignores={})
+        resources = fileutils.resource_iter(abs_input, ignored=ignored)
 
-        #extract_directory(input)
+        extract_directory(resources)
+
+        '''
 
 
         #This achieves silent extraction of archives before starting the scanning

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -70,9 +70,6 @@ from scancode.interrupt import DEFAULT_MAX_MEMORY
 
 from scancode import utils
 
-from extractcode.extract import extract
-from extractcode import default_kinds
-from extractcode import archive
 from extractcode.extract_directory import extract_directory
 
 echo_stderr = partial(click.secho, err=True)

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -73,6 +73,7 @@ from scancode import utils
 from extractcode.extract import extract
 from extractcode import default_kinds
 from extractcode import archive
+from extractcode.extract_directory import extract_directory
 
 echo_stderr = partial(click.secho, err=True)
 
@@ -284,20 +285,16 @@ def scancode(ctx,
     scans_cache_class = get_scans_cache_class()
 
     try:
-        #Search for archives recursively in the input path and extract them
-        #After extracting the archives, Scancode can also search for licenses within the files of archives as well
-        abs_input = fileutils.as_posixpath(os.path.abspath(os.path.expanduser(input)))
-        original_input = fileutils.as_posixpath(input)
-        abs_input = fileutils.as_posixpath(os.path.abspath(os.path.expanduser(input)))
-        ignored = partial(ignore.is_ignored, ignores=ignore.ignores_VCS, unignores={})
-        resources = fileutils.resource_iter(abs_input, ignored=ignored)
-        for x in resources:
-            if archive.can_extract(x):
-                #TODO : Implement Extraction of Files without printing to the Terminal
-                for y in extract(x, kinds=default_kinds, recurse=True):
-                    print(y)
-                #TODO : Implement Extraction at a temporary location, and then delete the extracted archives after scanning is complete
+        #We could call the below function if required to first extract all the archives, and then start scanning
 
+
+        #extract_directory(input)
+
+
+        #This achieves silent extraction of archives before starting the scanning
+        #TODO: Delete the extracted files after the scanning process is complete.
+        #TODO: Implement a seperate option in the helper script like --extractandrecurse to call extract_directory
+        #before beginning the scanning process just like other options like --info and others.
         files_count, results = scan(input_path=input,
                                     scanners=scanners,
                                     license_score=license_score,


### PR DESCRIPTION
Signed-off-by: Ashutosh Saboo <ashutosh.saboo96@gmail.com>

@pombredanne Sir. This is a step towards implementing extraction of archives for scanning of licenses within the files of the archives as well. 

I feel, instead of extracting to a temporary location, as @pombredanne you were discussing in #14 , we must instead extract to the original location itself, since that will also not hinder the performance of the scanning engine as well. Scancode then itself, searches for licenses in the extracted files, and then we could delete the extracted files as well.

I have been looking at Scancode's source code since 2-3 days now, and I would be willing to work for implementing this. Any suggestions on this @pombredanne Sir? I'll issue new commits with the remaining TODOs as well.

Achieved:
1. Extraction of all archives in the folder tree under a specified location before starting the scanning process.
2. Silent extraction of archives.

Currently TODO's:
1. Delete extracted files after scanning is complete
2. Also implement points mentioned in #458 for specific archive extraction. 