### PR TITLE
With -n 0, disable multiprocessing #731

### DIFF
--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -370,6 +370,23 @@ def test_scan_works_with_multiple_processes():
     assert sorted(res1['files']) == sorted(res3['files'])
 
 
+def test_scan_works_with_no_processes_in_single_threaded_mode():
+    test_dir = test_env.get_test_loc('multiprocessing', copy=True)
+
+    # run the same scan with zero or one process
+    result_file_0 = test_env.get_temp_file('json')
+    result0 = run_scan_click([ '--copyright', '--processes', '0', '--format', 'json', test_dir, result_file_0])
+    assert result0.exit_code == 0
+    assert 'Disabling multi-processing and multi-threading...' in result0.output
+
+    result_file_1 = test_env.get_temp_file('json')
+    result1 = run_scan_click([ '--copyright', '--processes', '1', '--format', 'json', test_dir, result_file_1])
+    assert result1.exit_code == 0
+    res0 = json.loads(open(result_file_0).read())
+    res1 = json.loads(open(result_file_1).read())
+    assert sorted(res0['files']) == sorted(res1['files'])
+
+
 def test_scan_works_with_multiple_processes_and_timeouts():
     # this contains test files with a lot of copyrights that should
     # take more thant timeout to scan


### PR DESCRIPTION
 * When using the Cli option "--processes 0" or "-n 0" we bypass
   multiprocessing and threading entirely and use instead a plain
   iterools.imap iteration rather than a multiprocessing pool and a
   fake non-interruptible wrapper rather than a threaded one.
   Timeouts are not honored in this mode.
   This mode is useful for debugging.
 * Also improve traceback collections

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>