### PR TITLE
Simplify output option names #789

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ help. ScanCode will self-configure if needed::
 
 Run a sample scan saved to the `samples.html` file::
 
-    ./scancode --output-html-app samples.html samples
+    ./scancode --html-app samples.html samples
 
 Then open `samples.html` in your web browser to view the scan results. 
 
@@ -167,6 +167,6 @@ Run this command for a list of command line examples::
 
 To run a license scan on sample data, first run this::
 
-    ./scancode -l --output-html-app samples.html samples
+    ./scancode -l --html-app samples.html samples
 
 Then open samples.html in your web browser to see the results.

--- a/etc/release/release.sh
+++ b/etc/release/release.sh
@@ -63,17 +63,17 @@ function test_scan {
             $cmd
             echo "TEST PASSED"
 
-            cmd="./scancode --quiet -lcip apache-2.0.LICENSE --output-html test_scan.html"
+            cmd="./scancode --quiet -lcip apache-2.0.LICENSE --html test_scan.html"
             echo "RUNNING TEST: $cmd"
             $cmd
             echo "TEST PASSED"
 
-            cmd="./scancode --quiet -lcip  apache-2.0.LICENSE --output-html-app test_scan_app.html"
+            cmd="./scancode --quiet -lcip  apache-2.0.LICENSE --html-app test_scan_app.html"
             echo "RUNNING TEST: $cmd"
             $cmd
             echo "TEST PASSED"
 
-            cmd="./scancode --quiet -lcip apache-2.0.LICENSE --output-spdx-tv test_scan.spdx"
+            cmd="./scancode --quiet -lcip apache-2.0.LICENSE --spdx-tv test_scan.spdx"
             echo "RUNNING TEST: $cmd"
             $cmd
             echo "TEST PASSED"

--- a/src/formattedcode/output_csv.py
+++ b/src/formattedcode/output_csv.py
@@ -42,7 +42,7 @@ from scancode import OUTPUT_GROUP
 class CsvOutput(OutputPlugin):
 
     options = [
-        CommandLineOption(('--output-csv',),
+        CommandLineOption(('--csv',),
             type=FileOptionType(mode='wb', lazy=False),
             metavar='FILE',
             help='Write scan output as CSV to FILE.',
@@ -50,12 +50,12 @@ class CsvOutput(OutputPlugin):
             sort_order=30),
     ]
 
-    def is_enabled(self, output_csv, **kwargs):
-        return output_csv
+    def is_enabled(self, csv, **kwargs):
+        return csv
 
-    def process_codebase(self, codebase, output_csv, **kwargs):
+    def process_codebase(self, codebase, csv, **kwargs):
         results = self.get_results(codebase, **kwargs)
-        write_csv(results, output_csv)
+        write_csv(results, csv)
 
 
 def write_csv(results, output_file):

--- a/src/formattedcode/output_html.py
+++ b/src/formattedcode/output_html.py
@@ -68,7 +68,7 @@ which is NOT a plugin
 class HtmlOutput(OutputPlugin):
 
     options = [
-        CommandLineOption(('--output-html',),
+        CommandLineOption(('--html',),
             type=FileOptionType(mode='wb', lazy=False),
             metavar='FILE',
             help='Write scan output as HTML to FILE.',
@@ -76,12 +76,12 @@ class HtmlOutput(OutputPlugin):
             sort_order=50),
     ]
 
-    def is_enabled(self, output_html, **kwargs):
-        return output_html
+    def is_enabled(self, html, **kwargs):
+        return html
 
-    def process_codebase(self, codebase, output_html, scancode_version, **kwargs):
+    def process_codebase(self, codebase, html, scancode_version, **kwargs):
         results = self.get_results(codebase, **kwargs)
-        write_templated(output_html, results, scancode_version,
+        write_templated(html, results, scancode_version,
                         template_or_format='html')
 
 
@@ -89,7 +89,7 @@ class HtmlOutput(OutputPlugin):
 class CustomTemplateOutput(OutputPlugin):
 
     options = [
-        CommandLineOption(('--output-custom',),
+        CommandLineOption(('--custom-output',),
             type=FileOptionType(mode='wb', lazy=False),
             requires=['custom_template'],
             metavar='FILE',
@@ -102,23 +102,23 @@ class CustomTemplateOutput(OutputPlugin):
             type=click.Path(
                 exists=True, file_okay=True, dir_okay=False,
                 readable=True, path_type=PATH_TYPE),
-            requires=['output_custom'],
+            requires=['custom_output'],
             metavar='FILE',
             help='Use this Jinja template FILE as a custom template.',
             help_group=OUTPUT_GROUP,
             sort_order=65),
     ]
 
-    def is_enabled(self, output_custom, custom_template, **kwargs):
-        return output_custom and custom_template
+    def is_enabled(self, custom_output, custom_template, **kwargs):
+        return custom_output and custom_template
 
-    def process_codebase(self, codebase, output_custom, custom_template,
+    def process_codebase(self, codebase, custom_output, custom_template,
                          scancode_version, **kwargs):
 
         results = self.get_results(codebase, **kwargs)
         if on_linux:
             custom_template = fsencode(custom_template)
-        write_templated(output_custom, results, scancode_version,
+        write_templated(custom_output, results, scancode_version,
                         template_or_format=custom_template)
 
 
@@ -128,7 +128,7 @@ class HtmlAppOutput(OutputPlugin):
     Write scan output as a mini HTML application.
     """
     options = [
-        CommandLineOption(('--output-html-app',),
+        CommandLineOption(('--html-app',),
             type=FileOptionType(mode='wb', lazy=False),
             metavar='FILE',
             help='Write scan output as a mini HTML application to FILE.',
@@ -136,17 +136,17 @@ class HtmlAppOutput(OutputPlugin):
             sort_order=70),
     ]
 
-    def is_enabled(self, output_html_app, **kwargs):
-        return output_html_app
+    def is_enabled(self, html_app, **kwargs):
+        return html_app
 
     def process_codebase(self, codebase,
                          input,  # NOQA
-                         output_html_app,
+                         html_app,
                          scancode_version, **kwargs):
 
         results = self.get_results(codebase, **kwargs)
-        output_html_app.write(as_html_app(output_html_app, input, scancode_version))
-        create_html_app_assets(results, output_html_app)
+        html_app.write(as_html_app(html_app, input, scancode_version))
+        create_html_app_assets(results, html_app)
 
 
 def write_templated(output_file, results, version, template_or_format):

--- a/src/formattedcode/output_spdx.py
+++ b/src/formattedcode/output_spdx.py
@@ -92,7 +92,7 @@ Output plugins to write scan results in SPDX format.
 class SpdxTvOutput(OutputPlugin):
 
     options = [
-        CommandLineOption(('--output-spdx-tv',),
+        CommandLineOption(('--spdx-tv',),
             type=FileOptionType(mode='wb', lazy=False),
             metavar='FILE',
             requires=['info'],
@@ -100,16 +100,16 @@ class SpdxTvOutput(OutputPlugin):
             help_group=OUTPUT_GROUP)
     ]
 
-    def is_enabled(self, output_spdx_tv, info, **kwargs):
-        return output_spdx_tv and info
+    def is_enabled(self, spdx_tv, info, **kwargs):
+        return spdx_tv and info
 
     def process_codebase(self, codebase,
                          input,  # NOQA
-                         output_spdx_tv,
+                         spdx_tv,
                          scancode_version, scancode_notice, **kwargs):
 
         results = self.get_results(codebase, **kwargs)
-        write_spdx(output_spdx_tv, results, scancode_version, scancode_notice,
+        write_spdx(spdx_tv, results, scancode_version, scancode_notice,
                    input, as_tagvalue=True)
 
 
@@ -117,7 +117,7 @@ class SpdxTvOutput(OutputPlugin):
 class SpdxRdfOutput(OutputPlugin):
 
     options = [
-        CommandLineOption(('--output-spdx-rdf',),
+        CommandLineOption(('--spdx-rdf',),
             type=FileOptionType(mode='wb', lazy=False),
             metavar='FILE',
             requires=['info'],
@@ -125,16 +125,16 @@ class SpdxRdfOutput(OutputPlugin):
             help_group=OUTPUT_GROUP)
     ]
 
-    def is_enabled(self, output_spdx_rdf, info, **kwargs):
-        return output_spdx_rdf and info
+    def is_enabled(self, spdx_rdf, info, **kwargs):
+        return spdx_rdf and info
 
     def process_codebase(self, codebase,
                          input,  # NOQA
-                         output_spdx_rdf,
+                         spdx_rdf,
                          scancode_version, scancode_notice, **kwargs):
 
         results = self.get_results(codebase, **kwargs)
-        write_spdx(output_spdx_rdf, results, scancode_version, scancode_notice,
+        write_spdx(spdx_rdf, results, scancode_version, scancode_notice,
                    input, as_tagvalue=False)
 
 

--- a/src/scancode/help.py
+++ b/src/scancode/help.py
@@ -56,12 +56,12 @@ an HTML app file for interactive scan results navigation. When the scan is done,
 open 'scancode_result.html' in your web browser. Note that additional app files
 are saved in a directory named 'scancode_result_files':
 
-    scancode --output-html-app scancode_result.html samples/
+    scancode --html-app scancode_result.html samples/
 
 Scan a directory for licenses and copyrights. Save scan results to an
 HTML file:
 
-    scancode --output-html scancode_result.html samples/zlib
+    scancode --html scancode_result.html samples/zlib
 
 To extract archives, see the 'extractcode' command instead.
 '''

--- a/tests/formattedcode/test_output_csv.py
+++ b/tests/formattedcode/test_output_csv.py
@@ -192,7 +192,7 @@ def test_csv_minimal():
     test_dir = test_env.get_test_loc('csv/srp')
     result_file = test_env.get_temp_file('csv')
     expected_file = test_env.get_test_loc('csv/srp.csv')
-    args = ['--copyright', test_dir, '--output-csv', result_file]
+    args = ['--copyright', test_dir, '--csv', result_file]
     run_scan_click(args)
     check_csvs(result_file, expected_file)
 
@@ -201,7 +201,7 @@ def test_csv_tree():
     test_dir = test_env.get_test_loc('csv/tree/scan')
     result_file = test_env.get_temp_file('csv')
     expected_file = test_env.get_test_loc('csv/tree/expected.csv')
-    args = ['--copyright', test_dir, '--output-csv', result_file]
+    args = ['--copyright', test_dir, '--csv', result_file]
     run_scan_click(args)
     check_csvs(result_file, expected_file)
 
@@ -209,7 +209,7 @@ def test_csv_tree():
 def test_can_process_live_scan_with_all_options():
     test_dir = test_env.get_test_loc('csv/livescan/scan')
     result_file = test_env.get_temp_file('csv')
-    args = ['-clip', '--email', '--url', '--strip-root', test_dir, '--output-csv', result_file]
+    args = ['-clip', '--email', '--url', '--strip-root', test_dir, '--csv', result_file]
     run_scan_plain(args)
     expected_file = test_env.get_test_loc('csv/livescan/expected.csv')
     check_csvs(result_file, expected_file)

--- a/tests/formattedcode/test_output_spdx.py
+++ b/tests/formattedcode/test_output_spdx.py
@@ -149,7 +149,7 @@ def test_spdx_rdf_basic():
     test_file = test_env.get_test_loc('spdx/simple/test.txt')
     result_file = test_env.get_temp_file('rdf')
     expected_file = test_env.get_test_loc('spdx/simple/expected.rdf')
-    run_scan_click([test_file, '-clip', '--output-spdx-rdf', result_file])
+    run_scan_click([test_file, '-clip', '--spdx-rdf', result_file])
     check_rdf_scan(expected_file, result_file)
 
 
@@ -157,7 +157,7 @@ def test_spdx_tv_basic():
     test_dir = test_env.get_test_loc('spdx/simple/test.txt')
     result_file = test_env.get_temp_file('tv')
     expected_file = test_env.get_test_loc('spdx/simple/expected.tv')
-    run_scan_click([test_dir, '-clip', '--output-spdx-tv', result_file])
+    run_scan_click([test_dir, '-clip', '--spdx-tv', result_file])
     check_tv_scan(expected_file, result_file)
 
 
@@ -165,7 +165,7 @@ def test_spdx_rdf_with_known_licenses():
     test_dir = test_env.get_test_loc('spdx/license_known/scan')
     result_file = test_env.get_temp_file('rdf')
     expected_file = test_env.get_test_loc('spdx/license_known/expected.rdf')
-    run_scan_click([test_dir, '-clip', '--output-spdx-rdf', result_file])
+    run_scan_click([test_dir, '-clip', '--spdx-rdf', result_file])
     check_rdf_scan(expected_file, result_file)
 
 
@@ -173,7 +173,7 @@ def test_spdx_rdf_with_license_ref():
     test_dir = test_env.get_test_loc('spdx/license_ref/scan')
     result_file = test_env.get_temp_file('rdf')
     expected_file = test_env.get_test_loc('spdx/license_ref/expected.rdf')
-    run_scan_click([test_dir, '-clip', '--output-spdx-rdf', result_file])
+    run_scan_click([test_dir, '-clip', '--spdx-rdf', result_file])
     check_rdf_scan(expected_file, result_file)
 
 
@@ -181,7 +181,7 @@ def test_spdx_tv_with_known_licenses():
     test_dir = test_env.get_test_loc('spdx/license_known/scan')
     result_file = test_env.get_temp_file('tv')
     expected_file = test_env.get_test_loc('spdx/license_known/expected.tv')
-    run_scan_click([test_dir, '-clip', '--output-spdx-tv', result_file])
+    run_scan_click([test_dir, '-clip', '--spdx-tv', result_file])
     check_tv_scan(expected_file, result_file)
 
 
@@ -189,7 +189,7 @@ def test_spdx_tv_with_license_ref():
     test_dir = test_env.get_test_loc('spdx/license_ref/scan')
     result_file = test_env.get_temp_file('tv')
     expected_file = test_env.get_test_loc('spdx/license_ref/expected.tv')
-    run_scan_click([test_dir, '-clip', '--output-spdx-tv', result_file])
+    run_scan_click([test_dir, '-clip', '--spdx-tv', result_file])
     check_tv_scan(expected_file, result_file)
 
 
@@ -197,7 +197,7 @@ def test_spdx_rdf_with_known_licenses_with_text():
     test_dir = test_env.get_test_loc('spdx/license_known/scan')
     result_file = test_env.get_temp_file('rdf')
     expected_file = test_env.get_test_loc('spdx/license_known/expected_with_text.rdf')
-    run_scan_click([ '-clip', '--license-text', test_dir, '--output-spdx-rdf', result_file])
+    run_scan_click([ '-clip', '--license-text', test_dir, '--spdx-rdf', result_file])
     check_rdf_scan(expected_file, result_file)
 
 
@@ -205,7 +205,7 @@ def test_spdx_rdf_with_license_ref_with_text():
     test_dir = test_env.get_test_loc('spdx/license_ref/scan')
     result_file = test_env.get_temp_file('rdf')
     expected_file = test_env.get_test_loc('spdx/license_ref/expected_with_text.rdf')
-    run_scan_click(['-clip', '--license-text', test_dir, '--output-spdx-rdf', result_file])
+    run_scan_click(['-clip', '--license-text', test_dir, '--spdx-rdf', result_file])
     check_rdf_scan(expected_file, result_file)
 
 
@@ -213,7 +213,7 @@ def test_spdx_tv_with_known_licenses_with_text():
     test_dir = test_env.get_test_loc('spdx/license_known/scan')
     result_file = test_env.get_temp_file('tv')
     expected_file = test_env.get_test_loc('spdx/license_known/expected_with_text.tv')
-    run_scan_click(['-clip', '--license-text', test_dir, '--output-spdx-tv', result_file])
+    run_scan_click(['-clip', '--license-text', test_dir, '--spdx-tv', result_file])
     check_tv_scan(expected_file, result_file)
 
 
@@ -221,7 +221,7 @@ def test_spdx_tv_with_license_ref_with_text():
     test_dir = test_env.get_test_loc('spdx/license_ref/scan')
     result_file = test_env.get_temp_file('tv')
     expected_file = test_env.get_test_loc('spdx/license_ref/expected_with_text.tv')
-    run_scan_click(['-clip', '--license-text', test_dir, '--output-spdx-tv', result_file])
+    run_scan_click(['-clip', '--license-text', test_dir, '--spdx-tv', result_file])
     check_tv_scan(expected_file, result_file)
 
 
@@ -229,7 +229,7 @@ def test_spdx_tv_tree():
     test_dir = test_env.get_test_loc('spdx/tree/scan')
     result_file = test_env.get_temp_file('tv')
     expected_file = test_env.get_test_loc('spdx/tree/expected.tv')
-    run_scan_click(['-clip', test_dir, '--output-spdx-tv', result_file])
+    run_scan_click(['-clip', test_dir, '--spdx-tv', result_file])
     check_tv_scan(expected_file, result_file)
 
 
@@ -237,7 +237,7 @@ def test_spdx_rdf_tree():
     test_dir = test_env.get_test_loc('spdx/tree/scan')
     result_file = test_env.get_temp_file('rdf')
     expected_file = test_env.get_test_loc('spdx/tree/expected.rdf')
-    run_scan_click(['-clip', test_dir, '--output-spdx-rdf', result_file])
+    run_scan_click(['-clip', test_dir, '--spdx-rdf', result_file])
     check_rdf_scan(expected_file, result_file)
 
 
@@ -246,7 +246,7 @@ def test_spdx_tv_with_unicode_license_text_does_not_fail():
     result_file = test_env.get_temp_file('tv')
     expected_file = test_env.get_test_loc('spdx/unicode/expected.tv')
     args = ['--license', '--copyright', '--info', '--strip-root', '--license-text',
-            '--license-diag', test_file, '--output-spdx-tv', result_file]
+            '--license-diag', test_file, '--spdx-tv', result_file]
     run_scan_plain(args)
     check_tv_scan(expected_file, result_file)
 
@@ -256,7 +256,7 @@ def test_spdx_rdf_with_unicode_license_text_does_not_fail():
     result_file = test_env.get_temp_file('rdf')
     expected_file = test_env.get_test_loc('spdx/unicode/expected.rdf')
     args = ['--license', '--copyright', '--info', '--strip-root',
-            '--license-text', '--license-diag', test_file, '--output-spdx-rdf', result_file]
+            '--license-text', '--license-diag', test_file, '--spdx-rdf', result_file]
     run_scan_plain(args)
     check_rdf_scan(expected_file, result_file)
 
@@ -266,7 +266,7 @@ def test_spdx_rdf_with_or_later_license_does_not_fail():
     result_file = test_env.get_temp_file('rdf')
     expected_file = test_env.get_test_loc('spdx/or_later/expected.rdf')
     args = ['--license', '--copyright', '--info', '--strip-root', '--license-text',
-            '--license-diag', test_file, '--output-spdx-rdf', result_file]
+            '--license-diag', test_file, '--spdx-rdf', result_file]
     run_scan_plain(args)
     check_rdf_scan(expected_file, result_file)
 
@@ -275,7 +275,7 @@ def test_spdx_tv_with_empty_scan():
     test_file = test_env.get_test_loc('spdx/empty/scan')
     result_file = test_env.get_temp_file('spdx.tv')
     expected_file = test_env.get_test_loc('spdx/empty/expected.tv')
-    args = ['--license', '--strip-root', '--info', '--only-findings', test_file, '--output-spdx-tv', result_file]
+    args = ['--license', '--strip-root', '--info', '--only-findings', test_file, '--spdx-tv', result_file]
     run_scan_plain(args)
     check_tv_scan(expected_file, result_file, regen=True)
 
@@ -283,7 +283,7 @@ def test_spdx_tv_with_empty_scan():
 def test_spdx_rdf_with_empty_scan():
     test_file = test_env.get_test_loc('spdx/empty/scan')
     result_file = test_env.get_temp_file('spdx.rdf')
-    args = ['--license', '--strip-root', '--info', '--only-findings', test_file, '--output-spdx-rdf', result_file]
+    args = ['--license', '--strip-root', '--info', '--only-findings', test_file, '--spdx-rdf', result_file]
     run_scan_plain(args)
     expected = "<!-- No results for package 'scan'. -->\n"
     results = open(result_file).read()

--- a/tests/formattedcode/test_output_templated.py
+++ b/tests/formattedcode/test_output_templated.py
@@ -43,7 +43,7 @@ test_env.test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
 def test_paths_are_posix_paths_in_html_app_format_output():
     test_dir = test_env.get_test_loc('templated/simple')
     result_file = test_env.get_temp_file(extension='html', file_name='test_html')
-    run_scan_click(['--copyright', test_dir, '--output-html-app', result_file])
+    run_scan_click(['--copyright', test_dir, '--html-app', result_file])
     # the data we want to test is in the data.json file
     data_file = os.path.join(fileutils.parent_directory(result_file), 'test_html_files', 'data.json')
     assert '/copyright_acme_c-c.c' in open(data_file).read()
@@ -54,7 +54,7 @@ def test_paths_are_posix_paths_in_html_app_format_output():
 def test_paths_are_posix_in_html_format_output():
     test_dir = test_env.get_test_loc('templated/simple')
     result_file = test_env.get_temp_file('html')
-    run_scan_click(['--copyright', test_dir, '--output-html', result_file])
+    run_scan_click(['--copyright', test_dir, '--html', result_file])
     results = open(result_file).read()
     assert '/copyright_acme_c-c.c' in results
     assert __version__ in results
@@ -63,7 +63,7 @@ def test_paths_are_posix_in_html_format_output():
 def test_scanned_path_is_present_in_html_app_output():
     test_dir = test_env.get_test_loc('templated/html_app')
     result_file = test_env.get_temp_file('test.html')
-    run_scan_click(['--copyright', '--output-html-app', result_file, test_dir])
+    run_scan_click(['--copyright', '--html-app', result_file, test_dir])
     results = open(result_file).read()
     assert '<title>ScanCode scan results for: %(test_dir)s</title>' % locals() in results
     assert '<div class="row" id = "scan-result-header">' % locals() in results
@@ -76,7 +76,7 @@ def test_scan_html_output_does_not_truncate_copyright_html():
     test_dir = test_env.get_test_loc('templated/tree/scan/')
     result_file = test_env.get_temp_file('test.html')
 
-    args = ['-clip', '--strip-root', '--verbose', test_dir, '--output-html', result_file, '--verbose']
+    args = ['-clip', '--strip-root', '--verbose', test_dir, '--html', result_file, '--verbose']
 
     run_scan_click(args)
     results = open(result_file).read()
@@ -114,7 +114,7 @@ def test_scan_html_output_does_not_truncate_copyright_html():
 def test_custom_format_with_custom_filename_fails_for_directory():
     test_dir = test_env.get_temp_dir('html')
     result_file = test_env.get_temp_file('html')
-    args = ['--info', '--custom-template', test_dir, '--output-custom', result_file, test_dir]
+    args = ['--info', '--custom-template', test_dir, '--custom-output', result_file, test_dir]
     result = run_scan_click(args, expected_rc=2)
     assert 'Invalid value for "--custom-template": Path' in result.output
 
@@ -123,7 +123,7 @@ def test_custom_format_with_custom_filename():
     test_dir = test_env.get_test_loc('templated/simple')
     custom_template = test_env.get_test_loc('templated/sample-template.html')
     result_file = test_env.get_temp_file('html')
-    args = ['--info', '--custom-template', custom_template, '--output-custom', result_file, test_dir]
+    args = ['--info', '--custom-template', custom_template, '--custom-output', result_file, test_dir]
     run_scan_click(args)
     results = open(result_file).read()
     assert 'Custom Template' in results

--- a/tests/scancode/data/help/help.txt
+++ b/tests/scancode/data/help/help.txt
@@ -37,14 +37,14 @@ Options:
     --json FILE             Write scan output as compact JSON to FILE.
     --json-pp FILE          Write scan output as pretty-printed JSON to FILE.
     --json-lines FILE       Write scan output as JSON Lines to FILE.
-    --output-csv FILE       Write scan output as CSV to FILE.
-    --output-html FILE      Write scan output as HTML to FILE.
-    --output-custom FILE    Write scan output to FILE formatted with the custom
+    --csv FILE              Write scan output as CSV to FILE.
+    --html FILE             Write scan output as HTML to FILE.
+    --custom-output FILE    Write scan output to FILE formatted with the custom
                             Jinja template file.
     --custom-template FILE  Use this Jinja template FILE as a custom template.
-    --output-html-app FILE  Write scan output as a mini HTML application to FILE.
-    --output-spdx-rdf FILE  Write scan output as SPDX RDF to FILE.
-    --output-spdx-tv FILE   Write scan output as SPDX Tag/Value to FILE.
+    --html-app FILE         Write scan output as a mini HTML application to FILE.
+    --spdx-rdf FILE         Write scan output as SPDX RDF to FILE.
+    --spdx-tv FILE          Write scan output as SPDX Tag/Value to FILE.
 
   output filters:
     --ignore-author <pattern>       Ignore findings with an author matching

--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -237,14 +237,14 @@ def test_failing_scan_return_proper_exit_code():
 def test_scan_should_not_fail_on_faulty_pdf_or_pdfminer_bug_but_instead_report_errors_and_keep_trucking_with_html():
     test_file = test_env.get_test_loc('failing/patchelf.pdf')
     result_file = test_env.get_temp_file('test.html')
-    args = ['--copyright', test_file, '--output-html', result_file]
+    args = ['--copyright', test_file, '--html', result_file]
     run_scan_click(args, expected_rc=1)
 
 
 def test_scan_should_not_fail_on_faulty_pdf_or_pdfminer_bug_but_instead_report_errors_and_keep_trucking_with_html_app():
     test_file = test_env.get_test_loc('failing/patchelf.pdf')
     result_file = test_env.get_temp_file('test.app.html')
-    args = ['--copyright', test_file, '--output-html-app', result_file]
+    args = ['--copyright', test_file, '--html-app', result_file]
     run_scan_click(args, expected_rc=1)
 
 


### PR DESCRIPTION
Some output formats were prefixed with "output" while others were not.
For the sake of consistency and simplicity, "output" is dropped as a prefix
to these output options.

Signed-off-by: Yash Nisar <yash.nisar@somaiya.edu>