### PR TITLE
#564 add code coverage to .travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,35 @@
-language: cpp
+language: python
 
-os: 
-    - osx
-    - linux 
+python:
+  - 2.7.13
 
-env:
-    matrix:
-        - TEST_SUITE="bin/py.test -n 2 -vvs --ignore=tests/scancode --ignore=tests/extractcode --ignore=tests/licensedcode --ignore=tests/cluecode --ignore=tests/packagedcode"
-        - TEST_SUITE="bin/py.test -n 2 -vvs tests/scancode"
-        - TEST_SUITE="bin/py.test -n 2 -vvs tests/extractcode"
-        - TEST_SUITE="bin/py.test -n 2 -s tests/licensedcode"
-        - TEST_SUITE="bin/py.test -n 2 -s tests/cluecode"
-        - TEST_SUITE="bin/py.test -n 2 -s tests/packagedcode"
-        - TEST_SUITE="./etc/release/release.sh"
-
+matrix:
+  include:
+    - os: osx
+      language: generic
+      python:
+      osx_image: xcode7.3
 
 install:
-    - ./configure
+  - ./configure
+  - ./bin/pip install pytest-cov coveralls
 
 script:
-    - $TEST_SUITE
+  # If debugging, use a subset of tests to reduce wait:
+  # - ./bin/py.test -n 2 -vvs --cov=src/scancode tests/scancode
+  - ./bin/py.test -n 2 -s --cov=src
+
+after_success:
+  - ./bin/coveralls
+  - ./etc/release/release.sh
 
 notifications:
-    irc:
-        channels:
-          - "chat.freenode.net#aboutcode"
-    on_success: change
-    on_failure: always
-    use_notice: true
-    skip_join: true
-    template:
-        - "%{repository_slug}#%{build_number} (%{branch}-%{commit}:%{author})-%{message}- %{build_url}"
-        - 
-        - 
+  irc:
+    channels:
+      - "chat.freenode.net#aboutcode"
+  on_success: change
+  on_failure: always
+  use_notice: true
+  skip_join: true
+  template:
+    - "%{repository_slug}#%{build_number} (%{branch}-%{commit}:%{author})-%{message}- %{build_url}"

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,22 @@
-===============================
+================
 ScanCode toolkit
-===============================
+================
 
 
 Build and tests status
 ======================
 
-+-------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
-|Branch |                         **Linux (Travis)**                                  |                         **MacOSX (Travis)**                                 |                         **Windows (AppVeyor)**                                                |
-+=======+=============================================================================+=============================================================================+===============================================================================================+
-|       |.. image:: https://api.travis-ci.org/nexB/scancode-toolkit.png?branch=master |.. image:: https://api.travis-ci.org/nexB/scancode-toolkit.png?branch=master |.. image:: https://ci.appveyor.com/api/projects/status/4webymu0l2ip8utr/branch/master?png=true |
-|Master |   :target: https://travis-ci.org/nexB/scancode-toolkit                      |   :target: https://travis-ci.org/nexB/scancode-toolkit                      |   :target: https://ci.appveyor.com/project/nexB/scancode-toolkit                              |
-|       |   :alt: Linux Master branch tests status                                    |   :alt: MacOSX Master branch tests status                                   |   :alt: Windows Master branch tests status                                                    |
-+-------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
-|       |.. image:: https://api.travis-ci.org/nexB/scancode-toolkit.png?branch=develop|.. image:: https://api.travis-ci.org/nexB/scancode-toolkit.png?branch=develop|.. image:: https://ci.appveyor.com/api/projects/status/4webymu0l2ip8utr/branch/develop?png=true|
-|Develop|   :target: https://travis-ci.org/nexB/scancode-toolkit                      |   :target: https://travis-ci.org/nexB/scancode-toolkit                      |   :target: https://ci.appveyor.com/project/nexB/scancode-toolkit                              |
-|       |   :alt: Linux Develop branch tests status                                   |   :alt: MacOSX Develop branch tests status                                  |   :alt: Windows Develop branch tests status                                                   |
-+-------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
-
++-------+--------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
+|Branch |                                        **Coverage**                                        |                         **Linux (Travis)**                                  |                         **MacOSX (Travis)**                                 |                         **Windows (AppVeyor)**                                                |
++=======+============================================================================================+=============================================================================+=============================================================================+===============================================================================================+
+|       |.. image:: https://coveralls.io/repos/github/nexB/scancode-toolkit/badge.svg?branch=master  |.. image:: https://api.travis-ci.org/nexB/scancode-toolkit.png?branch=master |.. image:: https://api.travis-ci.org/nexB/scancode-toolkit.png?branch=master |.. image:: https://ci.appveyor.com/api/projects/status/4webymu0l2ip8utr/branch/master?png=true |
+|Master |   :target: https://coveralls.io/github/nexB/scancode-toolkit?branch=master                 |   :target: https://travis-ci.org/nexB/scancode-toolkit                      |   :target: https://travis-ci.org/nexB/scancode-toolkit                      |   :target: https://ci.appveyor.com/project/nexB/scancode-toolkit                              |
+|       |   :alt: Linux Master branch test coverage                                                  |   :alt: Linux Master branch tests status                                    |   :alt: MacOSX Master branch tests status                                   |   :alt: Windows Master branch tests status                                                    |
++-------+--------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
+|       |.. image:: https://coveralls.io/repos/github/nexB/scancode-toolkit/badge.svg?branch=develop |.. image:: https://api.travis-ci.org/nexB/scancode-toolkit.png?branch=develop|.. image:: https://api.travis-ci.org/nexB/scancode-toolkit.png?branch=develop|.. image:: https://ci.appveyor.com/api/projects/status/4webymu0l2ip8utr/branch/develop?png=true|
+|Develop|   :target: https://coveralls.io/github/nexB/scancode-toolkit?branch=develop                |   :target: https://travis-ci.org/nexB/scancode-toolkit                      |   :target: https://travis-ci.org/nexB/scancode-toolkit                      |   :target: https://ci.appveyor.com/project/nexB/scancode-toolkit                              |
+|       |   :alt: Linux Develop branch test coverage                                                 |   :alt: Linux Develop branch tests status                                   |   :alt: MacOSX Develop branch tests status                                  |   :alt: Windows Develop branch tests status                                                   |
++-------+--------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------+
 
 
 ScanCode is a suite of utilities used to scan a codebase for license, copyright


### PR DESCRIPTION
I have figured how to add `pytest-cov`, `coveralls` and its dependency `docopt` to the configure system you described [in the issue][1] (will add .ABOUT and .LICENSE files later. Also, `docopt` lacks a wheel so created it.):

Now, when I locally do:

```
./configure
```
Then `type pytest` gives `pytest not found` which means there is no globally installed pytest on my machine. Then I do:

```
source bin/activate
type pytest
type coveralls
```

Which gives me:

```
pytest is /home/alex/Code/scancode-toolkit/bin/pytest
coveralls is /home/alex/Code/scancode-toolkit/bin/coveralls
```

This means that a local `./configure` installs `pytest` and `coveralls` just fine for me. However, when I use the following `.travis.yml` on CI, it tells me 

```
/Users/travis/build.sh: line 62: bin/pytest: No such file or directory
```

So, it looks like pytest does not get installed and the build fails. Any ideas why?

Update: for this PR I changed the order of `type pytest` and `type coveralls`, so travis will probably be missing coveralls, but you get the idea. Here is a link to my ci runs that miss pytest:

https://travis-ci.org/all3fox/scancode-toolkit/jobs/215599442

[1]: https://github.com/nexB/scancode-toolkit/issues/564#issuecomment-289366836