### PR TITLE
[pre-scan] Rename process_resources() and use it.

### DIFF
--- a/src/plugincode/pre_scan.py
+++ b/src/plugincode/pre_scan.py
@@ -49,12 +49,13 @@ class PreScanPlugin(object):
     def __init__(self, user_input):
         self.user_input = user_input
 
-    def process_resources(self, resources):
+    def process_resource(self, resource):
         """
-        Yield the absolute paths after processing.
-         - `resources`: a generator with absolute paths of files to be scanned.
+        Process a resource prior to scan.
+        :param resource: instance of Resource to process
+        :return: resource or None to ignore the resource
         """
-        return resources
+        return resource
 
     def get_ignores(self):
         """

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -536,7 +536,7 @@ def scan(input_path,
          scans_cache_class=None,
          strip_root=False,
          full_root=False,
-         pre_scan_plugins=()):
+         pre_scan_plugins=None):
     """
     Return a tuple of (files_count, scan_results, success) where
     scan_results is an iterable and success is a boolean.
@@ -794,7 +794,7 @@ def build_ignorer(ignores, unignores):
     return partial(ignore.is_ignored, ignores=ignores, unignores=unignores)
 
 
-def resource_paths(base_path, diag, scans_cache_class, pre_scan_plugins=()):
+def resource_paths(base_path, diag, scans_cache_class, pre_scan_plugins=None):
     """
     Yield `Resource` objects for all the files found at base_path
     (either a directory or file) given an absolute base_path. Only yield

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -827,7 +827,11 @@ def resource_paths(base_path, diag, scans_cache_class, pre_scan_plugins=()):
         resource = Resource(scans_cache_class, abs_path, base_is_dir, len_base_path)
         # always fetch infos and cache.
         resource.put_info(scan_infos(abs_path, diag=diag))
-        yield resource
+        if pre_scan_plugins:
+            for plugin in pre_scan_plugins:
+                resource = plugin.process_resource(resource)
+        if resource:
+            yield resource
 
 
 def scan_infos(input_file, diag=False):


### PR DESCRIPTION
I've been looking at how the pre-scan plugins work in order to fix #689.

I've realized that the [process_resources()](https://github.com/nexB/scancode-toolkit/blob/develop/src/plugincode/pre_scan.py#L52) is actually never used,
so I'm adding a code which runs it.

The pre-scan plugin which does what I need would then look like (it's not part of this PR):

```python
@pre_scan_impl
class ProcessIgnoreBinaries(PreScanPlugin):
    """
    Ignore binaries, medias and files bigger than specified size.
    """
    option_attrs = dict(metavar='<size>', default=1000000)

    def __init__(self, user_input):
        super(ProcessIgnoreBinaries, self).__init__(user_input)

    def process_resource(self, resource):
        if any((resource.infos['is_binary'],
                resource.infos['is_media'],
                resource.infos['size'] > self.user_input)):
            return None
        return resource
```