### PR TITLE
Change ignore plugin logic #1007

### DIFF
--- a/src/scancode/plugin_ignore.py
+++ b/src/scancode/plugin_ignore.py
@@ -64,7 +64,7 @@ class ProcessIgnore(PreScanPlugin):
         }
 
         ignorable = partial(is_ignored, ignores=ignores)
-        rid_to_remove = []
+        rids_to_remove = []
         remove_resource = codebase.remove_resource
 
         # First, walk the codebase from the top-down and collect the rids of
@@ -72,16 +72,16 @@ class ProcessIgnore(PreScanPlugin):
         for resource in codebase.walk(topdown=True):
             if ignorable(resource.path):
                 for child in resource.children(codebase):
-                    rid_to_remove.append(child.rid)
-                rid_to_remove.append(resource.rid)
+                    rids_to_remove.append(child.rid)
+                rids_to_remove.append(resource.rid)
 
         # Then, walk bottom-up and remove the ignored Resources from the
         # Codebase if the Resource's rid is in our list of rid's to remove.
         for resource in codebase.walk(topdown=False):
-            if ignorable(resource.path):
-                if resource.rid in rid_to_remove:
-                    rid_to_remove.remove(resource.rid)
-                    remove_resource(resource)
+            resource_rid = resource.rid
+            if resource_rid in rids_to_remove:
+                rids_to_remove.remove(resource_rid)
+                remove_resource(resource)
 
 
 def is_ignored(location, ignores):


### PR DESCRIPTION
The ignore plugin now works in two steps:

- The ignore plugin first walks the codebase top-down to collect the rid's of the resources that are to be ignored
- Then the plugin walks the codebase bottom up and removes resources if their rid is in the list of rids to remove