### PR TITLE
Return minimal type information #802

### DIFF
--- a/src/scancode/plugin_info.py
+++ b/src/scancode/plugin_info.py
@@ -63,7 +63,7 @@ class InfoScanner(ScanPlugin):
     options = [
         CommandLineOption(('-i', '--info'),
             is_flag=True, default=False,
-            help='Scan <input> for file information (size, type, checksums, etc).',
+            help='Scan <input> for file information (size, checksums, etc).',
             help_group=OTHER_SCAN_GROUP, sort_order=10
             )
     ]

--- a/src/scancode/resource.py
+++ b/src/scancode/resource.py
@@ -927,9 +927,9 @@ class Resource(object):
         """
         res = OrderedDict()
         res['path'] = self.path
+        res['type'] = self.type
 
         if with_info:
-            res['type'] = self.type
             res['name'] = fsdecode(self.name)
             res['base_name'] = fsdecode(self.base_name)
             res['extension'] = fsdecode(self.extension)

--- a/tests/formattedcode/data/csv/srp.csv
+++ b/tests/formattedcode/data/csv/srp.csv
@@ -1,9 +1,9 @@
-Resource,scan_errors,copyright,start_line,end_line,copyright_holder
-/srp,,,,,
-/srp/build.info,,,,,
-/srp/srp_lib.c,,,,,
-/srp/srp_lib.c,,Copyright 2011-2016 The OpenSSL Project,2,2,
-/srp/srp_lib.c,,,2,2,The OpenSSL Project
-/srp/srp_vfy.c,,,,,
-/srp/srp_vfy.c,,Copyright 2011-2016 The OpenSSL Project,2,2,
-/srp/srp_vfy.c,,,2,2,The OpenSSL Project
+Resource,type,scan_errors,copyright,start_line,end_line,copyright_holder
+/srp/,directory,,,,,
+/srp/build.info,file,,,,,
+/srp/srp_lib.c,file,,,,,
+/srp/srp_lib.c,,,Copyright 2011-2016 The OpenSSL Project,2,2,
+/srp/srp_lib.c,,,,2,2,The OpenSSL Project
+/srp/srp_vfy.c,file,,,,,
+/srp/srp_vfy.c,,,Copyright 2011-2016 The OpenSSL Project,2,2,
+/srp/srp_vfy.c,,,,2,2,The OpenSSL Project

--- a/tests/formattedcode/data/csv/tree/expected.csv
+++ b/tests/formattedcode/data/csv/tree/expected.csv
@@ -1,24 +1,24 @@
-Resource,scan_errors,copyright,start_line,end_line,copyright_holder
-/scan,,,,,
-/scan/copy1.c,,,,,
-/scan/copy1.c,,"Copyright (c) 2000 ACME, Inc.",1,1,
-/scan/copy1.c,,,1,1,"ACME, Inc."
-/scan/copy2.c,,,,,
-/scan/copy2.c,,"Copyright (c) 2000 ACME, Inc.",1,1,
-/scan/copy2.c,,,1,1,"ACME, Inc."
-/scan/copy3.c,,,,,
-/scan/copy3.c,,"Copyright (c) 2000 ACME, Inc.",1,1,
-/scan/copy3.c,,,1,1,"ACME, Inc."
-/scan/subdir,,,,,
-/scan/subdir/copy1.c,,,,,
-/scan/subdir/copy1.c,,"Copyright (c) 2000 ACME, Inc.",1,1,
-/scan/subdir/copy1.c,,,1,1,"ACME, Inc."
-/scan/subdir/copy2.c,,,,,
-/scan/subdir/copy2.c,,"Copyright (c) 2000 ACME, Inc.",1,1,
-/scan/subdir/copy2.c,,,1,1,"ACME, Inc."
-/scan/subdir/copy3.c,,,,,
-/scan/subdir/copy3.c,,"Copyright (c) 2000 ACME, Inc.",1,1,
-/scan/subdir/copy3.c,,,1,1,"ACME, Inc."
-/scan/subdir/copy4.c,,,,,
-/scan/subdir/copy4.c,,"Copyright (c) 2000 ACME, Inc.",1,1,
-/scan/subdir/copy4.c,,,1,1,"ACME, Inc."
+Resource,type,scan_errors,copyright,start_line,end_line,copyright_holder
+/scan/,directory,,,,,
+/scan/copy1.c,file,,,,,
+/scan/copy1.c,,,"Copyright (c) 2000 ACME, Inc.",1,1,
+/scan/copy1.c,,,,1,1,"ACME, Inc."
+/scan/copy2.c,file,,,,,
+/scan/copy2.c,,,"Copyright (c) 2000 ACME, Inc.",1,1,
+/scan/copy2.c,,,,1,1,"ACME, Inc."
+/scan/copy3.c,file,,,,,
+/scan/copy3.c,,,"Copyright (c) 2000 ACME, Inc.",1,1,
+/scan/copy3.c,,,,1,1,"ACME, Inc."
+/scan/subdir/,directory,,,,,
+/scan/subdir/copy1.c,file,,,,,
+/scan/subdir/copy1.c,,,"Copyright (c) 2000 ACME, Inc.",1,1,
+/scan/subdir/copy1.c,,,,1,1,"ACME, Inc."
+/scan/subdir/copy2.c,file,,,,,
+/scan/subdir/copy2.c,,,"Copyright (c) 2000 ACME, Inc.",1,1,
+/scan/subdir/copy2.c,,,,1,1,"ACME, Inc."
+/scan/subdir/copy3.c,file,,,,,
+/scan/subdir/copy3.c,,,"Copyright (c) 2000 ACME, Inc.",1,1,
+/scan/subdir/copy3.c,,,,1,1,"ACME, Inc."
+/scan/subdir/copy4.c,file,,,,,
+/scan/subdir/copy4.c,,,"Copyright (c) 2000 ACME, Inc.",1,1,
+/scan/subdir/copy4.c,,,,1,1,"ACME, Inc."

--- a/tests/scancode/data/composer/composer.expected.json
+++ b/tests/scancode/data/composer/composer.expected.json
@@ -9,6 +9,7 @@
   "files": [
     {
       "path": "composer.json",
+      "type": "file",
       "packages": [
         {
           "type": "phpcomposer",

--- a/tests/scancode/data/failing/patchelf.expected.json
+++ b/tests/scancode/data/failing/patchelf.expected.json
@@ -10,6 +10,7 @@
   "files": [
     {
       "path": "patchelf.pdf",
+      "type": "file",
       "copyrights": [],
       "scan_errors": [
         "ERROR: for scanner: copyrights:\nerror: unpack requires a string argument of length 8\n"

--- a/tests/scancode/data/help/help.txt
+++ b/tests/scancode/data/help/help.txt
@@ -13,7 +13,7 @@ Options:
     -c, --copyright  Scan <input> for copyrights.
 
   other scans:
-    -i, --info   Scan <input> for file information (size, type, checksums, etc).
+    -i, --info   Scan <input> for file information (size, checksums, etc).
     -e, --email  Scan <input> for emails.
     -u, --url    Scan <input> for urls.
 

--- a/tests/scancode/data/info/all.rooted.expected.json
+++ b/tests/scancode/data/info/all.rooted.expected.json
@@ -12,6 +12,7 @@
   "files": [
     {
       "path": "basic.tgz",
+      "type": "directory",
       "licenses": [],
       "copyrights": [],
       "emails": [],
@@ -20,6 +21,7 @@
     },
     {
       "path": "basic.tgz/basic",
+      "type": "directory",
       "licenses": [],
       "copyrights": [],
       "emails": [],
@@ -28,6 +30,7 @@
     },
     {
       "path": "basic.tgz/basic/dbase.fdt",
+      "type": "file",
       "licenses": [],
       "copyrights": [],
       "emails": [],
@@ -36,6 +39,7 @@
     },
     {
       "path": "basic.tgz/basic/dir",
+      "type": "directory",
       "licenses": [],
       "copyrights": [],
       "emails": [],
@@ -44,6 +48,7 @@
     },
     {
       "path": "basic.tgz/basic/dir/e.tar",
+      "type": "file",
       "licenses": [],
       "copyrights": [],
       "emails": [],
@@ -52,6 +57,7 @@
     },
     {
       "path": "basic.tgz/basic/dir/subdir",
+      "type": "directory",
       "licenses": [],
       "copyrights": [],
       "emails": [],
@@ -60,6 +66,7 @@
     },
     {
       "path": "basic.tgz/basic/dir/subdir/a.aif",
+      "type": "file",
       "licenses": [],
       "copyrights": [],
       "emails": [],
@@ -68,6 +75,7 @@
     },
     {
       "path": "basic.tgz/basic/dir2",
+      "type": "directory",
       "licenses": [],
       "copyrights": [],
       "emails": [],
@@ -76,6 +84,7 @@
     },
     {
       "path": "basic.tgz/basic/dir2/subdir",
+      "type": "directory",
       "licenses": [],
       "copyrights": [],
       "emails": [],
@@ -84,6 +93,7 @@
     },
     {
       "path": "basic.tgz/basic/dir2/subdir/bcopy.s",
+      "type": "file",
       "licenses": [
         {
           "key": "bsd-original-uc",
@@ -147,6 +157,7 @@
     },
     {
       "path": "basic.tgz/basic/dir2/subdir/config.conf",
+      "type": "file",
       "licenses": [],
       "copyrights": [],
       "emails": [],
@@ -161,6 +172,7 @@
     },
     {
       "path": "basic.tgz/basic/main.c",
+      "type": "file",
       "licenses": [
         {
           "key": "gpl-2.0",

--- a/tests/scancode/data/license_text/test.expected
+++ b/tests/scancode/data/license_text/test.expected
@@ -11,6 +11,7 @@
   "files": [
     {
       "path": "test.txt",
+      "type": "file",
       "licenses": [
         {
           "key": "lgpl-2.1",

--- a/tests/scancode/data/plugin_ignore_copyrights/authors.expected.json
+++ b/tests/scancode/data/plugin_ignore_copyrights/authors.expected.json
@@ -13,21 +13,25 @@
   "files": [
     {
       "path": "basic.tgz",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dbase.fdt",
+      "type": "file",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/main.c",
+      "type": "file",
       "copyrights": [
         {
           "statements": [
@@ -45,36 +49,43 @@
     },
     {
       "path": "basic.tgz/basic/dir",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir/e.tar",
+      "type": "file",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir/subdir",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir/subdir/a.aif",
+      "type": "file",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir2",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir2/subdir",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir2/subdir/config.conf",
+      "type": "file",
       "copyrights": [],
       "scan_errors": []
     }

--- a/tests/scancode/data/plugin_ignore_copyrights/holders.expected.json
+++ b/tests/scancode/data/plugin_ignore_copyrights/holders.expected.json
@@ -13,21 +13,25 @@
   "files": [
     {
       "path": "basic.tgz",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dbase.fdt",
+      "type": "file",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/main.c",
+      "type": "file",
       "copyrights": [
         {
           "statements": [
@@ -45,36 +49,43 @@
     },
     {
       "path": "basic.tgz/basic/dir",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir/e.tar",
+      "type": "file",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir/subdir",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir/subdir/a.aif",
+      "type": "file",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir2",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir2/subdir",
+      "type": "directory",
       "copyrights": [],
       "scan_errors": []
     },
     {
       "path": "basic.tgz/basic/dir2/subdir/config.conf",
+      "type": "file",
       "copyrights": [],
       "scan_errors": []
     }

--- a/tests/scancode/data/plugin_license/license_url.expected.json
+++ b/tests/scancode/data/plugin_license/license_url.expected.json
@@ -10,11 +10,13 @@
   "files": [
     {
       "path": "license_url",
+      "type": "directory",
       "licenses": [],
       "scan_errors": []
     },
     {
       "path": "license_url/apache-1.0.txt",
+      "type": "file",
       "licenses": [
         {
           "key": "apache-1.0",

--- a/tests/scancode/data/rpm/fping-2.4-0.b2.rhfc1.dag.i386.rpm.expected.json
+++ b/tests/scancode/data/rpm/fping-2.4-0.b2.rhfc1.dag.i386.rpm.expected.json
@@ -9,6 +9,7 @@
   "files": [
     {
       "path": "fping-2.4-0.b2.rhfc1.dag.i386.rpm",
+      "type": "file",
       "packages": [
         {
           "type": "RPM",

--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -318,12 +318,15 @@ def test_scan_works_with_multiple_processes_and_timeouts():
 
     expected = [
         [(u'path', u'test1.txt'),
+         (u'type', u'file'),
          (u'copyrights', []),
          (u'scan_errors', [u'ERROR: for scanner: copyrights:\nERROR: Processing interrupted: timeout after 0 seconds.'])],
         [(u'path', u'test2.txt'),
+         (u'type', u'file'),
          (u'copyrights', []),
          (u'scan_errors', [u'ERROR: for scanner: copyrights:\nERROR: Processing interrupted: timeout after 0 seconds.'])],
         [(u'path', u'test3.txt'),
+         (u'type', u'file'),
          (u'copyrights', []),
          (u'scan_errors', [u'ERROR: for scanner: copyrights:\nERROR: Processing interrupted: timeout after 0 seconds.'])]
     ]


### PR DESCRIPTION
AboutCode Manager and other tools need to know if a path is a file or
directory at the minimum. This information was previously returned
only with the `--info` option. We now always return minimal type
file information with a scanned file for proper downstream processing
of scan results by tools like the AboutCode Manager.

Signed-off-by: Yash Nisar <yash.nisar@somaiya.edu>

Closes https://github.com/nexB/scancode-toolkit/issues/802