### PR TITLE
warn if the license cache is corrupted

### DIFF
--- a/src/licensedcode/cache.py
+++ b/src/licensedcode/cache.py
@@ -226,15 +226,15 @@ def load_index(cache_file):
     from licensedcode.index import LicenseIndex
     with open(cache_file, 'rb') as ifc:
         # Note: weird but read() + loads() is much (twice++???) faster than load()
-	try:
-		return LicenseIndex.loads(ifc.read())
-	except:
-		import click
-		click.secho("ERROR: Failed to load license cache (file corrupted?). Please delete '{0}' "
-				"and retry. If the problem persists, copy the following error message and file a "
-				"bug report.".format(cache_file),
-				 fg="red")
-		raise
+    try:
+        return LicenseIndex.loads(ifc.read())
+    except:
+    import click
+        click.secho("ERROR: Failed to load license cache (file corrupted?). Please delete '{0}' "
+                            "and retry. If the problem persists, copy the following error message and file a "
+                            "bug report.".format(cache_file),
+                            fg="red")
+        raise
 
 _ignored_from_hash = partial(
     ignore.is_ignored,

--- a/src/licensedcode/cache.py
+++ b/src/licensedcode/cache.py
@@ -226,15 +226,15 @@ def load_index(cache_file):
     from licensedcode.index import LicenseIndex
     with open(cache_file, 'rb') as ifc:
         # Note: weird but read() + loads() is much (twice++???) faster than load()
-    try:
-        return LicenseIndex.loads(ifc.read())
-    except:
-    import click
-        click.secho("ERROR: Failed to load license cache (file corrupted?). Please delete '{0}' "
-                            "and retry. If the problem persists, copy the following error message and file a "
-                            "bug report.".format(cache_file),
-                            fg="red")
-        raise
+        try:
+            return LicenseIndex.loads(ifc.read())
+        except:
+            import click
+            click.secho("ERROR: Failed to load license cache (file corrupted?). Please delete '{0}' "
+                                "and retry. If the problem persists, copy the following error message and file a "
+                                "bug report.".format(cache_file),
+                                fg="red")
+            raise
 
 _ignored_from_hash = partial(
     ignore.is_ignored,

--- a/src/licensedcode/cache.py
+++ b/src/licensedcode/cache.py
@@ -41,6 +41,8 @@ from scancode_config import scancode_cache_dir
 from scancode_config import scancode_src_dir
 from scancode_config import SCANCODE_DEV_MODE
 
+import click
+
 """
 An on-disk persistent cache of LicenseIndex. The index is pickled and invalidated if
 there are any changes in the code or licenses text or rules. Loading and dumping the
@@ -226,8 +228,14 @@ def load_index(cache_file):
     from licensedcode.index import LicenseIndex
     with open(cache_file, 'rb') as ifc:
         # Note: weird but read() + loads() is much (twice++???) faster than load()
-        return LicenseIndex.loads(ifc.read())
-
+	try:
+		return LicenseIndex.loads(ifc.read())
+	except:
+		click.secho("ERROR: Failed to load license cache (file corrupted?). Please delete '{0}' "
+				"and retry. If the problem persists, copy the following error message and file a "
+				"bug report.".format(cache_file),
+				 fg="red")
+		raise
 
 _ignored_from_hash = partial(
     ignore.is_ignored,

--- a/src/licensedcode/cache.py
+++ b/src/licensedcode/cache.py
@@ -41,8 +41,6 @@ from scancode_config import scancode_cache_dir
 from scancode_config import scancode_src_dir
 from scancode_config import SCANCODE_DEV_MODE
 
-import click
-
 """
 An on-disk persistent cache of LicenseIndex. The index is pickled and invalidated if
 there are any changes in the code or licenses text or rules. Loading and dumping the
@@ -231,6 +229,7 @@ def load_index(cache_file):
 	try:
 		return LicenseIndex.loads(ifc.read())
 	except:
+		import click
 		click.secho("ERROR: Failed to load license cache (file corrupted?). Please delete '{0}' "
 				"and retry. If the problem persists, copy the following error message and file a "
 				"bug report.".format(cache_file),


### PR DESCRIPTION
Display a warning if loading the license cache fails. Tell the user to delete the cache file and retry, file a bug report if the problem persists. Reraise the original python exception as discussed in #1070 to avoid error masking.

Signed-off-by: Felix Kauselmann <licorn@gmail.com>