### PR TITLE
Improve indexing speed

### DIFF
--- a/src/licensedcode/models.py
+++ b/src/licensedcode/models.py
@@ -709,7 +709,7 @@ class Rule(object):
         """
         if self.text_file and exists(self.text_file):
             # IMPORTANT: use the same process as query text loading for symmetry
-            lines = text_lines(self.text_file, demarkup=False)
+            lines = text_lines(self.text_file, demarkup=False, plain_text=True)
             return ''.join(lines)
 
         # used for non-file backed rules

--- a/tests/licensedcode/test_performance.py
+++ b/tests/licensedcode/test_performance.py
@@ -134,10 +134,11 @@ class TestIndexingPerformance(FileBasedTesting):
         import cProfile as profile
         import pstats
         stats = 'build_index_performance_profile_log.txt'
-        test_py = 'cache.get_index()'
+        test_py = 'cache.get_index(return_value=False)'
         profile.runctx(test_py, globals(), locals(), stats)
         p = pstats.Stats(stats)
         p.sort_stats('time').print_stats(40)
+        raise Exception('indexing perfs test')
 
 
 class TestTokenizingPerformance(FileBasedTesting):


### PR DESCRIPTION
This speeds up initial license indexing by 2X by avoiding the file type checks that are not necessary when loading license rules and texts. 
