### PR TITLE
Improvements to the configuration logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ScanCode special files
 /SCANCODE_DEV_MODE
+/SCANCODE_GIT_MODE
 
 # Python compiled files
 *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,6 @@ graft src
 graft etc
 graft thirdparty
 graft samples
-
 graft tests
 
 prune src/scancode_toolkit.egg-info
@@ -27,8 +26,10 @@ include scancode
 include scancode.bat
 include extractcode
 include extractcode.bat
+include .travis.yml
+include appveyor.yml
 
-include .travis.yml appveyor.yml
 exclude SCANCODE_DEV_MODE
+exclude SCANCODE_GIT_MODE
 
 global-exclude *.py[co] __pycache__ *.*~

--- a/etc/conf/base.py
+++ b/etc/conf/base.py
@@ -23,11 +23,11 @@ else:
 
 sys_platform = str(sys.platform).lower()
 if 'linux' in sys_platform:
-    os = 'linux'
+    platform = 'linux'
 elif'win32' in sys_platform:
-    os = 'win'
+    platform = 'win'
 elif 'darwin' in sys_platform:
-    os = 'mac'
+    platform = 'mac'
 else:
     unsupported(sys_platform)
 
@@ -38,9 +38,9 @@ supported_combos = {
     'mac': ['64',],
 }
 
-arches = supported_combos[os]
+arches = supported_combos[platform]
 if arch not in arches:
-    unsupported(os + arch)
+    unsupported(platform + arch)
 
 
 def clear_dev_mode():

--- a/etc/conf/base.py
+++ b/etc/conf/base.py
@@ -43,6 +43,21 @@ if arch not in arches:
     unsupported(os + arch)
 
 
+def clear_dev_mode():
+    """
+    Remove any stale development tag file from previous configure runs.
+    """
+    import os
+    from scancode import root_dir
+    try:
+        os.remove(os.path.join(root_dir, 'SCANCODE_DEV_MODE'))
+    except OSError:
+        pass
+
+
+clear_dev_mode()
+
+
 """
 Re/build the license cache on every configure run.
 """

--- a/etc/conf/dev/base.py
+++ b/etc/conf/dev/base.py
@@ -7,14 +7,11 @@ import os
 
 
 def setup_dev_mode():
-    """
-    Create the development mode tag file. In development mode, ScanCode does
-    not rely on license data to remain untouched and will always check the
-    license index cache for consistency, rebuilding it if necessary.
-    """
     from scancode import root_dir
     with open(os.path.join(root_dir, 'SCANCODE_DEV_MODE'), 'wb') as sdm:
-        sdm.write('This is a tag file to notify that ScanCode is used in development mode.')
+        sdm.write('This is a tag file to notify that ScanCode is used in development mode. '
+                  'In this mode, ScanCode does not rely on license data to remain untouched and will '
+                  'always check the license index cache for consistency, rebuilding it if necessary.')
 
 
 setup_dev_mode()

--- a/etc/configure.py
+++ b/etc/configure.py
@@ -365,6 +365,8 @@ if __name__ == '__main__':
             abs_path = os.path.join(root_dir, path)
             if os.path.exists(abs_path):
                 configs.append(path)
+                print('Using configuration directory:\n'
+                      '  %(path)s' % locals())
         else:
             print()
             print('WARNING: Skipping missing Configuration directory:\n'

--- a/etc/configure.py
+++ b/etc/configure.py
@@ -213,7 +213,7 @@ def create_virtualenv(std_python, root_dir, tpp_dirs, quiet=False):
 
 def activate(root_dir):
     """ Activate a virtualenv in the current process."""
-    print("* Activating ...")
+    print("* Activating...")
     bin_dir = os.path.join(root_dir, 'bin')
     activate_this = os.path.join(bin_dir, 'activate_this.py')
     with open(activate_this) as f:

--- a/etc/release/MANIFEST.in.release
+++ b/etc/release/MANIFEST.in.release
@@ -26,7 +26,10 @@ include scancode
 include scancode.bat
 include extractcode
 include extractcode.bat
-include .travis.yml appveyor.yml
+include .travis.yml
+include appveyor.yml
 
 exclude SCANCODE_DEV_MODE
+exclude SCANCODE_GIT_MODE
+
 global-exclude *.py[co] __pycache__ *.*~

--- a/scancode
+++ b/scancode
@@ -105,10 +105,33 @@ _canonicalize_file_path() {
 SCANCODE_BIN="$( realpath "${BASH_SOURCE[0]}" )"
 SCANCODE_ROOT_DIR="$( cd "$( dirname "${SCANCODE_BIN}" )" && pwd )"
 
+SCANCODE_CONFIG_DIR="etc/conf"
+
+GIT_STATUS=$(git -C "$SCANCODE_ROOT_DIR" status --porcelain 2> /dev/null)
+if [ $? -eq 0 ]; then
+    # This is a Git working tree, check whether it is clean.
+    if [ -z "$GIT_STATUS" ]; then
+        # This is a clean working tree, check whether configure has been run
+        # before for this commit.
+        GIT_COMMIT_CONFIGURED=$(cat "$SCANCODE_ROOT_DIR/SCANCODE_GIT_MODE" 2> /dev/null)
+        GIT_COMMIT_HEAD=$(git -C "$SCANCODE_ROOT_DIR" rev-parse HEAD)
+        if [ "$GIT_COMMIT_CONFIGURED" != "$GIT_COMMIT_HEAD" ]; then
+            echo "* (Re-)Configuring ScanCode because Git commits have changed..."
+            CONFIGURE_QUIET=1 $SCANCODE_ROOT_DIR/configure $SCANCODE_CONFIG_DIR
+        fi
+        echo $GIT_COMMIT_HEAD > "$SCANCODE_ROOT_DIR/SCANCODE_GIT_MODE"
+    else
+        echo "* (Re-)Configuring ScanCode because Git working tree is not clean..."
+        CONFIGURE_QUIET=1 $SCANCODE_ROOT_DIR/configure $SCANCODE_CONFIG_DIR
+    fi
+else
+    rm -f "$SCANCODE_ROOT_DIR/SCANCODE_GIT_MODE"
+fi
+
 SCANCODE_CONFIGURED_PYTHON=$SCANCODE_ROOT_DIR/bin/python
 if [ ! -f "$SCANCODE_CONFIGURED_PYTHON" ]; then
     echo "* Configuring ScanCode for first use..."
-    CONFIGURE_QUIET=1 $SCANCODE_ROOT_DIR/configure etc/conf
+    CONFIGURE_QUIET=1 $SCANCODE_ROOT_DIR/configure $SCANCODE_CONFIG_DIR
 fi
 
 $SCANCODE_ROOT_DIR/bin/scancode "$@"


### PR DESCRIPTION
Most notably, automatically re-configure if ScanCode is run from a Git working tree and new commits are present. This is useful for running on CI which incrementally fetches ScanCode's code from Git (without applying any local changes).

Note that the new `SCANCODE_GIT_MODE` is orthogonal to the existing `SCANCODE_DEV_MODE`: In development mode the license cache is always checked for consistency, which is not needed when running from a clean Git working tree without any local changes.

This fixes issues like the one I've been running into as described at #735.