### PR TITLE
#573 Compute width of terminal window and use it in shortening the filename

### DIFF
--- a/tests/formattedcode/test_writers.py
+++ b/tests/formattedcode/test_writers.py
@@ -56,7 +56,6 @@ def test_json_pretty_print_option(monkeypatch):
     result = runner.invoke(cli.scancode, ['--copyright', '--format', 'json-pp', test_dir, result_file], catch_exceptions=True)
     assert result.exit_code == 0
     assert 'Scanning done' in result.output
-    assert 'copyright_acme_c-c.c' in result.output
     assert os.path.exists(result_file)
     assert len(open(result_file).read()) > 10
     assert len(open(result_file).readlines()) > 1
@@ -70,7 +69,6 @@ def test_json_output_option_is_minified(monkeypatch):
     result = runner.invoke(cli.scancode, ['--copyright', '--format', 'json', test_dir, result_file], catch_exceptions=True)
     assert result.exit_code == 0
     assert 'Scanning done' in result.output
-    assert 'copyright_acme_c-c.c' in result.output
     assert os.path.exists(result_file)
     assert len(open(result_file).read()) > 10
     assert len(open(result_file).readlines()) == 1

--- a/tests/scancode/data/long_file_name/abcdefghijklmnopqrtu0123456789012345678901234567890123456789abcdefghijklmnopqrtu0123456789012345678901234567890123456789.c
+++ b/tests/scancode/data/long_file_name/abcdefghijklmnopqrtu0123456789012345678901234567890123456789abcdefghijklmnopqrtu0123456789012345678901234567890123456789.c
@@ -1,0 +1,1 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */

--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -510,6 +510,14 @@ def test_scan_logs_errors_messages_with_diag():
 
 class TestFixedWidthFilename(TestCase):
 
+    def test_fixed_width_file_name_with_click_get_terminal_size(self):
+        terminal_width = click.get_terminal_size()[0]
+        max_length = terminal_width - 60
+        test = cli.fixed_width_file_name('0123456789012345678901234.c')
+        assert len(test) <= max_length
+        expected = ''
+        assert expected == test
+
     def test_fixed_width_file_name_with_file_name_larger_than_max_length_is_shortened(self):
         test = cli.fixed_width_file_name('0123456789012345678901234.c')
         expected = '0123456789...5678901234.c'


### PR DESCRIPTION
Fixes #573.
@pombredanne Please review.
I have removed the tests as hard coded `assert` cannot be used now.