### PR TITLE
Don't mark SVG files as source

### DIFF
--- a/src/typecode/contenttype.py
+++ b/src/typecode/contenttype.py
@@ -459,9 +459,11 @@ class Type(object):
             return False
 
         ft = self.filetype_file.lower()
-        pt = self.filetype_pygment
+        pt = self.filetype_pygment.lower()
 
-        if not 'xml' in ft and (pt or self.is_script is True):
+        if 'xml' not in ft and \
+           ('xml' not in pt or self.location.endswith('pom.xml')) and \
+           (pt or self.is_script is True):
             return True
         else:
             return False

--- a/tests/typecode/test_contenttype.py
+++ b/tests/typecode/test_contenttype.py
@@ -877,7 +877,7 @@ class TestContentType(FileBasedTesting):
         test_file = self.get_test_loc('contenttype/media/drawing.svg')
         assert not is_binary(test_file)
         assert is_media(test_file)
-        assert is_media(test_file)
+        assert not is_source(test_file)
 
     def test_media_image_tgg(self):
         test_file = self.get_test_loc('contenttype/media/Image1.tga')


### PR DESCRIPTION
SVG file is XML and the only (I guess) XML that we want to mark as source is maven's pom.xml