### PR TITLE
#609 New rule and test for notice by Xin Yang

### DIFF
--- a/src/licensedcode/data/rules/other-permissive_xin-yang.RULE
+++ b/src/licensedcode/data/rules/other-permissive_xin-yang.RULE
@@ -1,0 +1,1 @@
+This script is free as long as the copyright notice remains intact.

--- a/src/licensedcode/data/rules/other-permissive_xin-yang.yml
+++ b/src/licensedcode/data/rules/other-permissive_xin-yang.yml
@@ -1,0 +1,2 @@
+licenses:
+    - other-permissive

--- a/tests/licensedcode/data/licenses/other-permissive_xin-yang.txt
+++ b/tests/licensedcode/data/licenses/other-permissive_xin-yang.txt
@@ -1,0 +1,7 @@
+// Select Menu
+
+// Copyright Xin Yang 2003
+// Web Site: www.yxScripts.com
+// EMail: m_yangxin@hotmail.com
+
+// This script is free as long as the copyright notice remains intact.

--- a/tests/licensedcode/data/licenses/other-permissive_xin-yang.yml
+++ b/tests/licensedcode/data/licenses/other-permissive_xin-yang.yml
@@ -1,0 +1,2 @@
+licenses:
+    - other-permissive


### PR DESCRIPTION
A new rule and test have been added to detect the licensing notice by Xin Yang. It is now detected as `other-permissive`.