### PR TITLE
Improve detection of Oracle as a copyright holder

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -41,7 +41,7 @@ if os.environ.get('SCANCODE_COPYRIGHT_DEBUG'):
     import sys
     logging.basicConfig(stream=sys.stdout)
     logger.setLevel(logging.DEBUG)
-    COPYRIGHT_TRACE = 2
+    COPYRIGHT_TRACE = 0
 
 """
 Detect and collect copyright statements.
@@ -257,6 +257,8 @@ patterns = [
     (r'^[Ii]nstitut(s|o|os|e|es|et|a|at|as|u|i)?$', 'NNP'),
     # "holders" is considered as a common noun
     (r'^([Hh]olders?|HOLDERS?|[Rr]espective)$', 'NN'),
+    # affiliates
+    (r'^[Aa]ffiliates?\.?$', 'NNP'),
 
     # OU as in Org unit, found in some certficates
     (r'^OU$', 'OU'),
@@ -286,7 +288,8 @@ patterns = [
     (r'^following$', 'FOLLOW'),
 
     # conjunction: and
-    (r'^([Aa]nd|&|[Uu]nd|ET|[Ee]t|at)$', 'CC'),
+    (r'^([Aa]nd|&|[Uu]nd|ET|[Ee]t|at|and/or)$', 'CC'),
+
     # conjunction: or. Even though or is not conjunctive ....
     # (r'^or$', 'CC'),
     # conjunction: or. Even though or is not conjunctive ....
@@ -560,6 +563,7 @@ grammar = """
 # XZY emails
     COMPANY: {<COMPANY> <EMAIL>+}        #1400
 
+
 # "And" some name
     ANDCO: {<CC>+ <NN> <NNP>+<UNI|COMP>?}        #1430
     ANDCO: {<CC>+ <NNP> <NNP>+<UNI|COMP>?}        #1440
@@ -567,6 +571,9 @@ grammar = """
     COMPANY: {<COMPANY|NAME|NAME2|NAME3> <ANDCO>+}        #1460
 
     COMPANY: {<COMPANY><COMPANY>+}        #1480
+
+# Oracle and/or its affiliates.
+    NAME: {<NNP> <ANDCO>}        #1410
 
 # Various forms of copyright statements
     COPYRIGHT: {<COPY> <NAME> <COPY> <YR-RANGE>}        #1510

--- a/tests/cluecode/data/holders/oracle.txt
+++ b/tests/cluecode/data/holders/oracle.txt
@@ -1,0 +1,13 @@
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+    Copyright (c) 1997-2015 Oracle and/or its affiliates. All rights reserved.
+
+    The contents of this file are subject to the terms of either the GNU
+    General Public License Version 2 only ("GPL") or the Common Development
+    and Distribution License("CDDL") (collectively, the "License").  You
+    may not use this file except in compliance with the License.  You can
+    obtain a copy of the License at
+    https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+    or packager/legal/LICENSE.txt.  See the License for the specific
+    language governing permissions and limitations under the License.
+

--- a/tests/cluecode/test_copyrights.py
+++ b/tests/cluecode/test_copyrights.py
@@ -259,8 +259,8 @@ class TestCopyrightDetection(FileBasedTesting):
     def test_copyright_apostrophe_in_name(self):
         test_file = self.get_test_loc('copyrights/copyright_with_apos.txt')
         expected = [
-            u"Copyright Marco d'Itri <md@Linux.IT>",
-            u"Copyright Marco d'Itri",
+            "Copyright Marco d'Itri <md@Linux.IT>",
+            "Copyright Marco d'Itri",
         ]
         check_detection(expected, test_file)
 
@@ -292,7 +292,7 @@ class TestCopyrightDetection(FileBasedTesting):
         test_file = self.get_test_loc('copyrights/copyright_andre_darcy-c.c')
         expected = [
             'Copyright (c) 1995, Pascal Andre (andre@via.ecp.fr).',
-            u"copyright 1997, 1998, 1999 by D'Arcy J.M. Cain (darcy@druid.net)",
+            "copyright 1997, 1998, 1999 by D'Arcy J.M. Cain (darcy@druid.net)",
         ]
         check_detection(expected, test_file)
 
@@ -1575,7 +1575,7 @@ class TestCopyrightDetection(FileBasedTesting):
             'Copyright (c) 2007, Hubert Figuiere <hub@figuiere.net>',
             '(c) 1994, Kongji Huang and Brian C. Smith , Cornell University',
             '(c) 1993, Brian C. Smith , The Regents of the University of California',
-            u"(c) 1991-1992, Thomas G. Lane , Part of the Independent JPEG Group's",
+            "(c) 1991-1992, Thomas G. Lane , Part of the Independent JPEG Group's",
             'Copyright (c) 2005, Hubert Figuiere <hub@figuiere.net>',
             'Copyright (c) 2007, Hubert Figuiere <hub@figuiere.net>',
         ]
@@ -3006,7 +3006,7 @@ class TestCopyrightDetection(FileBasedTesting):
     def test_copyright_o_brien_style_name(self):
         test_file = self.get_test_loc('copyrights/copyright_o_brien_style_name.txt')
         expected = [
-            u"Copyright (c) 2001-2003, Patrick K. O'Brien",
+            "Copyright (c) 2001-2003, Patrick K. O'Brien",
         ]
         check_detection(expected, test_file)
 
@@ -4097,4 +4097,10 @@ class TestCopyrightDetection(FileBasedTesting):
     def test_copyright_copr5_correct(self):
         test_lines = ['Copyright or Copr. Mines Paristech, France - Mark NOBLE, Alexandrine GESRET']
         expected = ['Copyright or Copr. Mines Paristech, France - Mark NOBLE, Alexandrine GESRET']
+        check_detection(expected, test_lines)
+
+    def test_copyright_oracle(self):
+        test_lines =['Copyright (c) 1997-2015 Oracle and/or its affiliates. All rights reserved.']
+
+        expected = ['Copyright (c) 1997-2015 Oracle and/or its affiliates.']
         check_detection(expected, test_lines)

--- a/tests/cluecode/test_holders.py
+++ b/tests/cluecode/test_holders.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015 nexB Inc. and others. All rights reserved.
+# Copyright (c) 2017 nexB Inc. and others. All rights reserved.
 # http://nexb.com and https://github.com/nexB/scancode-toolkit/
 # The ScanCode software is licensed under the Apache License version 2.0.
 # Data generated with ScanCode require an acknowledgment.
@@ -22,7 +22,9 @@
 #  ScanCode is a free software code scanning tool from nexB Inc. and others.
 #  Visit https://github.com/nexB/scancode-toolkit/ for support and download.
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import os.path
 from unittest.case import expectedFailure
@@ -37,74 +39,74 @@ class TestHolders(FileBasedTesting):
     def test_holder_acme_c(self):
         test_file = self.get_test_loc('holders/holder_acme_c-c.c')
         expected = [
-            u'ACME, Inc.',
+            'ACME, Inc.',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_addr_c(self):
         test_file = self.get_test_loc('holders/holder_addr_c-addr_c.c')
         expected = [
-            u'Cornell University.',
-            u'Jon Doe.',
+            'Cornell University.',
+            'Jon Doe.',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_atheros_py(self):
         test_file = self.get_test_loc('holders/holder_atheros_py-py.py')
         expected = [
-            u'Atheros Communications, Inc.',
-            u'Atheros Communications, Inc.',
-            u'Intel Corporation.',
+            'Atheros Communications, Inc.',
+            'Atheros Communications, Inc.',
+            'Intel Corporation.',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_audio_c(self):
         test_file = self.get_test_loc('holders/holder_audio_c-c.c')
         expected = [
-            u'AudioCodes, DSP Group',
-            u'France Telecom, Universite de Sherbrooke.',
+            'AudioCodes, DSP Group',
+            'France Telecom, Universite de Sherbrooke.',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_basic(self):
         test_file = self.get_test_loc('holders/holder_basic-copy_c.c')
         expected = [
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'Markus Franz Xaver Johannes Oberhumer',
-            u'http://www.oberhumer.com'
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'Markus Franz Xaver Johannes Oberhumer',
+            'http://www.oberhumer.com'
          ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_complex(self):
         test_file = self.get_test_loc('holders/holder_complex-strtol_c.c')
         expected = [
-            u'The Regents of the University of California.',
+            'The Regents of the University of California.',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_extjs_c(self):
         test_file = self.get_test_loc('holders/holder_extjs_c-c.c')
         expected = [
-            u'Ext JS, LLC.',
+            'Ext JS, LLC.',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_hans_jurgen_html(self):
         test_file = self.get_test_loc('holders/holder_hans_jurgen_html-9_html.html')
         expected = [
-            u'Hans-Jurgen Koch.',
+            'Hans-Jurgen Koch.',
         ]
         check_detection(expected, test_file, what='holders')
 
@@ -119,12 +121,12 @@ class TestHolders(FileBasedTesting):
     def test_holder_ibm_c(self):
         test_file = self.get_test_loc('holders/holder_ibm_c-ibm_c.c')
         expected = [
-            u'ibm technologies',
-            u'IBM Corporation',
-            u'Ibm Corp.',
-            u'ibm.com',
-            u'IBM technology',
-            u'IBM company',
+            'ibm technologies',
+            'IBM Corporation',
+            'Ibm Corp.',
+            'ibm.com',
+            'IBM technology',
+            'IBM company',
         ]
         check_detection(expected, test_file, what='holders')
 
@@ -168,8 +170,8 @@ class TestHolders(FileBasedTesting):
     def test_holder_in_license(self):
         test_file = self.get_test_loc('holders/holder_in_license-COPYING_gpl.gpl')
         expected = [
-            u'Free Software Foundation, Inc.',
-            u'the Free Software Foundation',
+            'Free Software Foundation, Inc.',
+            'the Free Software Foundation',
         ]
         check_detection(expected, test_file, what='holders')
 
@@ -214,14 +216,14 @@ class TestHolders(FileBasedTesting):
     def test_holder_javascript_large(self):
         test_file = self.get_test_loc('holders/holder_javascript_large-ext_all_js.js')
         expected = [
-            u'Ext JS, LLC',
+            'Ext JS, LLC',
          ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_mergesort_java(self):
         test_file = self.get_test_loc('holders/holder_mergesort_java-MergeSort_java.java')
         expected = [
-            u'Sun Microsystems, Inc.',
+            'Sun Microsystems, Inc.',
         ]
         check_detection(expected, test_file, what='holders')
 
@@ -236,14 +238,14 @@ class TestHolders(FileBasedTesting):
     def test_holder_nokia_cpp(self):
         test_file = self.get_test_loc('holders/holder_nokia_cpp-cpp.cpp')
         expected = [
-            u'Nokia Mobile Phones.',
+            'Nokia Mobile Phones.',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_sample_java(self):
         test_file = self.get_test_loc('holders/holder_sample_java-java.java')
         expected = [
-            u'Sample ABC Inc.',
+            'Sample ABC Inc.',
         ]
         check_detection(expected, test_file, what='holders')
 
@@ -257,67 +259,72 @@ class TestHolders(FileBasedTesting):
     def test_holder_snmptrapd_c(self):
         test_file = self.get_test_loc('holders/holder_snmptrapd_c-snmptrapd_c.c')
         expected = [
-            u'Carnegie Mellon University',
+            'Carnegie Mellon University',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_somefile_cpp(self):
         test_file = self.get_test_loc('holders/holder_somefile_cpp-somefile_cpp.cpp')
         expected = [
-            u'Private Company (PC) Property of Private Company',
-            u'Private Company'        ]
+            'Private Company (PC) Property of Private Company',
+            'Private Company'        ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_stacktrace_cpp(self):
         test_file = self.get_test_loc('holders/holder_stacktrace_cpp-stacktrace_cpp.cpp')
         expected = [
-            u'Rickard E. Faith',
+            'Rickard E. Faith',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_super_c(self):
         test_file = self.get_test_loc('holders/holder_super_c-c.c')
         expected = [
-            u'Super Technologies Corporation, Cedar Rapids, Iowa, U.S.A.',
-            u'Benjamin Herrenschmuidt',
-            u'IBM Corp.',
+            'Super Technologies Corporation, Cedar Rapids, Iowa, U.S.A.',
+            'Benjamin Herrenschmuidt',
+            'IBM Corp.',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_treetablemodeladapter_java(self):
         test_file = self.get_test_loc('holders/holder_treetablemodeladapter_java-TreeTableModelAdapter_java.java')
         expected = [
-            u'Sun Microsystems, Inc.',
+            'Sun Microsystems, Inc.',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_tunnel_h(self):
         test_file = self.get_test_loc('holders/holder_tunnel_h-tunnel_h.h')
         expected = [
-            u'Frank Strauss',
+            'Frank Strauss',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_var_route_c(self):
         test_file = self.get_test_loc('holders/holder_var_route_c-var_route_c.c')
         expected = [
-            u'Carnegie Mellon University',
-            u'TGV, Incorporated',
-            u'Erik Schoenfelder',
-            u'Simon Leinen'
+            'Carnegie Mellon University',
+            'TGV, Incorporated',
+            'Erik Schoenfelder',
+            'Simon Leinen'
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_xcon_sh(self):
         test_file = self.get_test_loc('holders/holder_xcon_sh-9_sh.sh')
         expected = [
-            u'X Consortium',
+            'X Consortium',
         ]
         check_detection(expected, test_file, what='holders')
 
     def test_holder_young_c(self):
         test_file = self.get_test_loc('holders/holder_young_c-c.c')
         expected = [
-            u'Eric Young',
+            'Eric Young',
         ]
+        check_detection(expected, test_file, what='holders')
+
+    def test_holder_oracle(self):
+        test_file = self.get_test_loc('holders/oracle.txt')
+        expected = ['Oracle and/or its affiliates.']
         check_detection(expected, test_file, what='holders')


### PR DESCRIPTION
This deals with the "Oracle and/or its affiliates" case better as reported in #635
@edbratt you can give it a spin, but I am confident that the fix is sound.
I will merge once all the CI tests are passing
Thanks again for the report!
