### PR TITLE
Fix sample command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,8 +165,8 @@ Run this command for a list of command line examples::
 
     ./scancode --examples
 
-To run a scan on sample data, first run this::
+To run a license scan on sample data, first run this::
 
-    ./scancode --output-html-app samples.html samples
+    ./scancode -l --output-html-app samples.html samples
 
 Then open samples.html in your web browser to see the results.


### PR DESCRIPTION
Running the provided sample command results in:
```
Error: Missing scan option(s): at least one scan option is required.
```

It seems the scan type is required.