### PR TITLE
Add 'EPL 1.0 or LGPL 2.1' rule

### DIFF
--- a/src/licensedcode/data/rules/epl-1.0_or_lgpl-2.1.RULE
+++ b/src/licensedcode/data/rules/epl-1.0_or_lgpl-2.1.RULE
@@ -1,0 +1,8 @@
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.

--- a/src/licensedcode/data/rules/epl-1.0_or_lgpl-2.1.yml
+++ b/src/licensedcode/data/rules/epl-1.0_or_lgpl-2.1.yml
@@ -1,0 +1,4 @@
+licenses:
+    - epl-1.0
+    - lgpl-2.1
+license: epl-1.0 or lgpl-2.1


### PR DESCRIPTION
After bd6ae3a170c ScanCode no longer finds EPL 1.0 in any file in [qos-ch/logback](https://github.com/qos-ch/logback/tree/master/logback-core/src/main/java/ch/qos/logback/core)

Therefore this change adds a separate rule.