### PR TITLE
Deal with install path containing spaces

### DIFF
--- a/configure
+++ b/configure
@@ -23,7 +23,7 @@ fi
 
 CONFIGURE_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-python2.7 $CONFIGURE_ROOT_DIR/etc/configure.py $CFG_CMD_LINE_ARGS
+python2.7 "$CONFIGURE_ROOT_DIR/etc/configure.py" $CFG_CMD_LINE_ARGS
 if [ -f "$CONFIGURE_ROOT_DIR/bin/activate" ]; then
     source $CONFIGURE_ROOT_DIR/bin/activate
 fi

--- a/scancode
+++ b/scancode
@@ -105,10 +105,10 @@ _canonicalize_file_path() {
 SCANCODE_BIN="$( realpath "${BASH_SOURCE[0]}" )"
 SCANCODE_ROOT_DIR="$( cd "$( dirname "${SCANCODE_BIN}" )" && pwd )"
 
-SCANCODE_CONFIGURED_PYTHON=$SCANCODE_ROOT_DIR/bin/python
+SCANCODE_CONFIGURED_PYTHON="$SCANCODE_ROOT_DIR/bin/python"
 if [ ! -f "$SCANCODE_CONFIGURED_PYTHON" ]; then
     echo "* Configuring ScanCode for first use..."
-    CONFIGURE_QUIET=1 $SCANCODE_ROOT_DIR/configure etc/conf
+    CONFIGURE_QUIET=1 "$SCANCODE_ROOT_DIR/configure" etc/conf
 fi
 
-$SCANCODE_ROOT_DIR/bin/scancode "$@"
+"$SCANCODE_ROOT_DIR/bin/scancode" "$@"


### PR DESCRIPTION
So I am trying to run this on Cygwin with an install path containing spaces.
I understand that Cygwin is not supported (as this fails inside python with a clear message).
However, there is no harm in being more robust in the bash scripts

Signed-off-by: Arnaud Jeansen <arnaud.jeansen@gmail.com>