### PR TITLE
Improve license match filtering and tracing

### DIFF
--- a/src/licensedcode/__init__.py
+++ b/src/licensedcode/__init__.py
@@ -51,6 +51,8 @@ if not exists(license_index_cache_dir):
 MIN_MATCH_LENGTH = 4
 MIN_MATCH_HIGH_LENGTH = 3
 
+# FIXME: we should consider the length of two rules and two matches when considering MAX_DIST
+# eventually this should be skipped early right during the matching too
 # maximum distance between two matches to merge
 MAX_DIST = 120
 

--- a/src/licensedcode/match.py
+++ b/src/licensedcode/match.py
@@ -438,6 +438,8 @@ def merge_matches(matches, max_dist=MAX_DIST):
     returned as-is.
     For being merged two matches must also be in increasing query and index positions.
     """
+    from licensedcode.match_seq import MATCH_SEQ
+
     # shortcut for single matches
     if len(matches) < 2:
         return matches
@@ -453,6 +455,8 @@ def merge_matches(matches, max_dist=MAX_DIST):
     merged = []
     for rid, rule_matches in matches_by_rule:
         if TRACE_MERGE: logger_debug('merge_matches: processing rule:', rid)
+        rlen = rule_matches[0].rule.length
+        max_rlen_dist = min(rlen // 5, MAX_DIST)
 
         # compare two matches in the sorted sequence: current and next
         i = 0
@@ -464,12 +468,23 @@ def merge_matches(matches, max_dist=MAX_DIST):
                 if TRACE_MERGE: logger_debug('---> merge_matches: current:', current_match)
                 if TRACE_MERGE: logger_debug('---> merge_matches: next:   ', next_match)
 
-                # stop if we exceed max dist
-                if (current_match.qdistance_to(next_match) > MAX_DIST
-                or current_match.idistance_to(next_match) > MAX_DIST):
+                # two exact matches can never be merged as they will not be overlapping
+                if current_match.matcher != MATCH_SEQ and next_match.matcher != MATCH_SEQ:
+                    if TRACE_MERGE: logger_debug('    ---> ###merge_matches: both matches are EXACT_MATCHES, skipping')
                     break
 
+                # FIXME: also considers the match length!
+                # stop if we exceed max dist
+                # or distance over 1/5 of rule length
+
+                if (current_match.qdistance_to(next_match) > max_rlen_dist
+                or current_match.idistance_to(next_match) > max_rlen_dist):
+                    if TRACE_MERGE: logger_debug('    ---> ###merge_matches: MAX_DIST reached, breaking')
+                    break
+
+
                 # keep one of equal matches
+                # with same qspan: FIXME: is this ever possible?
                 if current_match.qspan == next_match.qspan and current_match.ispan == next_match.ispan:
                     if TRACE_MERGE: logger_debug('    ---> ###merge_matches: next EQUALS current, del next')
                     del rule_matches[j]
@@ -526,6 +541,8 @@ def merge_matches(matches, max_dist=MAX_DIST):
                         i -= 1
                         break
 
+                # FIXME: what about the distance??
+
                 # next_match is strictly in increasing sequence: merge in current
                 if next_match.is_after(current_match):
                     current_match.update(next_match)
@@ -554,6 +571,9 @@ def merge_matches(matches, max_dist=MAX_DIST):
         merged.extend(rule_matches)
     return merged
 
+
+# FIXME we should consider the length and distance between matches to break
+# early from the loops: trying to check containment on wildly separated matches does not make sense
 
 def filter_contained_matches(matches):
     """
@@ -597,9 +617,11 @@ def filter_contained_matches(matches):
             current_match = matches[i]
             next_match = matches[j]
 
+            # TODO: is this really correct?
             # stop when no overlap: Touching and overlapping matches have a zero distance.
-#             if current_match.qdistance_to(next_match):
-#                 break
+            if current_match.qdistance_to(next_match):
+                if TRACE_FILTER_CONTAINS: logger_debug('    ---> ###filter_contained_matches: matches have a distance: NO OVERLAP POSSIBLE\n')
+                break
 
             if TRACE_FILTER_CONTAINS: logger_debug('---> filter_contained_matches: current: i=', i, current_match)
             if TRACE_FILTER_CONTAINS: logger_debug('---> filter_contained_matches: next:    j=', j, next_match)
@@ -779,9 +801,14 @@ def filter_rule_min_coverage(matches):
     Return a list of matches scoring at or above a rule-defined minimum coverage and
     a list of matches with a coverage below a rule-defined minimum coverage.
     """
+    from licensedcode.match_seq import MATCH_SEQ
+
     kept = []
     discarded = []
     for match in matches:
+        if match.matcher != MATCH_SEQ:
+            kept.append(match)
+            continue
         if match.coverage() < match.rule.minimum_coverage:
             if TRACE_REFINE_RULE_MIN_COVERAGE: logger_debug('    ==> DISCARDING rule.minimum_coverage:', type(match.rule.minimum_coverage), ':', repr(match.rule.minimum_coverage), 'match:', match)
             discarded.append(match)
@@ -817,6 +844,7 @@ def filter_spurious_single_token(matches, query=None, unknown_count=5):
     on both sides by at least `unknown_count` tokens of either unknown tokens, short
     tokens composed of a single character or tokens composed only of digits.
     """
+    from licensedcode.match_seq import MATCH_SEQ
     kept = []
     discarded = []
     if not query:
@@ -826,6 +854,10 @@ def filter_spurious_single_token(matches, query=None, unknown_count=5):
     shorts_and_digits = query.shorts_and_digits_pos
     for match in matches:
         if not match.qlen() == 1:
+            kept.append(match)
+            continue
+
+        if match.matcher != MATCH_SEQ:
             kept.append(match)
             continue
 
@@ -864,9 +896,14 @@ def filter_short_matches(matches):
     """
     Return a list of matches that are not short and a list of short spurious matches.
     """
+    from licensedcode.match_seq import MATCH_SEQ
     kept = []
     discarded = []
     for match in matches:
+        if match.matcher != MATCH_SEQ:
+            kept.append(match)
+            continue
+
         if match.small():
             if TRACE_REFINE_SMALL: logger_debug('    ==> DISCARDING SHORT:', match)
             discarded.append(match)
@@ -883,10 +920,15 @@ def filter_spurious_matches(matches):
     Spurious matches are small matches with a low density (e.g. where the matched
     tokens are separated by many unmatched tokens.)
     """
+    from licensedcode.match_seq import MATCH_SEQ
     kept = []
     discarded = []
 
     for match in matches:
+        if match.matcher != MATCH_SEQ:
+            kept.append(match)
+            continue
+
         qdens = match.qspan.density()
         idens = match.ispan.density()
         ilen = match.ilen()
@@ -922,7 +964,7 @@ def filter_false_positive_matches(matches, idx):
     return kept, discarded
 
 
-def refine_matches(matches, idx, query=None, min_score=0, max_dist=MAX_DIST):
+def refine_matches(matches, idx, query=None, min_score=0, max_dist=MAX_DIST, merge=True):
     """
     Return two sequences of matches: one contains refined good matches, and the
     other contains matches that were filtered out.
@@ -931,10 +973,14 @@ def refine_matches(matches, idx, query=None, min_score=0, max_dist=MAX_DIST):
     if TRACE: logger_debug(' #####refine_matches: STARTING matches#', len(matches))
     if TRACE_REFINE: map(logger_debug, matches)
 
-    matches = merge_matches(matches, max_dist=max_dist)
-    if TRACE: logger_debug('     ##### refine_matches: STARTING MERGED_matches#:', len(matches))
+    if merge:
+        matches = merge_matches(matches, max_dist=max_dist)
+        if TRACE: logger_debug('     ##### refine_matches: STARTING MERGED_matches#:', len(matches))
 
     all_discarded = []
+
+    # FIXME: we should have only a single loop on all the matches at once!!
+    # and not 10's of loops!!!
 
     matches, discarded = filter_rule_min_coverage(matches)
     all_discarded.extend(discarded)
@@ -990,7 +1036,8 @@ def refine_matches(matches, idx, query=None, min_score=0, max_dist=MAX_DIST):
         if TRACE: logger_debug('   ###refine_matches: LOW SCORE discarded #:', len(discarded))
         if TRACE_REFINE: map(logger_debug, discarded)
 
-    matches = merge_matches(matches, max_dist=max_dist)
+    if merge:
+        matches = merge_matches(matches, max_dist=max_dist)
 
     logger_debug('   ##### refine_matches: FINAL MERGED_matches#:', len(matches))
     if TRACE_REFINE: map(logger_debug, matches)

--- a/src/licensedcode/match_set.py
+++ b/src/licensedcode/match_set.py
@@ -264,7 +264,15 @@ tids_set_counter = tids_inbitset_counter
 
 CandidateData = namedtuple('CandidateData', 'intersection distance matched_length high_inter_len low_inter_len')
 
+# FIXME: we should consider existing aho matches when considering candidate
+# and not rematch these at all
 
+# FIXME: we should consider more aggressively the thresholds and what a match filters
+# would discard when we compute candaites to eventually discard many or all candidates
+# we compute too many candidates that may waste time in seq matching for no reason
+
+# FIXME: Also we should remove any weak and or small rules from the top candidates
+# and anything that cannot be seq matched at all. (e.g. no high match)
 def compute_candidates(query_run, idx, rules_subset, top=30):
     """
     Return a ranked list of rule candidates for further matching as a tuple of:


### PR DESCRIPTION
 * refine logging and tracing
 * match_seq.py: pre-bind some function names in loops
 * match.py
   * refine match tracing
   * minor performance and clarification in match merging and filtering
   * ensure contained match filtering stop early
   * make merge optional in refine
  * add TODO and FIXME comments

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>
