### PR TITLE
Reverted version of pygments back to 2.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ setup(
         'six',
 
         # typecode and textcode
-        'pygments >= 2.1.0, <3.0.0',
+        'pygments >= 2.0.1, <3.0.0',
         'pdfminer >= 20140328',
 
         # pymaven


### PR DESCRIPTION
As reported here #670 after changing version range to 2.1.0 setuptools can't resolve it. This should fix this problem.