### PR TITLE
Allow cache location configuration

### DIFF
--- a/src/commoncode/fileutils.py
+++ b/src/commoncode/fileutils.py
@@ -222,7 +222,7 @@ def build_cache_path(dir_name, dev_mode=False):
         if dev_mode:
             cache_root = dirname(dirname(dirname(abspath(__file__))))
         else:
-            cache_root = os.path.expanduser('~')
+            cache_root = abspath(os.path.expanduser('~'))
 
     return os.path.join(cache_root, '.cache', 'scancode', tree_checksum(), dir_name)
 

--- a/src/commoncode/fileutils.py
+++ b/src/commoncode/fileutils.py
@@ -224,7 +224,6 @@ def build_cache_path(dir_name, dev_mode=False):
         else:
             cache_root = os.path.expanduser('~')
 
-    # tree_hash = tree_checksum()
     return os.path.join(cache_root, '.cache', 'scancode', tree_checksum(), dir_name)
 
 

--- a/src/commoncode/fileutils.py
+++ b/src/commoncode/fileutils.py
@@ -23,8 +23,8 @@
 #  Visit https://github.com/nexB/scancode-toolkit/ for support and download.
 
 from __future__ import absolute_import
-from __future__ import unicode_literals
 from __future__ import print_function
+from __future__ import unicode_literals
 
 # Python 2 and 3 support
 try:
@@ -44,22 +44,22 @@ except ImportError:
 
 import codecs
 import errno
-import os
+from functools import partial
+from hashlib import md5
 import ntpath
+import os
+from os.path import abspath
+from os.path import dirname
 import posixpath
 import shutil
 import stat
 import sys
 import tempfile
-from functools import partial
-from hashlib import md5
-from os.path import abspath
-from os.path import dirname
 
 from commoncode import filetype
 from commoncode.filetype import is_rwx
-from commoncode import system
 from commoncode.system import on_linux
+from commoncode import system
 from commoncode import text
 
 # this exception is not available on posix

--- a/src/licensedcode/__init__.py
+++ b/src/licensedcode/__init__.py
@@ -27,8 +27,6 @@ from __future__ import absolute_import
 
 from os.path import dirname
 from os.path import abspath
-from os.path import getsize
-from os.path import getmtime
 from os.path import join
 from os.path import exists
 

--- a/src/licensedcode/__init__.py
+++ b/src/licensedcode/__init__.py
@@ -30,20 +30,15 @@ from os.path import abspath
 from os.path import join
 from os.path import exists
 
-from commoncode import fileutils
-
-
 lic_src_dir = abspath(dirname(__file__))
 src_dir = dirname(lic_src_dir)
 data_dir = join(lic_src_dir, 'data')
 licenses_data_dir = join(data_dir, 'licenses')
 rules_data_dir = join(data_dir, 'rules')
 root_dir = dirname(src_dir)
-cache_dir = join(root_dir, '.cache')
-license_index_cache_dir = join(cache_dir, 'license_index')
 
-if not exists(license_index_cache_dir):
-    fileutils.create_dir(license_index_cache_dir)
+# If this file exists at the root, the cache is always checked for consistency
+DEV_MODE = exists(join(root_dir, 'SCANCODE_DEV_MODE'))
 
 # minimum number of tokens a match should have to be considered as worthy keeping
 MIN_MATCH_LENGTH = 4

--- a/src/licensedcode/__init__.py
+++ b/src/licensedcode/__init__.py
@@ -30,6 +30,7 @@ from os.path import abspath
 from os.path import join
 from os.path import exists
 
+
 lic_src_dir = abspath(dirname(__file__))
 src_dir = dirname(lic_src_dir)
 data_dir = join(lic_src_dir, 'data')

--- a/src/licensedcode/cache.py
+++ b/src/licensedcode/cache.py
@@ -32,10 +32,9 @@ from functools import partial
 import yg.lockfile  # @UnresolvedImport
 
 from commoncode.fileutils import tree_checksum
+from commoncode.fileutils import create_cache_dir
 
-from licensedcode import root_dir
-from licensedcode import src_dir
-from licensedcode import license_index_cache_dir
+from licensedcode import DEV_MODE
 
 
 """
@@ -44,6 +43,7 @@ there are any changes in the code or licenses text or rules. Loading and dumping
 cached index is safe to use across multiple processes using lock files.
 """
 
+license_index_cache_dir = create_cache_dir('license_index', dev_mode=DEV_MODE)
 index_lock_file = join(license_index_cache_dir, 'lockfile')
 tree_checksum_file = join(license_index_cache_dir, 'tree_checksums')
 index_cache_file = join(license_index_cache_dir, 'index_cache')
@@ -52,15 +52,11 @@ index_cache_file = join(license_index_cache_dir, 'index_cache')
 LICENSE_INDEX_LOCK_TIMEOUT = 60 * 3
 
 
-# If this file exists at the root, the cache is always checked for consistency
-DEV_MODE = os.path.exists(os.path.join(root_dir, 'SCANCODE_DEV_MODE'))
-
-
 def get_or_build_index_through_cache(
         check_consistency=DEV_MODE,
         return_index=True,
         # used for testing only
-        _tree_base_dir=src_dir,
+        _tree_base_dir=None,
         _tree_checksum_file=tree_checksum_file,
         _index_lock_file=index_lock_file,
         _index_cache_file=index_cache_file,

--- a/src/licensedcode/cache.py
+++ b/src/licensedcode/cache.py
@@ -24,15 +24,14 @@
 
 from __future__ import absolute_import, print_function
 
-import os
+from functools import partial
 from os.path import exists
 from os.path import join
-from functools import partial
 
 import yg.lockfile  # @UnresolvedImport
 
-from commoncode.fileutils import tree_checksum
 from commoncode.fileutils import create_cache_dir
+from commoncode.fileutils import tree_checksum
 
 from licensedcode import DEV_MODE
 

--- a/src/licensedcode/cache.py
+++ b/src/licensedcode/cache.py
@@ -24,18 +24,14 @@
 
 from __future__ import absolute_import, print_function
 
-from functools import partial
-from hashlib import md5
 import os
 from os.path import exists
-from os.path import getmtime
-from os.path import getsize
 from os.path import join
+from functools import partial
 
 import yg.lockfile  # @UnresolvedImport
 
-from commoncode.fileutils import file_iter
-from commoncode import ignore
+from commoncode.fileutils import tree_checksum
 
 from licensedcode import root_dir
 from licensedcode import src_dir
@@ -51,28 +47,6 @@ cached index is safe to use across multiple processes using lock files.
 index_lock_file = join(license_index_cache_dir, 'lockfile')
 tree_checksum_file = join(license_index_cache_dir, 'tree_checksums')
 index_cache_file = join(license_index_cache_dir, 'index_cache')
-
-
-_ignored_from_hash = partial(
-    ignore.is_ignored,
-    ignores={'*.pyc': 'pyc files', '*~': 'temp gedit files', '*.swp': 'vi swap files'},
-    unignores={}
-)
-
-
-def tree_checksum(tree_base_dir=src_dir, _ignored=_ignored_from_hash):
-    """
-    Return a checksum computed from a file tree using the file paths,
-    size and last modified time stamps.
-    The purpose is to detect is there has been any modification to
-    source code or data files and use this as a proxy to verify the
-    cache consistency.
-
-    NOTE: this is not 100% fool proof but good enough in practice.
-    """
-    hashable = (pth + str(getmtime(pth)) + str(getsize(pth))
-                for pth in file_iter(tree_base_dir, ignored=_ignored))
-    return md5(''.join(sorted(hashable))).hexdigest()
 
 
 LICENSE_INDEX_LOCK_TIMEOUT = 60 * 3

--- a/src/scancode/__init__.py
+++ b/src/scancode/__init__.py
@@ -27,8 +27,6 @@ from __future__ import absolute_import
 
 from os.path import dirname
 from os.path import abspath
-from os.path import getsize
-from os.path import getmtime
 from os.path import join
 from os.path import exists
 

--- a/src/scancode/__init__.py
+++ b/src/scancode/__init__.py
@@ -27,21 +27,8 @@ from __future__ import absolute_import
 
 from os.path import dirname
 from os.path import abspath
-from os.path import join
-from os.path import exists
 
-from commoncode import fileutils
-
-
-scan_src_dir = abspath(dirname(__file__))
-src_dir = dirname(scan_src_dir)
-root_dir = dirname(src_dir)
-cache_dir = join(root_dir, '.cache')
-scans_cache_dir = join(cache_dir, 'scan_results_caches')
-
-if not exists(scans_cache_dir):
-    fileutils.create_dir(scans_cache_dir)
-
+root_dir = dirname(dirname(dirname(abspath(__file__))))
 
 from pkg_resources import get_distribution, DistributionNotFound
 try:

--- a/src/scancode/__init__.py
+++ b/src/scancode/__init__.py
@@ -25,8 +25,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-from os.path import dirname
 from os.path import abspath
+from os.path import dirname
 
 root_dir = dirname(dirname(dirname(abspath(__file__))))
 

--- a/src/scancode/cache.py
+++ b/src/scancode/cache.py
@@ -41,6 +41,7 @@ from commoncode.fileutils import path_to_bytes
 from commoncode.fileutils import path_to_unicode
 from commoncode.system import on_linux
 from commoncode import timeutils
+
 from licensedcode import DEV_MODE
 
 """

--- a/src/scancode/cache.py
+++ b/src/scancode/cache.py
@@ -41,9 +41,7 @@ from commoncode.fileutils import path_to_bytes
 from commoncode.fileutils import path_to_unicode
 from commoncode.system import on_linux
 from commoncode import timeutils
-
-from scancode import scans_cache_dir
-
+from licensedcode import DEV_MODE
 
 """
 Cache scan results for a file or directory disk using a file-based cache.
@@ -86,6 +84,8 @@ if TRACE:
     def logger_debug(*args):
         return logger.debug(' '.join(isinstance(a, unicode) and a or repr(a) for a in args))
 
+
+scans_cache_dir = fileutils.create_cache_dir('scan_results_caches', dev_mode=DEV_MODE)
 
 def get_scans_cache_class(cache_dir=scans_cache_dir):
     """

--- a/tests/commoncode/test_fileutils.py
+++ b/tests/commoncode/test_fileutils.py
@@ -25,9 +25,13 @@
 from __future__ import absolute_import, print_function
 
 import os
+import tempfile
+from os.path import abspath
+from os.path import dirname
 from os.path import join
 from os.path import sep
-from unittest.case import skipIf
+from unittest import TestCase
+from unittest import skipIf
 
 from commoncode import filetype
 from commoncode import fileutils
@@ -970,3 +974,41 @@ class TestParentDir(FileBasedTesting):
         result = fileutils.parent_directory((os.path.join(test_dir, test_file)))
         result = fileutils.as_posixpath(result)
         assert result.endswith(expected_name)
+
+
+class TestBuildCachePath(TestCase):
+
+    def setUp(self):
+        self._old_val = os.environ.get(fileutils.TMP_DIR_ENV)
+        if self._old_val:
+            del os.environ[fileutils.TMP_DIR_ENV]
+
+    def tearDown(self):
+        if self._old_val:
+            os.environ[fileutils.TMP_DIR_ENV] = self._old_val
+        elif fileutils.TMP_DIR_ENV in os.environ:
+            del os.environ[fileutils.TMP_DIR_ENV]
+
+    def test_in_dev_mode(self):
+        root_dir = dirname(dirname(dirname(abspath(__file__))))
+        expected_path = join(root_dir, '.cache', 'scancode', 'testing')
+        cache_path = fileutils.build_cache_path('testing', dev_mode=True)
+        assert expected_path == cache_path
+
+    def test_not_in_dev_mode(self):
+        expected_path = join(os.path.expanduser('~'), '.cache', 'scancode', 'testing')
+        cache_path = fileutils.build_cache_path('testing', dev_mode=False)
+        assert expected_path == cache_path
+
+    def test_env_var_overrides(self):
+        root_dir = tempfile.gettempdir()
+        os.environ[fileutils.TMP_DIR_ENV] = root_dir
+        expected_path = join(root_dir, '.cache', 'scancode', 'testing')
+        cache_path = fileutils.build_cache_path('testing', dev_mode=True)
+        assert cache_path == expected_path
+
+    def test_raises_on_invalid_env_var(self):
+        root_dir = '/nosuchdir'
+        os.environ[fileutils.TMP_DIR_ENV] = root_dir
+        expected_path = join(root_dir, '.cache', 'scancode', 'testing')
+        self.assertRaises(OSError, fileutils.build_cache_path, 'testing', dev_mode=True)

--- a/tests/commoncode/test_fileutils.py
+++ b/tests/commoncode/test_fileutils.py
@@ -991,24 +991,32 @@ class TestBuildCachePath(TestCase):
 
     def test_in_dev_mode(self):
         root_dir = dirname(dirname(dirname(abspath(__file__))))
-        expected_path = join(root_dir, '.cache', 'scancode', 'testing')
+        expected_path = join(root_dir, '.cache', 'scancode', fileutils.tree_checksum(), 'testing')
         cache_path = fileutils.build_cache_path('testing', dev_mode=True)
         assert expected_path == cache_path
 
     def test_not_in_dev_mode(self):
-        expected_path = join(os.path.expanduser('~'), '.cache', 'scancode', 'testing')
+
+        expected_path = join(
+            os.path.expanduser('~'),
+            '.cache',
+            'scancode',
+            fileutils.tree_checksum(),
+            'testing'
+        )
+
         cache_path = fileutils.build_cache_path('testing', dev_mode=False)
         assert expected_path == cache_path
 
     def test_env_var_overrides(self):
         root_dir = tempfile.gettempdir()
         os.environ[fileutils.TMP_DIR_ENV] = root_dir
-        expected_path = join(root_dir, '.cache', 'scancode', 'testing')
+        expected_path = join(root_dir, '.cache', 'scancode', fileutils.tree_checksum(), 'testing')
         cache_path = fileutils.build_cache_path('testing', dev_mode=True)
         assert cache_path == expected_path
 
     def test_raises_on_invalid_env_var(self):
         root_dir = '/nosuchdir'
         os.environ[fileutils.TMP_DIR_ENV] = root_dir
-        expected_path = join(root_dir, '.cache', 'scancode', 'testing')
+        expected_path = join(root_dir, '.cache', 'scancode', fileutils.tree_checksum(), 'testing')
         self.assertRaises(OSError, fileutils.build_cache_path, 'testing', dev_mode=True)


### PR DESCRIPTION
This is a first attempt to address #357 and #685.

I tried to move around as few things as possible, but I'm still not totally happy with the result. IMHO The most problematic part are import side effects, especially the creation of directories.

Instead of the environment variable `SCANCODE_TEMP_DIR` the code looks for `SCANCODE_TMP`, because that was already in use in `commoncode/fileutils.py`.