### PR TITLE
Use the full browser window width for the tables in the HTML report

### DIFF
--- a/src/formattedcode/templates/html/template.html
+++ b/src/formattedcode/templates/html/template.html
@@ -33,18 +33,19 @@
     <meta charset="utf-8">
     <title>ScanCode results</title>
     <style type="text/css">
-      table  {
+      table {
         border-collapse:collapse;
         border: 1px solid gray;
         margin-bottom: 20px;
+        width: 100%;
       }
-      td{
+      td {
         padding: 5px 5px;
         border-style: solid;
         border-width: 1px;
         overflow: hidden;
       }
-      th{
+      th {
         padding:10px 5px;
         border-style: solid;
         border-width: 1px;
@@ -53,9 +54,9 @@
         color: #fff;
         background-color: #5E81B7;
       }
-      tr:nth-child(even)  { background-color:#FFFFFF; }
+      tr:nth-child(even) { background-color:#FFFFFF; }
       tr:nth-child(odd) { background-color:#F9F9F9; }
-      tr:hover {background-color: #EEEEEE;}
+      tr:hover { background-color: #EEEEEE; }
       * {
         font-family: Helvetica, Arial, sans-serif;
         font-weight: normal;


### PR DESCRIPTION
This way content is more convenient to view, esp. for long paths. Fix some
minor CSS formatting issues along the way.