### PR TITLE
Do not attempt to write empty package info to SPDX

### DIFF
--- a/src/formattedcode/output_spdx.py
+++ b/src/formattedcode/output_spdx.py
@@ -292,11 +292,10 @@ def write_spdx(output_file, results, scancode_version, scancode_notice,
     # Therefore in one case we do nothing (rdf) and in the other case we
     # encode to UTF8 bytes.
 
-    if len(package.files) > 0:
+    if package.files:
       from StringIO import StringIO
       spdx_output = StringIO()
-      if len(package.files) > 0:
-        write_document(doc, spdx_output, validate=True)
+      write_document(doc, spdx_output, validate=True)
       result = spdx_output.getvalue()
       if as_tagvalue:
           result = result.encode('utf-8')

--- a/src/formattedcode/output_spdx.py
+++ b/src/formattedcode/output_spdx.py
@@ -292,10 +292,12 @@ def write_spdx(output_file, results, scancode_version, scancode_notice,
     # Therefore in one case we do nothing (rdf) and in the other case we
     # encode to UTF8 bytes.
 
-    from StringIO import StringIO
-    spdx_output = StringIO()
-    write_document(doc, spdx_output, validate=True)
-    result = spdx_output.getvalue()
-    if as_tagvalue:
-        result = result.encode('utf-8')
-    output_file.write(result)
+    if len(package.files) > 0:
+      from StringIO import StringIO
+      spdx_output = StringIO()
+      if len(package.files) > 0:
+        write_document(doc, spdx_output, validate=True)
+      result = spdx_output.getvalue()
+      if as_tagvalue:
+          result = result.encode('utf-8')
+      output_file.write(result)


### PR DESCRIPTION
When you scan a component without any copyright or license info, ScanCode will report an error:
`spdx.writers.tagvalue.InvalidDocumentError: [u'Package must have at least one file.']`

Adding a check before writing spdx_output will fix this problem, the output file will only contain the string `""# No results for package [name]."`

Signed-off-by: Thorsten Harter <thorsten.harter@gmx.net>