### PR TITLE
Ensure that the Virtual codebase ouput is the same as a regular Codebase output

### DIFF
--- a/src/commoncode/testcase.py
+++ b/src/commoncode/testcase.py
@@ -45,34 +45,6 @@ from commoncode.system import on_posix
 from commoncode.system import on_windows
 
 
-class EnhancedAssertions(TestCaseClass):
-    """
-    Common new new assertions made better or simpler.
-    """
-    # always show full diff
-    maxDiff = None
-
-    def failUnlessRaisesInstance(self, excInstance, callableObj,
-                                 *args, **kwargs):
-        """
-        This assertion accepts an instance instead of a class for refined
-        exception testing.
-        """
-        excClass = excInstance.__class__
-        try:
-            callableObj(*args, **kwargs)
-        except excClass, e:
-            self.assertEqual(str(excInstance), str(e))
-        else:
-            if hasattr(excClass, '__name__'):
-                excName = excClass.__name__
-            else:
-                excName = str(excClass)
-            raise self.failureException('%s not raised' % excName)
-
-    assertRaisesInstance = failUnlessRaisesInstance
-
-
 # a base test dir specific to a given test run
 # to ensure that multiple tests run can be launched in parallel
 test_run_temp_dir = None
@@ -390,40 +362,8 @@ def tar_can_extract(tarinfo, verbatim):
         return True
 
 
-class FileBasedTesting(EnhancedAssertions, FileDrivenTesting):
-
-    def as_line_list(self, list_or_file, sort=False, skip_firstline=False):
-        """
-        Given a list of file path as an input, return a list of text lines
-        suitable for comparison. Optionally skip the first line (for CSV
-        comparisons) and sort the list.
-        """
-        L = []
-        if isinstance(list_or_file, basestring):
-            L = open(list_or_file, 'rb').readlines()
-        elif isinstance(list_or_file, (list, tuple,)):
-            L = list_or_file
-        else:
-            raise Exception('unsupported object type: '
-                            'must be a list, tuple or file name')
-
-        if skip_firstline and L:
-            L = L[1:]
-        if sort:
-            L = sorted(L)
-        return L
-
-    def failUnlessFilesLinesEqual(self, expected_list_or_file,
-                                  result_list_or_file,
-                                  msg=None, sort=False, skip_firstline=False):
-        """
-        Check equality of two lists of lines or files lines content.
-        """
-        expected = self.as_line_list(expected_list_or_file, sort, skip_firstline)
-        result = self.as_line_list(result_list_or_file, sort, skip_firstline)
-        self.failUnlessEqual(expected, result, msg)
-
-    assertLinesEqual = failUnlessFilesLinesEqual
+class FileBasedTesting(TestCaseClass, FileDrivenTesting):
+    pass
 
 
 class dircmp(filecmp.dircmp):

--- a/src/plugincode/output.py
+++ b/src/plugincode/output.py
@@ -94,7 +94,8 @@ class OutputPlugin(CodebasePlugin):
         """
         # FIXME: serialization SHOULD NOT be needed: only some format need it
         # (e.g. JSON) and only these should serialize
-        serializer = partial(Resource.to_dict, with_info=info, with_timing=timing)
+        with_info = info or getattr(codebase, 'with_info', False)
+        serializer = partial(Resource.to_dict, with_info=with_info, with_timing=timing)
         resources = codebase.walk_filtered(topdown=True, skip_root=strip_root)
         return imap(serializer, resources)
 

--- a/tests/extractcode/test_archive.py
+++ b/tests/extractcode/test_archive.py
@@ -359,6 +359,25 @@ class TestSmokeTest(FileBasedTesting):
 class BaseArchiveTestCase(FileBasedTesting):
     test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
+    def assertRaisesInstance(self, excInstance, callableObj,
+                                 *args, **kwargs):
+        """
+        This assertion accepts an instance instead of a class for refined
+        exception testing.
+        """
+        excClass = excInstance.__class__
+        try:
+            callableObj(*args, **kwargs)
+        except excClass, e:
+            self.assertEqual(str(excInstance), str(e))
+        else:
+            if hasattr(excClass, '__name__'):
+                excName = excClass.__name__
+            else:
+                excName = str(excClass)
+            raise self.failureException('%s not raised' % excName)
+
+
     def check_extract(self, test_function, test_file, expected, expected_warnings=None, check_all=False):
         """
         Run the extraction `test_function` on `test_file` checking that a map of

--- a/tests/scancode/data/resource/virtual_idempotent/codebase.json
+++ b/tests/scancode/data/resource/virtual_idempotent/codebase.json
@@ -1,0 +1,5610 @@
+{
+  "scancode_notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+  "scancode_version": "2.9.2.post270.4c423cfe5",
+  "scancode_options": {
+    "input": "samples/",
+    "--classify": true,
+    "--copyright": true,
+    "--email": true,
+    "--facet": [
+      "dev=FOOBAR"
+    ],
+    "--generated": true,
+    "--info": true,
+    "--json-pp": "scan.json",
+    "--license": true,
+    "--license-diag": true,
+    "--license-text": true,
+    "--package": true,
+    "--processes": "3",
+    "--summary-with-details": true,
+    "--url": true
+  },
+  "scan_start": "2018-07-30T124651.745759",
+  "files_count": 33,
+  "summary": {
+    "license_expressions": [
+      {
+        "value": "zlib",
+        "count": 10
+      },
+      {
+        "value": null,
+        "count": 7
+      },
+      {
+        "value": "lgpl-2.1-plus",
+        "count": 5
+      },
+      {
+        "value": "boost-1.0",
+        "count": 3
+      },
+      {
+        "value": "public-domain",
+        "count": 2
+      },
+      {
+        "value": "apache-1.1",
+        "count": 1
+      },
+      {
+        "value": "apache-2.0",
+        "count": 1
+      },
+      {
+        "value": "cc-by-2.5",
+        "count": 1
+      },
+      {
+        "value": "cmr-no",
+        "count": 1
+      },
+      {
+        "value": "cpl-1.0",
+        "count": 1
+      },
+      {
+        "value": "gpl-2.0-plus WITH ada-linking-exception",
+        "count": 1
+      },
+      {
+        "value": "jboss-eula",
+        "count": 1
+      },
+      {
+        "value": "mit",
+        "count": 1
+      }
+    ],
+    "copyrights": [
+      {
+        "value": null,
+        "count": 10
+      },
+      {
+        "value": "Copyright (c) Jean-loup Gailly",
+        "count": 3
+      },
+      {
+        "value": "Copyright (c) Jean-loup Gailly and Mark Adler",
+        "count": 3
+      },
+      {
+        "value": "Copyright (c) Mark Adler",
+        "count": 3
+      },
+      {
+        "value": "(c) Copyright Henrik Ravn",
+        "count": 2
+      },
+      {
+        "value": "Copyright (c) Free Software Foundation, Inc.",
+        "count": 2
+      },
+      {
+        "value": "copyrighted by the Free Software Foundation",
+        "count": 2
+      },
+      {
+        "value": "Copyright (c) - The Legion Of The Bouncy Castle (http://www.bouncycastle.org)",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) Brian Goetz and Tim Peierls",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) Christian Michelsen Research AS Advanced Computing",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) Dmitriy Anisimkov",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) The Apache Software Foundation.",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) by Henrik Ravn",
+        "count": 1
+      },
+      {
+        "value": "Copyright JBoss Inc., and individual contributors",
+        "count": 1
+      },
+      {
+        "value": "Copyright Red Hat Middleware LLC, and individual contributors",
+        "count": 1
+      },
+      {
+        "value": "Copyright Red Hat, Inc.",
+        "count": 1
+      },
+      {
+        "value": "Copyright Red Hat, Inc. and individual contributors",
+        "count": 1
+      }
+    ],
+    "holders": [
+      {
+        "value": null,
+        "count": 10
+      },
+      {
+        "value": "Free Software Foundation, Inc.",
+        "count": 4
+      },
+      {
+        "value": "Henrik Ravn",
+        "count": 3
+      },
+      {
+        "value": "Jean-loup Gailly",
+        "count": 3
+      },
+      {
+        "value": "Jean-loup Gailly and Mark Adler",
+        "count": 3
+      },
+      {
+        "value": "Mark Adler",
+        "count": 3
+      },
+      {
+        "value": "Brian Goetz and Tim Peierls",
+        "count": 1
+      },
+      {
+        "value": "Christian Michelsen Research AS Advanced Computing",
+        "count": 1
+      },
+      {
+        "value": "Dmitriy Anisimkov",
+        "count": 1
+      },
+      {
+        "value": "JBoss Inc., and individual contributors",
+        "count": 1
+      },
+      {
+        "value": "Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+        "count": 1
+      },
+      {
+        "value": "Red Hat Middleware LLC, and individual contributors",
+        "count": 1
+      },
+      {
+        "value": "Red Hat, Inc.",
+        "count": 1
+      },
+      {
+        "value": "Red Hat, Inc. and individual contributors",
+        "count": 1
+      },
+      {
+        "value": "The Apache Software Foundation.",
+        "count": 1
+      },
+      {
+        "value": "The Legion Of The Bouncy Castle",
+        "count": 1
+      }
+    ],
+    "authors": [
+      {
+        "value": null,
+        "count": 24
+      },
+      {
+        "value": "Bela Ban",
+        "count": 4
+      },
+      {
+        "value": "Brian Stansberry",
+        "count": 1
+      },
+      {
+        "value": "Chris Mills (millsy@jboss.com)",
+        "count": 1
+      },
+      {
+        "value": "Gilles Vollant",
+        "count": 1
+      },
+      {
+        "value": "Leonid Broukhis.",
+        "count": 1
+      },
+      {
+        "value": "Robert Harder",
+        "count": 1
+      },
+      {
+        "value": "rob@iharder.net",
+        "count": 1
+      },
+      {
+        "value": "the Apache Software Foundation (http://www.apache.org/).",
+        "count": 1
+      }
+    ],
+    "programming_language": [
+      {
+        "value": null,
+        "count": 11
+      },
+      {
+        "value": "C",
+        "count": 9
+      },
+      {
+        "value": "Java",
+        "count": 7
+      },
+      {
+        "value": "C#",
+        "count": 2
+      },
+      {
+        "value": "Ada",
+        "count": 1
+      },
+      {
+        "value": "C++",
+        "count": 1
+      },
+      {
+        "value": "GAS",
+        "count": 1
+      },
+      {
+        "value": "JavaScript+Lasso",
+        "count": 1
+      }
+    ]
+  },
+  "files": [
+    {
+      "path": "samples",
+      "type": "directory",
+      "name": "samples",
+      "base_name": "samples",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": true,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 10
+          },
+          {
+            "value": null,
+            "count": 7
+          },
+          {
+            "value": "lgpl-2.1-plus",
+            "count": 5
+          },
+          {
+            "value": "boost-1.0",
+            "count": 3
+          },
+          {
+            "value": "public-domain",
+            "count": 2
+          },
+          {
+            "value": "apache-1.1",
+            "count": 1
+          },
+          {
+            "value": "apache-2.0",
+            "count": 1
+          },
+          {
+            "value": "cc-by-2.5",
+            "count": 1
+          },
+          {
+            "value": "cmr-no",
+            "count": 1
+          },
+          {
+            "value": "cpl-1.0",
+            "count": 1
+          },
+          {
+            "value": "gpl-2.0-plus WITH ada-linking-exception",
+            "count": 1
+          },
+          {
+            "value": "jboss-eula",
+            "count": 1
+          },
+          {
+            "value": "mit",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 10
+          },
+          {
+            "value": "Copyright (c) Jean-loup Gailly",
+            "count": 3
+          },
+          {
+            "value": "Copyright (c) Jean-loup Gailly and Mark Adler",
+            "count": 3
+          },
+          {
+            "value": "Copyright (c) Mark Adler",
+            "count": 3
+          },
+          {
+            "value": "(c) Copyright Henrik Ravn",
+            "count": 2
+          },
+          {
+            "value": "Copyright (c) Free Software Foundation, Inc.",
+            "count": 2
+          },
+          {
+            "value": "copyrighted by the Free Software Foundation",
+            "count": 2
+          },
+          {
+            "value": "Copyright (c) - The Legion Of The Bouncy Castle (http://www.bouncycastle.org)",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) Brian Goetz and Tim Peierls",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) Christian Michelsen Research AS Advanced Computing",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) Dmitriy Anisimkov",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) The Apache Software Foundation.",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) by Henrik Ravn",
+            "count": 1
+          },
+          {
+            "value": "Copyright JBoss Inc., and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Copyright Red Hat Middleware LLC, and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Copyright Red Hat, Inc.",
+            "count": 1
+          },
+          {
+            "value": "Copyright Red Hat, Inc. and individual contributors",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 10
+          },
+          {
+            "value": "Free Software Foundation, Inc.",
+            "count": 4
+          },
+          {
+            "value": "Henrik Ravn",
+            "count": 3
+          },
+          {
+            "value": "Jean-loup Gailly",
+            "count": 3
+          },
+          {
+            "value": "Jean-loup Gailly and Mark Adler",
+            "count": 3
+          },
+          {
+            "value": "Mark Adler",
+            "count": 3
+          },
+          {
+            "value": "Brian Goetz and Tim Peierls",
+            "count": 1
+          },
+          {
+            "value": "Christian Michelsen Research AS Advanced Computing",
+            "count": 1
+          },
+          {
+            "value": "Dmitriy Anisimkov",
+            "count": 1
+          },
+          {
+            "value": "JBoss Inc., and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+            "count": 1
+          },
+          {
+            "value": "Red Hat Middleware LLC, and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Red Hat, Inc.",
+            "count": 1
+          },
+          {
+            "value": "Red Hat, Inc. and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "The Apache Software Foundation.",
+            "count": 1
+          },
+          {
+            "value": "The Legion Of The Bouncy Castle",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 24
+          },
+          {
+            "value": "Bela Ban",
+            "count": 4
+          },
+          {
+            "value": "Brian Stansberry",
+            "count": 1
+          },
+          {
+            "value": "Chris Mills (millsy@jboss.com)",
+            "count": 1
+          },
+          {
+            "value": "Gilles Vollant",
+            "count": 1
+          },
+          {
+            "value": "Leonid Broukhis.",
+            "count": 1
+          },
+          {
+            "value": "Robert Harder",
+            "count": 1
+          },
+          {
+            "value": "rob@iharder.net",
+            "count": 1
+          },
+          {
+            "value": "the Apache Software Foundation (http://www.apache.org/).",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 11
+          },
+          {
+            "value": "C",
+            "count": 9
+          },
+          {
+            "value": "Java",
+            "count": 7
+          },
+          {
+            "value": "C#",
+            "count": 2
+          },
+          {
+            "value": "Ada",
+            "count": 1
+          },
+          {
+            "value": "C++",
+            "count": 1
+          },
+          {
+            "value": "GAS",
+            "count": 1
+          },
+          {
+            "value": "JavaScript+Lasso",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 33,
+      "dirs_count": 10,
+      "size_count": 1161083,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/README",
+      "type": "file",
+      "name": "README",
+      "base_name": "README",
+      "extension": "",
+      "size": 236,
+      "date": "2017-10-26",
+      "sha1": "2e07e32c52d607204fad196052d70e3d18fb8636",
+      "md5": "effc6856ef85a9250fb1a470792b3f38",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://zlib.net/zlib-1.2.8.tar.gz",
+          "start_line": 3,
+          "end_line": 3
+        },
+        {
+          "url": "http://master.dl.sourceforge.net/project/javagroups/JGroups/2.10.0.GA/JGroups-2.10.0.GA.src.zip",
+          "start_line": 4,
+          "end_line": 4
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": true,
+      "is_top_level": true,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/screenshot.png",
+      "type": "file",
+      "name": "screenshot.png",
+      "base_name": "screenshot",
+      "extension": ".png",
+      "size": 622754,
+      "date": "2017-10-26",
+      "sha1": "01ff4b1de0bc6c75c9cca6e46c80c1802d6976d4",
+      "md5": "b6ef5a90777147423c98b42a6a25e57a",
+      "mime_type": "image/png",
+      "file_type": "PNG image data, 2880 x 1666, 8-bit/color RGB, non-interlaced",
+      "programming_language": null,
+      "is_binary": true,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": true,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": true,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/arch",
+      "type": "directory",
+      "name": "arch",
+      "base_name": "arch",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": true,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 1,
+      "dirs_count": 0,
+      "size_count": 28103,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/arch/zlib.tar.gz",
+      "type": "file",
+      "name": "zlib.tar.gz",
+      "base_name": "zlib",
+      "extension": ".tar.gz",
+      "size": 28103,
+      "date": "2017-10-26",
+      "sha1": "576f0ccfe534d7f5ff5d6400078d3c6586de3abd",
+      "md5": "20b2370751abfc08bb3556c1d8114b5a",
+      "mime_type": "application/x-gzip",
+      "file_type": "gzip compressed data, last modified: Wed Jul 15 09:08:19 2015, from Unix",
+      "programming_language": null,
+      "is_binary": true,
+      "is_text": false,
+      "is_archive": true,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": {
+        "type": "tarball",
+        "namespace": null,
+        "name": null,
+        "version": null,
+        "qualifiers": null,
+        "subpath": null,
+        "primary_language": null,
+        "code_type": null,
+        "description": null,
+        "size": null,
+        "release_date": null,
+        "parties": [],
+        "keywords": [],
+        "homepage_url": null,
+        "download_url": null,
+        "download_checksums": [],
+        "bug_tracking_url": null,
+        "code_view_url": null,
+        "vcs_tool": null,
+        "vcs_repository": null,
+        "vcs_revision": null,
+        "copyright": null,
+        "license_expression": null,
+        "declared_licensing": null,
+        "notice_text": null,
+        "dependencies": [],
+        "related_packages": []
+      },
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [
+        {
+          "type": "tarball",
+          "namespace": null,
+          "name": null,
+          "version": null,
+          "qualifiers": null,
+          "subpath": null,
+          "primary_language": null,
+          "code_type": null,
+          "description": null,
+          "size": null,
+          "release_date": null,
+          "parties": [],
+          "keywords": [],
+          "homepage_url": null,
+          "download_url": null,
+          "download_checksums": [],
+          "bug_tracking_url": null,
+          "code_view_url": null,
+          "vcs_tool": null,
+          "vcs_repository": null,
+          "vcs_revision": null,
+          "copyright": null,
+          "license_expression": null,
+          "declared_licensing": null,
+          "notice_text": null,
+          "dependencies": [],
+          "related_packages": []
+        }
+      ],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups",
+      "type": "directory",
+      "name": "JGroups",
+      "base_name": "JGroups",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": true,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "lgpl-2.1-plus",
+            "count": 5
+          },
+          {
+            "value": null,
+            "count": 2
+          },
+          {
+            "value": "public-domain",
+            "count": 2
+          },
+          {
+            "value": "apache-1.1",
+            "count": 1
+          },
+          {
+            "value": "apache-2.0",
+            "count": 1
+          },
+          {
+            "value": "cc-by-2.5",
+            "count": 1
+          },
+          {
+            "value": "cpl-1.0",
+            "count": 1
+          },
+          {
+            "value": "jboss-eula",
+            "count": 1
+          },
+          {
+            "value": "mit",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 5
+          },
+          {
+            "value": "Copyright (c) Free Software Foundation, Inc.",
+            "count": 2
+          },
+          {
+            "value": "copyrighted by the Free Software Foundation",
+            "count": 2
+          },
+          {
+            "value": "Copyright (c) - The Legion Of The Bouncy Castle (http://www.bouncycastle.org)",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) Brian Goetz and Tim Peierls",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) The Apache Software Foundation.",
+            "count": 1
+          },
+          {
+            "value": "Copyright JBoss Inc., and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Copyright Red Hat Middleware LLC, and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Copyright Red Hat, Inc.",
+            "count": 1
+          },
+          {
+            "value": "Copyright Red Hat, Inc. and individual contributors",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 5
+          },
+          {
+            "value": "Free Software Foundation, Inc.",
+            "count": 4
+          },
+          {
+            "value": "Brian Goetz and Tim Peierls",
+            "count": 1
+          },
+          {
+            "value": "JBoss Inc., and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Red Hat Middleware LLC, and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Red Hat, Inc.",
+            "count": 1
+          },
+          {
+            "value": "Red Hat, Inc. and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "The Apache Software Foundation.",
+            "count": 1
+          },
+          {
+            "value": "The Legion Of The Bouncy Castle",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 7
+          },
+          {
+            "value": "Bela Ban",
+            "count": 4
+          },
+          {
+            "value": "Brian Stansberry",
+            "count": 1
+          },
+          {
+            "value": "Chris Mills (millsy@jboss.com)",
+            "count": 1
+          },
+          {
+            "value": "Robert Harder",
+            "count": 1
+          },
+          {
+            "value": "rob@iharder.net",
+            "count": 1
+          },
+          {
+            "value": "the Apache Software Foundation (http://www.apache.org/).",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "Java",
+            "count": 7
+          },
+          {
+            "value": null,
+            "count": 6
+          },
+          {
+            "value": "JavaScript+Lasso",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 14,
+      "dirs_count": 2,
+      "size_count": 241228,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/EULA",
+      "type": "file",
+      "name": "EULA",
+      "base_name": "EULA",
+      "extension": "",
+      "size": 8156,
+      "date": "2017-10-26",
+      "sha1": "eb232aa0424eca9c4136904e6143b72aaa9cf4de",
+      "md5": "0be0aceb8296727efff0ac0bf8e6bdb3",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "JavaScript+Lasso",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "jboss-eula",
+          "score": 100.0,
+          "short_name": "JBoss EULA",
+          "category": "Proprietary Free",
+          "owner": "JBoss Community",
+          "homepage_url": "",
+          "text_url": "http://repository.jboss.org/licenses/jbossorg-eula.txt",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:jboss-eula",
+          "spdx_license_key": "",
+          "spdx_url": "",
+          "start_line": 3,
+          "end_line": 108,
+          "matched_rule": {
+            "identifier": "jboss-eula.LICENSE",
+            "license_expression": "jboss-eula",
+            "licenses": [
+              "jboss-eula"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 1300,
+            "matched_length": 1300,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "LICENSE AGREEMENT\nJBOSS(r)\n\nThis License Agreement governs the use of the Software Packages and any updates to the Software \nPackages, regardless of the delivery mechanism.  Each Software Package is a collective work \nunder U.S. Copyright Law.  Subject to the following terms, Red Hat, Inc. (\"Red Hat\") grants to \nthe user (\"Client\") a license to the applicable collective work(s) pursuant to the \nGNU Lesser General Public License v. 2.1 except for the following Software Packages: \n(a) JBoss Portal Forums and JBoss Transactions JTS, each of which is licensed pursuant to the \nGNU General Public License v.2; \n\n(b) JBoss Rules, which is licensed pursuant to the Apache  License v.2.0;\n\n(c) an optional download for JBoss Cache for the Berkeley DB for Java database, which is licensed under the \n(open source) Sleepycat License (if Client does not wish to use the open source version of this database, \nit may purchase a license from Sleepycat Software); \n\nand (d) the BPEL extension for JBoss jBPM, which is licensed under the Common Public License v.1, \nand, pursuant to the OASIS BPEL4WS standard, requires parties wishing to redistribute to enter various \nroyalty-free patent licenses.  \n\nEach of the foregoing licenses is available at http://www.opensource.org/licenses/index.php.\n\n1.  The Software.  \"Software Packages\" refer to the various software modules that are created and made available \nfor distribution by the JBoss.org open source community at http://www.jboss.org.   Each of the Software Packages \nmay be comprised of hundreds of software components.  The end user license agreement for each component is located in \nthe component's source code.  With the exception of certain image files identified in Section 2 below, \nthe license terms for the components permit Client to copy, modify, and redistribute the component, \nin both source code and binary code forms.  This agreement does not limit Client's rights under, \nor grant Client rights that supersede, the license terms of any particular component.\n\n2.  Intellectual Property Rights.  The Software Packages are owned by Red Hat and others and are protected under copyright \nand other laws.  Title to the Software Packages and any component, or to any copy, modification, or merged portion shall \nremain with the aforementioned, subject to the applicable license.  The \"JBoss\" trademark, \"Red Hat\" trademark, the \nindividual Software Package trademarks, and the \"Shadowman\" logo are registered trademarks of Red Hat and its affiliates \nin the U.S. and other countries.  This agreement permits Client to distribute unmodified copies of the Software Packages \nusing the Red Hat trademarks that Red Hat has inserted in the Software Packages on the condition that Client follows Red Hat's \ntrademark guidelines for those trademarks located at http://www.redhat.com/about/corporate/trademark/.  Client must abide by \nthese trademark guidelines when distributing the Software Packages, regardless of whether the Software Packages have been modified. \nIf Client modifies the Software Packages, then Client must replace all Red Hat trademarks and logos identified at \nhttp://www.jboss.com/company/logos, unless a separate agreement with Red Hat is executed or other permission granted.  \nMerely deleting the files containing the Red Hat trademarks may corrupt the Software Packages.  \n\n3.  Limited Warranty.  Except as specifically stated in this Paragraph 3 or a license for a particular \ncomponent, to the maximum extent permitted under applicable law, the Software Packages and the \ncomponents are provided and licensed \"as is\" without warranty of any kind, expressed or implied, \nincluding the implied warranties of merchantability, non-infringement or fitness for a particular purpose.  \nRed Hat warrants that the media on which Software Packages may be furnished will be free from defects in \nmaterials and manufacture under normal use for a period of 30 days from the date of delivery to Client.  \nRed Hat does not warrant that the functions contained in the Software Packages will meet Client's requirements \nor that the operation of the Software Packages will be entirely error free or appear precisely as described \nin the accompanying documentation. This warranty extends only to the party that purchases the Services \npertaining to the Software Packages from Red Hat or a Red Hat authorized distributor. \n\n4.  Limitation of Remedies and Liability. To the maximum extent permitted by applicable law, the remedies \ndescribed below are accepted by Client as its only remedies.  Red Hat's entire liability, and Client's \nexclusive remedies, shall be: If the Software media is defective, Client may return it within 30 days of \ndelivery along with a copy of Client's payment receipt and Red Hat, at its option, will replace it or \nrefund the money paid by Client for the Software.  To the maximum extent permitted by applicable law, \nRed Hat or any Red Hat authorized dealer will not be liable to Client for any incidental or consequential \ndamages, including lost profits or lost savings arising out of the use or inability to use the Software, \neven if Red Hat or such dealer has been advised of the possibility of such damages.  In no event shall \nRed Hat's liability under this agreement exceed the amount that Client paid to Red Hat under this \nAgreement during the twelve months preceding the action.\n\n5.  Export Control.  As required by U.S. law, Client represents and warrants that it: \n(a) understands that the Software Packages are subject to export controls under the \nU.S. Commerce Department's Export Administration Regulations (\"EAR\"); \n\n(b) is not located in a prohibited destination country under the EAR or U.S. sanctions regulations \n(currently Cuba, Iran, Iraq, Libya, North Korea, Sudan and Syria); \n\n(c) will not export, re-export, or transfer the Software Packages to any prohibited destination, entity, \nor individual without the necessary export license(s) or authorizations(s) from the U.S. Government; \n\n(d) will not use or transfer the Software Packages for use in any sensitive nuclear, chemical or \nbiological weapons, or missile technology end-uses unless authorized by the U.S. Government by \nregulation or specific license; \n\n(e) understands and agrees that if it is in the United States and exports or transfers the Software \nPackages to eligible end users, it will, as required by EAR Section 740.17(e), submit semi-annual \nreports to the Commerce Department's Bureau of Industry & Security (BIS), which include the name and \naddress (including country) of each transferee; \n\nand (f) understands that countries other than the United States may restrict the import, use, or \nexport of encryption products and that it shall be solely responsible for compliance with any such \nimport, use, or export restrictions.\n\n6.  Third Party Programs. Red Hat may distribute third party software programs with the Software Packages \nthat are not part of the Software Packages and which Client must install separately.  These third party \nprograms are subject to their own license terms.  The license terms either accompany the programs or \ncan be viewed at http://www.redhat.com/licenses/.  If Client does not agree to abide by the applicable \nlicense terms for such programs, then Client may not install them.  If Client wishes to install the programs \non more than one system or transfer the programs to another party, then Client must contact the licensor \nof the programs.\n\n7.  General.  If any provision of this agreement is held to be unenforceable, that shall not affect the \nenforceability of the remaining provisions.  This License Agreement shall be governed by the laws of the \nState of North Carolina and of the United States, without regard to any conflict of laws provisions, \nexcept that the United Nations Convention on the International Sale of Goods shall not apply.\n\nCopyright 2006 Red Hat, Inc.  All rights reserved.  \n\"JBoss\" and the JBoss logo are registered trademarks of Red Hat, Inc.  \nAll other trademarks are the property of their respective owners. \n\n\tPage 1 of 1\t18 October 2006"
+        }
+      ],
+      "license_expressions": [
+        "jboss-eula"
+      ],
+      "holders": [
+        {
+          "value": "Red Hat, Inc.",
+          "start_line": 104,
+          "end_line": 104
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright 2006 Red Hat, Inc.",
+          "start_line": 104,
+          "end_line": 104
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://www.opensource.org/licenses/index.php",
+          "start_line": 24,
+          "end_line": 24
+        },
+        {
+          "url": "http://www.jboss.org/",
+          "start_line": 27,
+          "end_line": 27
+        },
+        {
+          "url": "http://www.redhat.com/about/corporate/trademark",
+          "start_line": 40,
+          "end_line": 40
+        },
+        {
+          "url": "http://www.jboss.com/company/logos",
+          "start_line": 43,
+          "end_line": 43
+        },
+        {
+          "url": "http://www.redhat.com/licenses",
+          "start_line": 94,
+          "end_line": 94
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": true,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "jboss-eula",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright Red Hat, Inc.",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Red Hat, Inc.",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "JavaScript+Lasso",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/LICENSE",
+      "type": "file",
+      "name": "LICENSE",
+      "base_name": "LICENSE",
+      "extension": "",
+      "size": 26430,
+      "date": "2017-10-26",
+      "sha1": "e60c2e780886f95df9c9ee36992b8edabec00bcc",
+      "md5": "7fbc338309ac38fefcd64b04bb903e34",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "lgpl-2.1-plus",
+          "score": 100.0,
+          "short_name": "LGPL 2.1 or later",
+          "category": "Copyleft Limited",
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:lgpl-2.1-plus",
+          "spdx_license_key": "LGPL-2.1-or-later",
+          "spdx_url": "https://spdx.org/licenses/LGPL-2.1-or-later",
+          "start_line": 1,
+          "end_line": 502,
+          "matched_rule": {
+            "identifier": "lgpl-2.1-plus_2.RULE",
+            "license_expression": "lgpl-2.1-plus",
+            "licenses": [
+              "lgpl-2.1-plus"
+            ],
+            "matcher": "1-hash",
+            "rule_length": 4415,
+            "matched_length": 4415,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "GNU LESSER GENERAL PUBLIC LICENSE\n\t\t       Version 2.1, February 1999\n\n Copyright (C) 1991, 1999 Free Software Foundation, Inc.\n     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA\n Everyone is permitted to copy and distribute verbatim copies\n of this license document, but changing it is not allowed.\n\n[This is the first released version of the Lesser GPL.  It also counts\n as the successor of the GNU Library Public License, version 2, hence\n the version number 2.1.]\n\n\t\t\t    Preamble\n\n  The licenses for most software are designed to take away your\nfreedom to share and change it.  By contrast, the GNU General Public\nLicenses are intended to guarantee your freedom to share and change\nfree software--to make sure the software is free for all its users.\n\n  This license, the Lesser General Public License, applies to some\nspecially designated software packages--typically libraries--of the\nFree Software Foundation and other authors who decide to use it.  You\ncan use it too, but we suggest you first think carefully about whether\nthis license or the ordinary General Public License is the better\nstrategy to use in any particular case, based on the explanations below.\n\n  When we speak of free software, we are referring to freedom of use,\nnot price.  Our General Public Licenses are designed to make sure that\nyou have the freedom to distribute copies of free software (and charge\nfor this service if you wish); that you receive source code or can get\nit if you want it; that you can change the software and use pieces of\nit in new free programs; and that you are informed that you can do\nthese things.\n\n  To protect your rights, we need to make restrictions that forbid\ndistributors to deny you these rights or to ask you to surrender these\nrights.  These restrictions translate to certain responsibilities for\nyou if you distribute copies of the library or if you modify it.\n\n  For example, if you distribute copies of the library, whether gratis\nor for a fee, you must give the recipients all the rights that we gave\nyou.  You must make sure that they, too, receive or can get the source\ncode.  If you link other code with the library, you must provide\ncomplete object files to the recipients, so that they can relink them\nwith the library after making changes to the library and recompiling\nit.  And you must show them these terms so they know their rights.\n\n  We protect your rights with a two-step method: (1) we copyright the\nlibrary, and (2) we offer you this license, which gives you legal\npermission to copy, distribute and/or modify the library.\n\n  To protect each distributor, we want to make it very clear that\nthere is no warranty for the free library.  Also, if the library is\nmodified by someone else and passed on, the recipients should know\nthat what they have is not the original version, so that the original\nauthor's reputation will not be affected by problems that might be\nintroduced by others.\n\f\n  Finally, software patents pose a constant threat to the existence of\nany free program.  We wish to make sure that a company cannot\neffectively restrict the users of a free program by obtaining a\nrestrictive license from a patent holder.  Therefore, we insist that\nany patent license obtained for a version of the library must be\nconsistent with the full freedom of use specified in this license.\n\n  Most GNU software, including some libraries, is covered by the\nordinary GNU General Public License.  This license, the GNU Lesser\nGeneral Public License, applies to certain designated libraries, and\nis quite different from the ordinary General Public License.  We use\nthis license for certain libraries in order to permit linking those\nlibraries into non-free programs.\n\n  When a program is linked with a library, whether statically or using\na shared library, the combination of the two is legally speaking a\ncombined work, a derivative of the original library.  The ordinary\nGeneral Public License therefore permits such linking only if the\nentire combination fits its criteria of freedom.  The Lesser General\nPublic License permits more lax criteria for linking other code with\nthe library.\n\n  We call this license the \"Lesser\" General Public License because it\ndoes Less to protect the user's freedom than the ordinary General\nPublic License.  It also provides other free software developers Less\nof an advantage over competing non-free programs.  These disadvantages\nare the reason we use the ordinary General Public License for many\nlibraries.  However, the Lesser license provides advantages in certain\nspecial circumstances.\n\n  For example, on rare occasions, there may be a special need to\nencourage the widest possible use of a certain library, so that it becomes\na de-facto standard.  To achieve this, non-free programs must be\nallowed to use the library.  A more frequent case is that a free\nlibrary does the same job as widely used non-free libraries.  In this\ncase, there is little to gain by limiting the free library to free\nsoftware only, so we use the Lesser General Public License.\n\n  In other cases, permission to use a particular library in non-free\nprograms enables a greater number of people to use a large body of\nfree software.  For example, permission to use the GNU C Library in\nnon-free programs enables many more people to use the whole GNU\noperating system, as well as its variant, the GNU/Linux operating\nsystem.\n\n  Although the Lesser General Public License is Less protective of the\nusers' freedom, it does ensure that the user of a program that is\nlinked with the Library has the freedom and the wherewithal to run\nthat program using a modified version of the Library.\n\n  The precise terms and conditions for copying, distribution and\nmodification follow.  Pay close attention to the difference between a\n\"work based on the library\" and a \"work that uses the library\".  The\nformer contains code derived from the library, whereas the latter must\nbe combined with the library in order to run.\n\f\n\t\t  GNU LESSER GENERAL PUBLIC LICENSE\n   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION\n\n  0. This License Agreement applies to any software library or other\nprogram which contains a notice placed by the copyright holder or\nother authorized party saying it may be distributed under the terms of\nthis Lesser General Public License (also called \"this License\").\nEach licensee is addressed as \"you\".\n\n  A \"library\" means a collection of software functions and/or data\nprepared so as to be conveniently linked with application programs\n(which use some of those functions and data) to form executables.\n\n  The \"Library\", below, refers to any such software library or work\nwhich has been distributed under these terms.  A \"work based on the\nLibrary\" means either the Library or any derivative work under\ncopyright law: that is to say, a work containing the Library or a\nportion of it, either verbatim or with modifications and/or translated\nstraightforwardly into another language.  (Hereinafter, translation is\nincluded without limitation in the term \"modification\".)\n\n  \"Source code\" for a work means the preferred form of the work for\nmaking modifications to it.  For a library, complete source code means\nall the source code for all modules it contains, plus any associated\ninterface definition files, plus the scripts used to control compilation\nand installation of the library.\n\n  Activities other than copying, distribution and modification are not\ncovered by this License; they are outside its scope.  The act of\nrunning a program using the Library is not restricted, and output from\nsuch a program is covered only if its contents constitute a work based\non the Library (independent of the use of the Library in a tool for\nwriting it).  Whether that is true depends on what the Library does\nand what the program that uses the Library does.\n  \n  1. You may copy and distribute verbatim copies of the Library's\ncomplete source code as you receive it, in any medium, provided that\nyou conspicuously and appropriately publish on each copy an\nappropriate copyright notice and disclaimer of warranty; keep intact\nall the notices that refer to this License and to the absence of any\nwarranty; and distribute a copy of this License along with the\nLibrary.\n\n  You may charge a fee for the physical act of transferring a copy,\nand you may at your option offer warranty protection in exchange for a\nfee.\n\f\n  2. You may modify your copy or copies of the Library or any portion\nof it, thus forming a work based on the Library, and copy and\ndistribute such modifications or work under the terms of Section 1\nabove, provided that you also meet all of these conditions:\n\n    a) The modified work must itself be a software library.\n\n    b) You must cause the files modified to carry prominent notices\n    stating that you changed the files and the date of any change.\n\n    c) You must cause the whole of the work to be licensed at no\n    charge to all third parties under the terms of this License.\n\n    d) If a facility in the modified Library refers to a function or a\n    table of data to be supplied by an application program that uses\n    the facility, other than as an argument passed when the facility\n    is invoked, then you must make a good faith effort to ensure that,\n    in the event an application does not supply such function or\n    table, the facility still operates, and performs whatever part of\n    its purpose remains meaningful.\n\n    (For example, a function in a library to compute square roots has\n    a purpose that is entirely well-defined independent of the\n    application.  Therefore, Subsection 2d requires that any\n    application-supplied function or table used by this function must\n    be optional: if the application does not supply it, the square\n    root function must still compute square roots.)\n\nThese requirements apply to the modified work as a whole.  If\nidentifiable sections of that work are not derived from the Library,\nand can be reasonably considered independent and separate works in\nthemselves, then this License, and its terms, do not apply to those\nsections when you distribute them as separate works.  But when you\ndistribute the same sections as part of a whole which is a work based\non the Library, the distribution of the whole must be on the terms of\nthis License, whose permissions for other licensees extend to the\nentire whole, and thus to each and every part regardless of who wrote\nit.\n\nThus, it is not the intent of this section to claim rights or contest\nyour rights to work written entirely by you; rather, the intent is to\nexercise the right to control the distribution of derivative or\ncollective works based on the Library.\n\nIn addition, mere aggregation of another work not based on the Library\nwith the Library (or with a work based on the Library) on a volume of\na storage or distribution medium does not bring the other work under\nthe scope of this License.\n\n  3. You may opt to apply the terms of the ordinary GNU General Public\nLicense instead of this License to a given copy of the Library.  To do\nthis, you must alter all the notices that refer to this License, so\nthat they refer to the ordinary GNU General Public License, version 2,\ninstead of to this License.  (If a newer version than version 2 of the\nordinary GNU General Public License has appeared, then you can specify\nthat version instead if you wish.)  Do not make any other change in\nthese notices.\n\f\n  Once this change is made in a given copy, it is irreversible for\nthat copy, so the ordinary GNU General Public License applies to all\nsubsequent copies and derivative works made from that copy.\n\n  This option is useful when you wish to copy part of the code of\nthe Library into a program that is not a library.\n\n  4. You may copy and distribute the Library (or a portion or\nderivative of it, under Section 2) in object code or executable form\nunder the terms of Sections 1 and 2 above provided that you accompany\nit with the complete corresponding machine-readable source code, which\nmust be distributed under the terms of Sections 1 and 2 above on a\nmedium customarily used for software interchange.\n\n  If distribution of object code is made by offering access to copy\nfrom a designated place, then offering equivalent access to copy the\nsource code from the same place satisfies the requirement to\ndistribute the source code, even though third parties are not\ncompelled to copy the source along with the object code.\n\n  5. A program that contains no derivative of any portion of the\nLibrary, but is designed to work with the Library by being compiled or\nlinked with it, is called a \"work that uses the Library\".  Such a\nwork, in isolation, is not a derivative work of the Library, and\ntherefore falls outside the scope of this License.\n\n  However, linking a \"work that uses the Library\" with the Library\ncreates an executable that is a derivative of the Library (because it\ncontains portions of the Library), rather than a \"work that uses the\nlibrary\".  The executable is therefore covered by this License.\nSection 6 states terms for distribution of such executables.\n\n  When a \"work that uses the Library\" uses material from a header file\nthat is part of the Library, the object code for the work may be a\nderivative work of the Library even though the source code is not.\nWhether this is true is especially significant if the work can be\nlinked without the Library, or if the work is itself a library.  The\nthreshold for this to be true is not precisely defined by law.\n\n  If such an object file uses only numerical parameters, data\nstructure layouts and accessors, and small macros and small inline\nfunctions (ten lines or less in length), then the use of the object\nfile is unrestricted, regardless of whether it is legally a derivative\nwork.  (Executables containing this object code plus portions of the\nLibrary will still fall under Section 6.)\n\n  Otherwise, if the work is a derivative of the Library, you may\ndistribute the object code for the work under the terms of Section 6.\nAny executables containing that work also fall under Section 6,\nwhether or not they are linked directly with the Library itself.\n\f\n  6. As an exception to the Sections above, you may also combine or\nlink a \"work that uses the Library\" with the Library to produce a\nwork containing portions of the Library, and distribute that work\nunder terms of your choice, provided that the terms permit\nmodification of the work for the customer's own use and reverse\nengineering for debugging such modifications.\n\n  You must give prominent notice with each copy of the work that the\nLibrary is used in it and that the Library and its use are covered by\nthis License.  You must supply a copy of this License.  If the work\nduring execution displays copyright notices, you must include the\ncopyright notice for the Library among them, as well as a reference\ndirecting the user to the copy of this License.  Also, you must do one\nof these things:\n\n    a) Accompany the work with the complete corresponding\n    machine-readable source code for the Library including whatever\n    changes were used in the work (which must be distributed under\n    Sections 1 and 2 above); and, if the work is an executable linked\n    with the Library, with the complete machine-readable \"work that\n    uses the Library\", as object code and/or source code, so that the\n    user can modify the Library and then relink to produce a modified\n    executable containing the modified Library.  (It is understood\n    that the user who changes the contents of definitions files in the\n    Library will not necessarily be able to recompile the application\n    to use the modified definitions.)\n\n    b) Use a suitable shared library mechanism for linking with the\n    Library.  A suitable mechanism is one that (1) uses at run time a\n    copy of the library already present on the user's computer system,\n    rather than copying library functions into the executable, and (2)\n    will operate properly with a modified version of the library, if\n    the user installs one, as long as the modified version is\n    interface-compatible with the version that the work was made with.\n\n    c) Accompany the work with a written offer, valid for at\n    least three years, to give the same user the materials\n    specified in Subsection 6a, above, for a charge no more\n    than the cost of performing this distribution.\n\n    d) If distribution of the work is made by offering access to copy\n    from a designated place, offer equivalent access to copy the above\n    specified materials from the same place.\n\n    e) Verify that the user has already received a copy of these\n    materials or that you have already sent this user a copy.\n\n  For an executable, the required form of the \"work that uses the\nLibrary\" must include any data and utility programs needed for\nreproducing the executable from it.  However, as a special exception,\nthe materials to be distributed need not include anything that is\nnormally distributed (in either source or binary form) with the major\ncomponents (compiler, kernel, and so on) of the operating system on\nwhich the executable runs, unless that component itself accompanies\nthe executable.\n\n  It may happen that this requirement contradicts the license\nrestrictions of other proprietary libraries that do not normally\naccompany the operating system.  Such a contradiction means you cannot\nuse both them and the Library together in an executable that you\ndistribute.\n\f\n  7. You may place library facilities that are a work based on the\nLibrary side-by-side in a single library together with other library\nfacilities not covered by this License, and distribute such a combined\nlibrary, provided that the separate distribution of the work based on\nthe Library and of the other library facilities is otherwise\npermitted, and provided that you do these two things:\n\n    a) Accompany the combined library with a copy of the same work\n    based on the Library, uncombined with any other library\n    facilities.  This must be distributed under the terms of the\n    Sections above.\n\n    b) Give prominent notice with the combined library of the fact\n    that part of it is a work based on the Library, and explaining\n    where to find the accompanying uncombined form of the same work.\n\n  8. You may not copy, modify, sublicense, link with, or distribute\nthe Library except as expressly provided under this License.  Any\nattempt otherwise to copy, modify, sublicense, link with, or\ndistribute the Library is void, and will automatically terminate your\nrights under this License.  However, parties who have received copies,\nor rights, from you under this License will not have their licenses\nterminated so long as such parties remain in full compliance.\n\n  9. You are not required to accept this License, since you have not\nsigned it.  However, nothing else grants you permission to modify or\ndistribute the Library or its derivative works.  These actions are\nprohibited by law if you do not accept this License.  Therefore, by\nmodifying or distributing the Library (or any work based on the\nLibrary), you indicate your acceptance of this License to do so, and\nall its terms and conditions for copying, distributing or modifying\nthe Library or works based on it.\n\n  10. Each time you redistribute the Library (or any work based on the\nLibrary), the recipient automatically receives a license from the\noriginal licensor to copy, distribute, link with or modify the Library\nsubject to these terms and conditions.  You may not impose any further\nrestrictions on the recipients' exercise of the rights granted herein.\nYou are not responsible for enforcing compliance by third parties with\nthis License.\n\f\n  11. If, as a consequence of a court judgment or allegation of patent\ninfringement or for any other reason (not limited to patent issues),\nconditions are imposed on you (whether by court order, agreement or\notherwise) that contradict the conditions of this License, they do not\nexcuse you from the conditions of this License.  If you cannot\ndistribute so as to satisfy simultaneously your obligations under this\nLicense and any other pertinent obligations, then as a consequence you\nmay not distribute the Library at all.  For example, if a patent\nlicense would not permit royalty-free redistribution of the Library by\nall those who receive copies directly or indirectly through you, then\nthe only way you could satisfy both it and this License would be to\nrefrain entirely from distribution of the Library.\n\nIf any portion of this section is held invalid or unenforceable under any\nparticular circumstance, the balance of the section is intended to apply,\nand the section as a whole is intended to apply in other circumstances.\n\nIt is not the purpose of this section to induce you to infringe any\npatents or other property right claims or to contest validity of any\nsuch claims; this section has the sole purpose of protecting the\nintegrity of the free software distribution system which is\nimplemented by public license practices.  Many people have made\ngenerous contributions to the wide range of software distributed\nthrough that system in reliance on consistent application of that\nsystem; it is up to the author/donor to decide if he or she is willing\nto distribute software through any other system and a licensee cannot\nimpose that choice.\n\nThis section is intended to make thoroughly clear what is believed to\nbe a consequence of the rest of this License.\n\n  12. If the distribution and/or use of the Library is restricted in\ncertain countries either by patents or by copyrighted interfaces, the\noriginal copyright holder who places the Library under this License may add\nan explicit geographical distribution limitation excluding those countries,\nso that distribution is permitted only in or among countries not thus\nexcluded.  In such case, this License incorporates the limitation as if\nwritten in the body of this License.\n\n  13. The Free Software Foundation may publish revised and/or new\nversions of the Lesser General Public License from time to time.\nSuch new versions will be similar in spirit to the present version,\nbut may differ in detail to address new problems or concerns.\n\nEach version is given a distinguishing version number.  If the Library\nspecifies a version number of this License which applies to it and\n\"any later version\", you have the option of following the terms and\nconditions either of that version or of any later version published by\nthe Free Software Foundation.  If the Library does not specify a\nlicense version number, you may choose any version ever published by\nthe Free Software Foundation.\n\f\n  14. If you wish to incorporate parts of the Library into other free\nprograms whose distribution conditions are incompatible with these,\nwrite to the author to ask for permission.  For software which is\ncopyrighted by the Free Software Foundation, write to the Free\nSoftware Foundation; we sometimes make exceptions for this.  Our\ndecision will be guided by the two goals of preserving the free status\nof all derivatives of our free software and of promoting the sharing\nand reuse of software generally.\n\n\t\t\t    NO WARRANTY\n\n  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO\nWARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.\nEXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR\nOTHER PARTIES PROVIDE THE LIBRARY \"AS IS\" WITHOUT WARRANTY OF ANY\nKIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE\nIMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\nPURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE\nLIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME\nTHE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\n\n  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN\nWRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY\nAND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU\nFOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR\nCONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE\nLIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING\nRENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A\nFAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF\nSUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH\nDAMAGES.\n\n\t\t     END OF TERMS AND CONDITIONS\n\f\n           How to Apply These Terms to Your New Libraries\n\n  If you develop a new library, and you want it to be of the greatest\npossible use to the public, we recommend making it free software that\neveryone can redistribute and change.  You can do so by permitting\nredistribution under these terms (or, alternatively, under the terms of the\nordinary General Public License).\n\n  To apply these terms, attach the following notices to the library.  It is\nsafest to attach them to the start of each source file to most effectively\nconvey the exclusion of warranty; and each file should have at least the\n\"copyright\" line and a pointer to where the full notice is found.\n\n    <one line to give the library's name and a brief idea of what it does.>\n    Copyright (C) <year>  <name of author>\n\n    This library is free software; you can redistribute it and/or\n    modify it under the terms of the GNU Lesser General Public\n    License as published by the Free Software Foundation; either\n    version 2.1 of the License, or (at your option) any later version.\n\n    This library is distributed in the hope that it will be useful,\n    but WITHOUT ANY WARRANTY; without even the implied warranty of\n    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU\n    Lesser General Public License for more details.\n\n    You should have received a copy of the GNU Lesser General Public\n    License along with this library; if not, write to the Free Software\n    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA\n\nAlso add information on how to contact you by electronic and paper mail.\n\nYou should also get your employer (if you work as a programmer) or your\nschool, if any, to sign a \"copyright disclaimer\" for the library, if\nnecessary.  Here is a sample; alter the names:\n\n  Yoyodyne, Inc., hereby disclaims all copyright interest in the\n  library `Frob' (a library for tweaking knobs) written by James Random Hacker.\n\n  <signature of Ty Coon>, 1 April 1990\n  Ty Coon, President of Vice\n\nThat's all there is to it"
+        }
+      ],
+      "license_expressions": [
+        "lgpl-2.1-plus"
+      ],
+      "holders": [
+        {
+          "value": "Free Software Foundation, Inc.",
+          "start_line": 4,
+          "end_line": 6
+        },
+        {
+          "value": "the Free Software Foundation",
+          "start_line": 428,
+          "end_line": 433
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1991, 1999 Free Software Foundation, Inc.",
+          "start_line": 4,
+          "end_line": 6
+        },
+        {
+          "value": "copyrighted by the Free Software Foundation",
+          "start_line": 428,
+          "end_line": 433
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": true,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "lgpl-2.1-plus",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Free Software Foundation, Inc.",
+            "count": 1
+          },
+          {
+            "value": "copyrighted by the Free Software Foundation",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Free Software Foundation, Inc.",
+            "count": 2
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses",
+      "type": "directory",
+      "name": "licenses",
+      "base_name": "licenses",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "apache-1.1",
+            "count": 1
+          },
+          {
+            "value": "apache-2.0",
+            "count": 1
+          },
+          {
+            "value": "cpl-1.0",
+            "count": 1
+          },
+          {
+            "value": "lgpl-2.1-plus",
+            "count": 1
+          },
+          {
+            "value": "mit",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 2
+          },
+          {
+            "value": "Copyright (c) - The Legion Of The Bouncy Castle (http://www.bouncycastle.org)",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) Free Software Foundation, Inc.",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) The Apache Software Foundation.",
+            "count": 1
+          },
+          {
+            "value": "copyrighted by the Free Software Foundation",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 2
+          },
+          {
+            "value": "Free Software Foundation, Inc.",
+            "count": 2
+          },
+          {
+            "value": "The Apache Software Foundation.",
+            "count": 1
+          },
+          {
+            "value": "The Legion Of The Bouncy Castle",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 4
+          },
+          {
+            "value": "the Apache Software Foundation (http://www.apache.org/).",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 5
+          }
+        ]
+      },
+      "files_count": 5,
+      "dirs_count": 0,
+      "size_count": 54552,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses/apache-1.1.txt",
+      "type": "file",
+      "name": "apache-1.1.txt",
+      "base_name": "apache-1.1",
+      "extension": ".txt",
+      "size": 2885,
+      "date": "2017-10-26",
+      "sha1": "6b5608d35c3e304532af43db8bbfc5947bef46a6",
+      "md5": "276982197c941f4cbf3d218546e17ae2",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "apache-1.1",
+          "score": 100.0,
+          "short_name": "Apache 1.1",
+          "category": "Permissive",
+          "owner": "Apache Software Foundation",
+          "homepage_url": "http://www.apache.org/licenses/",
+          "text_url": "http://apache.org/licenses/LICENSE-1.1",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-1.1",
+          "spdx_license_key": "Apache-1.1",
+          "spdx_url": "https://spdx.org/licenses/Apache-1.1",
+          "start_line": 2,
+          "end_line": 56,
+          "matched_rule": {
+            "identifier": "apache-1.1.SPDX.RULE",
+            "license_expression": "apache-1.1",
+            "licenses": [
+              "apache-1.1"
+            ],
+            "matcher": "1-hash",
+            "rule_length": 362,
+            "matched_length": 362,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "The Apache Software License, Version 1.1\n *\n * Copyright (c) 2000 The Apache Software Foundation.  All rights\n * reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n *\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n *\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in\n *    the documentation and/or other materials provided with the\n *    distribution.\n *\n * 3. The end-user documentation included with the redistribution,\n *    if any, must include the following acknowledgment:\n *       \"This product includes software developed by the\n *        Apache Software Foundation (http://www.apache.org/).\"\n *    Alternately, this acknowledgment may appear in the software itself,\n *    if and wherever such third-party acknowledgments normally appear.\n *\n * 4. The names \"Apache\" and \"Apache Software Foundation\" must\n *    not be used to endorse or promote products derived from this\n *    software without prior written permission. For written\n *    permission, please contact apache@apache.org.\n *\n * 5. Products derived from this software may not be called \"Apache\",\n *    nor may \"Apache\" appear in their name, without prior written\n *    permission of the Apache Software Foundation.\n *\n * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\n * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\n * DISCLAIMED.  IN NO EVENT SHALL THE APACHE SOFTWARE FOUNDATION OR\n * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\n * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\n * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF\n * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND\n * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\n * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT\n * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF\n * SUCH DAMAGE.\n * ====================================================================\n *\n * This software consists of voluntary contributions made by many\n * individuals on behalf of the Apache Software Foundation.  For more\n * information on the Apache Software Foundation, please see\n * <http://www.apache.org/>.\n *\n * Portions of this software are based upon public domain software\n * originally written at the National Center for Supercomputing Applications,\n * University of Illinois, Urbana-Champaign"
+        }
+      ],
+      "license_expressions": [
+        "apache-1.1"
+      ],
+      "holders": [
+        {
+          "value": "The Apache Software Foundation.",
+          "start_line": 4,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2000 The Apache Software Foundation.",
+          "start_line": 4,
+          "end_line": 5
+        }
+      ],
+      "authors": [
+        {
+          "value": "the Apache Software Foundation (http://www.apache.org/).",
+          "start_line": 21,
+          "end_line": 23
+        }
+      ],
+      "package_manifest": null,
+      "emails": [
+        {
+          "email": "apache@apache.org",
+          "start_line": 29,
+          "end_line": 29
+        }
+      ],
+      "urls": [
+        {
+          "url": "http://www.apache.org/",
+          "start_line": 22,
+          "end_line": 22
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "apache-1.1",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) The Apache Software Foundation.",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "The Apache Software Foundation.",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": "the Apache Software Foundation (http://www.apache.org/).",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses/apache-2.0.txt",
+      "type": "file",
+      "name": "apache-2.0.txt",
+      "base_name": "apache-2.0",
+      "extension": ".txt",
+      "size": 11560,
+      "date": "2017-10-26",
+      "sha1": "47b573e3824cd5e02a1a3ae99e2735b49e0256e4",
+      "md5": "d273d63619c9aeaf15cdaf76422c4f87",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "apache-2.0",
+          "score": 100.0,
+          "short_name": "Apache 2.0",
+          "category": "Permissive",
+          "owner": "Apache Software Foundation",
+          "homepage_url": "http://www.apache.org/licenses/",
+          "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+          "spdx_license_key": "Apache-2.0",
+          "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+          "start_line": 2,
+          "end_line": 202,
+          "matched_rule": {
+            "identifier": "apache-2.0.LICENSE",
+            "license_expression": "apache-2.0",
+            "licenses": [
+              "apache-2.0"
+            ],
+            "matcher": "1-hash",
+            "rule_length": 1608,
+            "matched_length": 1608,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n   APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"[]\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n   Copyright [yyyy] [name of copyright owner]\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License"
+        }
+      ],
+      "license_expressions": [
+        "apache-2.0"
+      ],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://www.apache.org/licenses/",
+          "start_line": 4,
+          "end_line": 4
+        },
+        {
+          "url": "http://www.apache.org/licenses/LICENSE-2.0",
+          "start_line": 196,
+          "end_line": 196
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": true,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "apache-2.0",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses/bouncycastle.txt",
+      "type": "file",
+      "name": "bouncycastle.txt",
+      "base_name": "bouncycastle",
+      "extension": ".txt",
+      "size": 1186,
+      "date": "2017-10-26",
+      "sha1": "74facb0e9a734479f9cd893b5be3fe1bf651b760",
+      "md5": "9fffd8de865a5705969f62b128381f85",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "mit",
+          "score": 98.8,
+          "short_name": "MIT License",
+          "category": "Permissive",
+          "owner": "MIT",
+          "homepage_url": "http://opensource.org/licenses/mit-license.php",
+          "text_url": "http://opensource.org/licenses/mit-license.php",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+          "spdx_license_key": "MIT",
+          "spdx_url": "https://spdx.org/licenses/MIT",
+          "start_line": 3,
+          "end_line": 18,
+          "matched_rule": {
+            "identifier": "mit_160.RULE",
+            "license_expression": "mit",
+            "licenses": [
+              "mit"
+            ],
+            "matcher": "3-seq",
+            "rule_length": 167,
+            "matched_length": 165,
+            "match_coverage": 98.8,
+            "rule_relevance": 100
+          },
+          "matched_text": "License\n\nCopyright ([c]) [2000] - [2006] [The] [Legion] [Of] [The] [Bouncy] [Castle] ([http]://[www].[bouncycastle].[org])\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated\ndocumentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the\nrights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions\nof the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE\nWARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS\nOR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE"
+        }
+      ],
+      "license_expressions": [
+        "mit"
+      ],
+      "holders": [
+        {
+          "value": "The Legion Of The Bouncy Castle",
+          "start_line": 5,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2000 - 2006 The Legion Of The Bouncy Castle (http://www.bouncycastle.org)",
+          "start_line": 5,
+          "end_line": 5
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://www.bouncycastle.org/",
+          "start_line": 5,
+          "end_line": 5
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "mit",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) - The Legion Of The Bouncy Castle (http://www.bouncycastle.org)",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "The Legion Of The Bouncy Castle",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses/cpl-1.0.txt",
+      "type": "file",
+      "name": "cpl-1.0.txt",
+      "base_name": "cpl-1.0",
+      "extension": ".txt",
+      "size": 11987,
+      "date": "2017-10-26",
+      "sha1": "681cf776bcd79752543d42490ec7ed22a29fd888",
+      "md5": "9a6d2c9ae73d59eb3dd38e3909750d14",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "cpl-1.0",
+          "score": 99.94,
+          "short_name": "CPL 1.0",
+          "category": "Copyleft Limited",
+          "owner": "IBM",
+          "homepage_url": "http://www.eclipse.org/legal/cpl-v10.html",
+          "text_url": "http://www.eclipse.org/legal/cpl-v10.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:cpl-1.0",
+          "spdx_license_key": "CPL-1.0",
+          "spdx_url": "https://spdx.org/licenses/CPL-1.0",
+          "start_line": 1,
+          "end_line": 212,
+          "matched_rule": {
+            "identifier": "cpl-1.0.SPDX.RULE",
+            "license_expression": "cpl-1.0",
+            "licenses": [
+              "cpl-1.0"
+            ],
+            "matcher": "3-seq",
+            "rule_length": 1765,
+            "matched_length": 1764,
+            "match_coverage": 99.94,
+            "rule_relevance": 100
+          },
+          "matched_text": "Common Public License Version 1.0\n\nTHE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS COMMON PUBLIC\nLICENSE (\"AGREEMENT\"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM\nCONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.\n\n1. DEFINITIONS\n\n\"Contribution\" means:\n\n    a) in the case of the initial Contributor, the initial code and documentation\n    distributed under this Agreement, and\n\n    b) in the case of each subsequent Contributor:\n\n    i) changes to the Program, and\n\n    ii) additions to the Program;\n\n    where such changes and/or additions to the Program originate from and are\n    distributed by that particular Contributor. A Contribution 'originates' from\n    a Contributor if it was added to the Program by such Contributor itself or\n    anyone acting on such Contributor's behalf. Contributions do not include\n    additions to the Program which: (i) are separate modules of software\n    distributed in conjunction with the Program under their own license\n    agreement, and (ii) are not derivative works of the Program.\n\n\"Contributor\" means any person or entity that distributes the Program.\n\n\"Licensed Patents \" mean patent claims licensable by a Contributor which are\nnecessarily infringed by the use or sale of its Contribution alone or when\ncombined with the Program.\n\n\"Program\" means the Contributions distributed in accordance with this Agreement.\n\n\"Recipient\" means anyone who receives the Program under this Agreement, including\nall Contributors.\n\n2. GRANT OF RIGHTS\n\n    a) Subject to the terms of this Agreement, each Contributor hereby grants\n    Recipient a non-exclusive, worldwide, royalty-free copyright license to\n    reproduce, prepare derivative works of, publicly display, publicly perform,\n    distribute and sublicense the Contribution of such Contributor, if any, and\n    such derivative works, in source code and object code form.\n\n    b) Subject to the terms of this Agreement, each Contributor hereby grants\n    Recipient a non-exclusive, worldwide, royalty-free patent license under\n    Licensed Patents to make, use, sell, offer to sell, import and otherwise\n    transfer the Contribution of such Contributor, if any, in source code and\n    object code form. This patent license shall apply to the combination of the\n    Contribution and the Program if, at the time the Contribution is added by\n    the Contributor, such addition of the Contribution causes such combination\n    to be covered by the Licensed Patents. The patent license shall not apply to\n    any other combinations which include the Contribution. No hardware per se is\n    licensed hereunder.\n\n    c) Recipient understands that although each Contributor grants the licenses\n    to its Contributions set forth herein, no assurances are provided by any\n    Contributor that the Program does not infringe the patent or other\n    intellectual property rights of any other entity. Each Contributor disclaims\n    any liability to Recipient for claims brought by any other entity based on\n    infringement of intellectual property rights or otherwise. As a condition to\n    exercising the rights and licenses granted hereunder, each Recipient hereby\n    assumes sole responsibility to secure any other intellectual property rights\n    needed, if any. For example, if a third party patent license is required to\n    allow Recipient to distribute the Program, it is Recipient's responsibility\n    to acquire that license before distributing the Program.\n\n    d) Each Contributor represents that to its knowledge it has sufficient\n    copyright rights in its Contribution, if any, to grant the copyright license\n    set forth in this Agreement.\n\n3. REQUIREMENTS\n\nA Contributor may choose to distribute the Program in object code form under its\nown license agreement, provided that:\n\n    a) it complies with the terms and conditions of this Agreement; and\n\n    b) its license agreement:\n\n    i) effectively disclaims on behalf of all Contributors all warranties and\n    conditions, express and implied, including warranties or conditions of title\n    and non-infringement, and implied warranties or conditions of merchantability\n    and fitness for a particular purpose;\n\n    ii) effectively excludes on behalf of all Contributors all liability for\n    damages, including direct, indirect, special, incidental and consequential\n    damages, such as lost profits;\n\n    iii) states that any provisions which differ from this Agreement are offered\n    by that Contributor alone and not by any other party; and\n\n    iv) states that source code for the Program is available from such Contributor,\n    and informs licensees how to obtain it in a reasonable manner on or through\n    a medium customarily used for software exchange. \n\nWhen the Program is made available in source code form:\n\n    a) it must be made available under this Agreement; and\n\n    b) a copy of this Agreement must be included with each copy of the Program. \n\nContributors may not remove or alter any copyright notices contained within the Program.\n\nEach Contributor must identify itself as the originator of its Contribution, if\nany, in a manner that reasonably allows subsequent Recipients to identify the\noriginator of the Contribution.\n\n4. COMMERCIAL DISTRIBUTION\n\nCommercial distributors of software may accept certain responsibilities with\nrespect to end users, business partners and the like. While this license is\nintended to facilitate the commercial use of the Program, the Contributor who\nincludes the Program in a commercial product offering should do so in a manner\nwhich does not create potential liability for other Contributors. Therefore, if\na Contributor includes the Program in a commercial product offering, such\nContributor (\"Commercial Contributor\") hereby agrees to defend and indemnify\nevery other Contributor (\"Indemnified Contributor\") against any losses, damages\nand costs (collectively \"Losses\") arising from claims, lawsuits and other legal\nactions brought by a third party against the Indemnified Contributor to the\nextent caused by the acts or omissions of such Commercial Contributor in\nconnection with its distribution of the Program in a commercial product offering.\nThe obligations in this section do not apply to any claims or Losses relating to\nany actual or alleged intellectual property infringement. In order to qualify,\nan Indemnified Contributor must: a) promptly notify the Commercial Contributor \n[n] writing of such claim, and b) allow the Commercial Contributor to control,\nand cooperate with the Commercial Contributor in, the defense and any related\nsettlement negotiations. The Indemnified Contributor may participate in any such\nclaim at its own expense.\n\nFor example, a Contributor might include the Program in a commercial product\noffering, Product X. That Contributor is then a Commercial Contributor. If that\nCommercial Contributor then makes performance claims, or offers warranties\nrelated to Product X, those performance claims and warranties are such Commercial\nContributor's responsibility alone. Under this section, the Commercial\nContributor would have to defend claims against the other Contributors related\nto those performance claims and warranties, and if a court requires any other\nContributor to pay any damages as a result, the Commercial Contributor must pay\nthose damages.\n\n5. NO WARRANTY\n\nEXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN\n\"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR\nIMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,\nNON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each\nRecipient is solely responsible for determining the appropriateness of using\nand distributing the Program and assumes all risks associated with its exercise\nof rights under this Agreement, including but not limited to the risks and costs\nof program errors, compliance with applicable laws, damage to or loss of data,\nprograms or equipment, and unavailability or interruption of operations.\n\n6. DISCLAIMER OF LIABILITY\n\nEXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY\nCONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,\nSPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST\nPROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,\nSTRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY\nWAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS\nGRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.\n\n7. GENERAL\n\nIf any provision of this Agreement is invalid or unenforceable under applicable\nlaw, it shall not affect the validity or enforceability of the remainder of the\nterms of this Agreement, and without further action by the parties hereto, such\nprovision shall be reformed to the minimum extent necessary to make such\nprovision valid and enforceable.\n\nIf Recipient institutes patent litigation against a Contributor with respect to\na patent applicable to software (including a cross-claim or counterclaim in a\nlawsuit), then any patent licenses granted by that Contributor to such Recipient\nunder this Agreement shall terminate as of the date such litigation is filed.\nIn addition, if Recipient institutes patent litigation against any entity\n(including a cross-claim or counterclaim in a lawsuit) alleging that the Program\nitself (excluding combinations of the Program with other software or hardware)\ninfringes such Recipient's patent(s), then such Recipient's rights granted under\nSection 2(b) shall terminate as of the date such litigation is filed.\n\nAll Recipient's rights under this Agreement shall terminate if it fails to comply\nwith any of the material terms or conditions of this Agreement and does not cure\nsuch failure in a reasonable period of time after becoming aware of such\nnoncompliance. If all Recipient's rights under this Agreement terminate, Recipient\nagrees to cease use and distribution of the Program as soon as reasonably\npracticable. However, Recipient's obligations under this Agreement and any\nlicenses granted by Recipient relating to the Program shall continue and survive.\n\nEveryone is permitted to copy and distribute copies of this Agreement, but in\norder to avoid inconsistency the Agreement is copyrighted and may only be modified\nin the following manner. The Agreement Steward reserves the right to publish new\nversions (including revisions) of this Agreement from time to time. No one other\nthan the Agreement Steward has the right to modify this Agreement. IBM is the\ninitial Agreement Steward. IBM may assign the responsibility to serve as the\nAgreement Steward to a suitable separate entity. Each new version of the Agreement\nwill be given a distinguishing version number. The Program (including Contributions)\nmay always be distributed subject to the version of the Agreement under which it\nwas received. In addition, after a new version of the Agreement is published,\nContributor may elect to distribute the Program (including its Contributions)\nunder the new version. Except as expressly stated in Sections 2(a) and 2(b) above,\nRecipient receives no rights or licenses to the intellectual property of any\nContributor under this Agreement, whether expressly, by implication, estoppel or\notherwise. All rights in the Program not expressly granted under this Agreement\nare reserved.\n\nThis Agreement is governed by the laws of the State of New York and the\nintellectual property laws of the United States of America. No party to this\nAgreement will bring a legal action under this Agreement more than one year after\nthe cause of action arose. Each party waives its rights to a jury trial in any\nresulting litigation"
+        }
+      ],
+      "license_expressions": [
+        "cpl-1.0"
+      ],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "cpl-1.0",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses/lgpl.txt",
+      "type": "file",
+      "name": "lgpl.txt",
+      "base_name": "lgpl",
+      "extension": ".txt",
+      "size": 26934,
+      "date": "2017-10-26",
+      "sha1": "8f1a637d2e2ed1bdb9eb01a7dccb5c12cc0557e1",
+      "md5": "f14599a2f089f6ff8c97e2baa4e3d575",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "lgpl-2.1-plus",
+          "score": 100.0,
+          "short_name": "LGPL 2.1 or later",
+          "category": "Copyleft Limited",
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:lgpl-2.1-plus",
+          "spdx_license_key": "LGPL-2.1-or-later",
+          "spdx_url": "https://spdx.org/licenses/LGPL-2.1-or-later",
+          "start_line": 1,
+          "end_line": 502,
+          "matched_rule": {
+            "identifier": "lgpl-2.1-plus_2.RULE",
+            "license_expression": "lgpl-2.1-plus",
+            "licenses": [
+              "lgpl-2.1-plus"
+            ],
+            "matcher": "1-hash",
+            "rule_length": 4415,
+            "matched_length": 4415,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "GNU LESSER GENERAL PUBLIC LICENSE\n\t\t       Version 2.1, February 1999\n\n Copyright (C) 1991, 1999 Free Software Foundation, Inc.\n     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA\n Everyone is permitted to copy and distribute verbatim copies\n of this license document, but changing it is not allowed.\n\n[This is the first released version of the Lesser GPL.  It also counts\n as the successor of the GNU Library Public License, version 2, hence\n the version number 2.1.]\n\n\t\t\t    Preamble\n\n  The licenses for most software are designed to take away your\nfreedom to share and change it.  By contrast, the GNU General Public\nLicenses are intended to guarantee your freedom to share and change\nfree software--to make sure the software is free for all its users.\n\n  This license, the Lesser General Public License, applies to some\nspecially designated software packages--typically libraries--of the\nFree Software Foundation and other authors who decide to use it.  You\ncan use it too, but we suggest you first think carefully about whether\nthis license or the ordinary General Public License is the better\nstrategy to use in any particular case, based on the explanations below.\n\n  When we speak of free software, we are referring to freedom of use,\nnot price.  Our General Public Licenses are designed to make sure that\nyou have the freedom to distribute copies of free software (and charge\nfor this service if you wish); that you receive source code or can get\nit if you want it; that you can change the software and use pieces of\nit in new free programs; and that you are informed that you can do\nthese things.\n\n  To protect your rights, we need to make restrictions that forbid\ndistributors to deny you these rights or to ask you to surrender these\nrights.  These restrictions translate to certain responsibilities for\nyou if you distribute copies of the library or if you modify it.\n\n  For example, if you distribute copies of the library, whether gratis\nor for a fee, you must give the recipients all the rights that we gave\nyou.  You must make sure that they, too, receive or can get the source\ncode.  If you link other code with the library, you must provide\ncomplete object files to the recipients, so that they can relink them\nwith the library after making changes to the library and recompiling\nit.  And you must show them these terms so they know their rights.\n\n  We protect your rights with a two-step method: (1) we copyright the\nlibrary, and (2) we offer you this license, which gives you legal\npermission to copy, distribute and/or modify the library.\n\n  To protect each distributor, we want to make it very clear that\nthere is no warranty for the free library.  Also, if the library is\nmodified by someone else and passed on, the recipients should know\nthat what they have is not the original version, so that the original\nauthor's reputation will not be affected by problems that might be\nintroduced by others.\n\f\n  Finally, software patents pose a constant threat to the existence of\nany free program.  We wish to make sure that a company cannot\neffectively restrict the users of a free program by obtaining a\nrestrictive license from a patent holder.  Therefore, we insist that\nany patent license obtained for a version of the library must be\nconsistent with the full freedom of use specified in this license.\n\n  Most GNU software, including some libraries, is covered by the\nordinary GNU General Public License.  This license, the GNU Lesser\nGeneral Public License, applies to certain designated libraries, and\nis quite different from the ordinary General Public License.  We use\nthis license for certain libraries in order to permit linking those\nlibraries into non-free programs.\n\n  When a program is linked with a library, whether statically or using\na shared library, the combination of the two is legally speaking a\ncombined work, a derivative of the original library.  The ordinary\nGeneral Public License therefore permits such linking only if the\nentire combination fits its criteria of freedom.  The Lesser General\nPublic License permits more lax criteria for linking other code with\nthe library.\n\n  We call this license the \"Lesser\" General Public License because it\ndoes Less to protect the user's freedom than the ordinary General\nPublic License.  It also provides other free software developers Less\nof an advantage over competing non-free programs.  These disadvantages\nare the reason we use the ordinary General Public License for many\nlibraries.  However, the Lesser license provides advantages in certain\nspecial circumstances.\n\n  For example, on rare occasions, there may be a special need to\nencourage the widest possible use of a certain library, so that it becomes\na de-facto standard.  To achieve this, non-free programs must be\nallowed to use the library.  A more frequent case is that a free\nlibrary does the same job as widely used non-free libraries.  In this\ncase, there is little to gain by limiting the free library to free\nsoftware only, so we use the Lesser General Public License.\n\n  In other cases, permission to use a particular library in non-free\nprograms enables a greater number of people to use a large body of\nfree software.  For example, permission to use the GNU C Library in\nnon-free programs enables many more people to use the whole GNU\noperating system, as well as its variant, the GNU/Linux operating\nsystem.\n\n  Although the Lesser General Public License is Less protective of the\nusers' freedom, it does ensure that the user of a program that is\nlinked with the Library has the freedom and the wherewithal to run\nthat program using a modified version of the Library.\n\n  The precise terms and conditions for copying, distribution and\nmodification follow.  Pay close attention to the difference between a\n\"work based on the library\" and a \"work that uses the library\".  The\nformer contains code derived from the library, whereas the latter must\nbe combined with the library in order to run.\n\f\n\t\t  GNU LESSER GENERAL PUBLIC LICENSE\n   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION\n\n  0. This License Agreement applies to any software library or other\nprogram which contains a notice placed by the copyright holder or\nother authorized party saying it may be distributed under the terms of\nthis Lesser General Public License (also called \"this License\").\nEach licensee is addressed as \"you\".\n\n  A \"library\" means a collection of software functions and/or data\nprepared so as to be conveniently linked with application programs\n(which use some of those functions and data) to form executables.\n\n  The \"Library\", below, refers to any such software library or work\nwhich has been distributed under these terms.  A \"work based on the\nLibrary\" means either the Library or any derivative work under\ncopyright law: that is to say, a work containing the Library or a\nportion of it, either verbatim or with modifications and/or translated\nstraightforwardly into another language.  (Hereinafter, translation is\nincluded without limitation in the term \"modification\".)\n\n  \"Source code\" for a work means the preferred form of the work for\nmaking modifications to it.  For a library, complete source code means\nall the source code for all modules it contains, plus any associated\ninterface definition files, plus the scripts used to control compilation\nand installation of the library.\n\n  Activities other than copying, distribution and modification are not\ncovered by this License; they are outside its scope.  The act of\nrunning a program using the Library is not restricted, and output from\nsuch a program is covered only if its contents constitute a work based\non the Library (independent of the use of the Library in a tool for\nwriting it).  Whether that is true depends on what the Library does\nand what the program that uses the Library does.\n  \n  1. You may copy and distribute verbatim copies of the Library's\ncomplete source code as you receive it, in any medium, provided that\nyou conspicuously and appropriately publish on each copy an\nappropriate copyright notice and disclaimer of warranty; keep intact\nall the notices that refer to this License and to the absence of any\nwarranty; and distribute a copy of this License along with the\nLibrary.\n\n  You may charge a fee for the physical act of transferring a copy,\nand you may at your option offer warranty protection in exchange for a\nfee.\n\f\n  2. You may modify your copy or copies of the Library or any portion\nof it, thus forming a work based on the Library, and copy and\ndistribute such modifications or work under the terms of Section 1\nabove, provided that you also meet all of these conditions:\n\n    a) The modified work must itself be a software library.\n\n    b) You must cause the files modified to carry prominent notices\n    stating that you changed the files and the date of any change.\n\n    c) You must cause the whole of the work to be licensed at no\n    charge to all third parties under the terms of this License.\n\n    d) If a facility in the modified Library refers to a function or a\n    table of data to be supplied by an application program that uses\n    the facility, other than as an argument passed when the facility\n    is invoked, then you must make a good faith effort to ensure that,\n    in the event an application does not supply such function or\n    table, the facility still operates, and performs whatever part of\n    its purpose remains meaningful.\n\n    (For example, a function in a library to compute square roots has\n    a purpose that is entirely well-defined independent of the\n    application.  Therefore, Subsection 2d requires that any\n    application-supplied function or table used by this function must\n    be optional: if the application does not supply it, the square\n    root function must still compute square roots.)\n\nThese requirements apply to the modified work as a whole.  If\nidentifiable sections of that work are not derived from the Library,\nand can be reasonably considered independent and separate works in\nthemselves, then this License, and its terms, do not apply to those\nsections when you distribute them as separate works.  But when you\ndistribute the same sections as part of a whole which is a work based\non the Library, the distribution of the whole must be on the terms of\nthis License, whose permissions for other licensees extend to the\nentire whole, and thus to each and every part regardless of who wrote\nit.\n\nThus, it is not the intent of this section to claim rights or contest\nyour rights to work written entirely by you; rather, the intent is to\nexercise the right to control the distribution of derivative or\ncollective works based on the Library.\n\nIn addition, mere aggregation of another work not based on the Library\nwith the Library (or with a work based on the Library) on a volume of\na storage or distribution medium does not bring the other work under\nthe scope of this License.\n\n  3. You may opt to apply the terms of the ordinary GNU General Public\nLicense instead of this License to a given copy of the Library.  To do\nthis, you must alter all the notices that refer to this License, so\nthat they refer to the ordinary GNU General Public License, version 2,\ninstead of to this License.  (If a newer version than version 2 of the\nordinary GNU General Public License has appeared, then you can specify\nthat version instead if you wish.)  Do not make any other change in\nthese notices.\n\f\n  Once this change is made in a given copy, it is irreversible for\nthat copy, so the ordinary GNU General Public License applies to all\nsubsequent copies and derivative works made from that copy.\n\n  This option is useful when you wish to copy part of the code of\nthe Library into a program that is not a library.\n\n  4. You may copy and distribute the Library (or a portion or\nderivative of it, under Section 2) in object code or executable form\nunder the terms of Sections 1 and 2 above provided that you accompany\nit with the complete corresponding machine-readable source code, which\nmust be distributed under the terms of Sections 1 and 2 above on a\nmedium customarily used for software interchange.\n\n  If distribution of object code is made by offering access to copy\nfrom a designated place, then offering equivalent access to copy the\nsource code from the same place satisfies the requirement to\ndistribute the source code, even though third parties are not\ncompelled to copy the source along with the object code.\n\n  5. A program that contains no derivative of any portion of the\nLibrary, but is designed to work with the Library by being compiled or\nlinked with it, is called a \"work that uses the Library\".  Such a\nwork, in isolation, is not a derivative work of the Library, and\ntherefore falls outside the scope of this License.\n\n  However, linking a \"work that uses the Library\" with the Library\ncreates an executable that is a derivative of the Library (because it\ncontains portions of the Library), rather than a \"work that uses the\nlibrary\".  The executable is therefore covered by this License.\nSection 6 states terms for distribution of such executables.\n\n  When a \"work that uses the Library\" uses material from a header file\nthat is part of the Library, the object code for the work may be a\nderivative work of the Library even though the source code is not.\nWhether this is true is especially significant if the work can be\nlinked without the Library, or if the work is itself a library.  The\nthreshold for this to be true is not precisely defined by law.\n\n  If such an object file uses only numerical parameters, data\nstructure layouts and accessors, and small macros and small inline\nfunctions (ten lines or less in length), then the use of the object\nfile is unrestricted, regardless of whether it is legally a derivative\nwork.  (Executables containing this object code plus portions of the\nLibrary will still fall under Section 6.)\n\n  Otherwise, if the work is a derivative of the Library, you may\ndistribute the object code for the work under the terms of Section 6.\nAny executables containing that work also fall under Section 6,\nwhether or not they are linked directly with the Library itself.\n\f\n  6. As an exception to the Sections above, you may also combine or\nlink a \"work that uses the Library\" with the Library to produce a\nwork containing portions of the Library, and distribute that work\nunder terms of your choice, provided that the terms permit\nmodification of the work for the customer's own use and reverse\nengineering for debugging such modifications.\n\n  You must give prominent notice with each copy of the work that the\nLibrary is used in it and that the Library and its use are covered by\nthis License.  You must supply a copy of this License.  If the work\nduring execution displays copyright notices, you must include the\ncopyright notice for the Library among them, as well as a reference\ndirecting the user to the copy of this License.  Also, you must do one\nof these things:\n\n    a) Accompany the work with the complete corresponding\n    machine-readable source code for the Library including whatever\n    changes were used in the work (which must be distributed under\n    Sections 1 and 2 above); and, if the work is an executable linked\n    with the Library, with the complete machine-readable \"work that\n    uses the Library\", as object code and/or source code, so that the\n    user can modify the Library and then relink to produce a modified\n    executable containing the modified Library.  (It is understood\n    that the user who changes the contents of definitions files in the\n    Library will not necessarily be able to recompile the application\n    to use the modified definitions.)\n\n    b) Use a suitable shared library mechanism for linking with the\n    Library.  A suitable mechanism is one that (1) uses at run time a\n    copy of the library already present on the user's computer system,\n    rather than copying library functions into the executable, and (2)\n    will operate properly with a modified version of the library, if\n    the user installs one, as long as the modified version is\n    interface-compatible with the version that the work was made with.\n\n    c) Accompany the work with a written offer, valid for at\n    least three years, to give the same user the materials\n    specified in Subsection 6a, above, for a charge no more\n    than the cost of performing this distribution.\n\n    d) If distribution of the work is made by offering access to copy\n    from a designated place, offer equivalent access to copy the above\n    specified materials from the same place.\n\n    e) Verify that the user has already received a copy of these\n    materials or that you have already sent this user a copy.\n\n  For an executable, the required form of the \"work that uses the\nLibrary\" must include any data and utility programs needed for\nreproducing the executable from it.  However, as a special exception,\nthe materials to be distributed need not include anything that is\nnormally distributed (in either source or binary form) with the major\ncomponents (compiler, kernel, and so on) of the operating system on\nwhich the executable runs, unless that component itself accompanies\nthe executable.\n\n  It may happen that this requirement contradicts the license\nrestrictions of other proprietary libraries that do not normally\naccompany the operating system.  Such a contradiction means you cannot\nuse both them and the Library together in an executable that you\ndistribute.\n\f\n  7. You may place library facilities that are a work based on the\nLibrary side-by-side in a single library together with other library\nfacilities not covered by this License, and distribute such a combined\nlibrary, provided that the separate distribution of the work based on\nthe Library and of the other library facilities is otherwise\npermitted, and provided that you do these two things:\n\n    a) Accompany the combined library with a copy of the same work\n    based on the Library, uncombined with any other library\n    facilities.  This must be distributed under the terms of the\n    Sections above.\n\n    b) Give prominent notice with the combined library of the fact\n    that part of it is a work based on the Library, and explaining\n    where to find the accompanying uncombined form of the same work.\n\n  8. You may not copy, modify, sublicense, link with, or distribute\nthe Library except as expressly provided under this License.  Any\nattempt otherwise to copy, modify, sublicense, link with, or\ndistribute the Library is void, and will automatically terminate your\nrights under this License.  However, parties who have received copies,\nor rights, from you under this License will not have their licenses\nterminated so long as such parties remain in full compliance.\n\n  9. You are not required to accept this License, since you have not\nsigned it.  However, nothing else grants you permission to modify or\ndistribute the Library or its derivative works.  These actions are\nprohibited by law if you do not accept this License.  Therefore, by\nmodifying or distributing the Library (or any work based on the\nLibrary), you indicate your acceptance of this License to do so, and\nall its terms and conditions for copying, distributing or modifying\nthe Library or works based on it.\n\n  10. Each time you redistribute the Library (or any work based on the\nLibrary), the recipient automatically receives a license from the\noriginal licensor to copy, distribute, link with or modify the Library\nsubject to these terms and conditions.  You may not impose any further\nrestrictions on the recipients' exercise of the rights granted herein.\nYou are not responsible for enforcing compliance by third parties with\nthis License.\n\f\n  11. If, as a consequence of a court judgment or allegation of patent\ninfringement or for any other reason (not limited to patent issues),\nconditions are imposed on you (whether by court order, agreement or\notherwise) that contradict the conditions of this License, they do not\nexcuse you from the conditions of this License.  If you cannot\ndistribute so as to satisfy simultaneously your obligations under this\nLicense and any other pertinent obligations, then as a consequence you\nmay not distribute the Library at all.  For example, if a patent\nlicense would not permit royalty-free redistribution of the Library by\nall those who receive copies directly or indirectly through you, then\nthe only way you could satisfy both it and this License would be to\nrefrain entirely from distribution of the Library.\n\nIf any portion of this section is held invalid or unenforceable under any\nparticular circumstance, the balance of the section is intended to apply,\nand the section as a whole is intended to apply in other circumstances.\n\nIt is not the purpose of this section to induce you to infringe any\npatents or other property right claims or to contest validity of any\nsuch claims; this section has the sole purpose of protecting the\nintegrity of the free software distribution system which is\nimplemented by public license practices.  Many people have made\ngenerous contributions to the wide range of software distributed\nthrough that system in reliance on consistent application of that\nsystem; it is up to the author/donor to decide if he or she is willing\nto distribute software through any other system and a licensee cannot\nimpose that choice.\n\nThis section is intended to make thoroughly clear what is believed to\nbe a consequence of the rest of this License.\n\n  12. If the distribution and/or use of the Library is restricted in\ncertain countries either by patents or by copyrighted interfaces, the\noriginal copyright holder who places the Library under this License may add\nan explicit geographical distribution limitation excluding those countries,\nso that distribution is permitted only in or among countries not thus\nexcluded.  In such case, this License incorporates the limitation as if\nwritten in the body of this License.\n\n  13. The Free Software Foundation may publish revised and/or new\nversions of the Lesser General Public License from time to time.\nSuch new versions will be similar in spirit to the present version,\nbut may differ in detail to address new problems or concerns.\n\nEach version is given a distinguishing version number.  If the Library\nspecifies a version number of this License which applies to it and\n\"any later version\", you have the option of following the terms and\nconditions either of that version or of any later version published by\nthe Free Software Foundation.  If the Library does not specify a\nlicense version number, you may choose any version ever published by\nthe Free Software Foundation.\n\f\n  14. If you wish to incorporate parts of the Library into other free\nprograms whose distribution conditions are incompatible with these,\nwrite to the author to ask for permission.  For software which is\ncopyrighted by the Free Software Foundation, write to the Free\nSoftware Foundation; we sometimes make exceptions for this.  Our\ndecision will be guided by the two goals of preserving the free status\nof all derivatives of our free software and of promoting the sharing\nand reuse of software generally.\n\n\t\t\t    NO WARRANTY\n\n  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO\nWARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.\nEXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR\nOTHER PARTIES PROVIDE THE LIBRARY \"AS IS\" WITHOUT WARRANTY OF ANY\nKIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE\nIMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\nPURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE\nLIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME\nTHE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\n\n  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN\nWRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY\nAND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU\nFOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR\nCONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE\nLIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING\nRENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A\nFAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF\nSUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH\nDAMAGES.\n\n\t\t     END OF TERMS AND CONDITIONS\n\f\n           How to Apply These Terms to Your New Libraries\n\n  If you develop a new library, and you want it to be of the greatest\npossible use to the public, we recommend making it free software that\neveryone can redistribute and change.  You can do so by permitting\nredistribution under these terms (or, alternatively, under the terms of the\nordinary General Public License).\n\n  To apply these terms, attach the following notices to the library.  It is\nsafest to attach them to the start of each source file to most effectively\nconvey the exclusion of warranty; and each file should have at least the\n\"copyright\" line and a pointer to where the full notice is found.\n\n    <one line to give the library's name and a brief idea of what it does.>\n    Copyright (C) <year>  <name of author>\n\n    This library is free software; you can redistribute it and/or\n    modify it under the terms of the GNU Lesser General Public\n    License as published by the Free Software Foundation; either\n    version 2.1 of the License, or (at your option) any later version.\n\n    This library is distributed in the hope that it will be useful,\n    but WITHOUT ANY WARRANTY; without even the implied warranty of\n    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU\n    Lesser General Public License for more details.\n\n    You should have received a copy of the GNU Lesser General Public\n    License along with this library; if not, write to the Free Software\n    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA\n\nAlso add information on how to contact you by electronic and paper mail.\n\nYou should also get your employer (if you work as a programmer) or your\nschool, if any, to sign a \"copyright disclaimer\" for the library, if\nnecessary.  Here is a sample; alter the names:\n\n  Yoyodyne, Inc., hereby disclaims all copyright interest in the\n  library `Frob' (a library for tweaking knobs) written by James Random Hacker.\n\n  <signature of Ty Coon>, 1 April 1990\n  Ty Coon, President of Vice\n\nThat's all there is to it"
+        }
+      ],
+      "license_expressions": [
+        "lgpl-2.1-plus"
+      ],
+      "holders": [
+        {
+          "value": "Free Software Foundation, Inc.",
+          "start_line": 4,
+          "end_line": 6
+        },
+        {
+          "value": "the Free Software Foundation",
+          "start_line": 428,
+          "end_line": 433
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1991, 1999 Free Software Foundation, Inc.",
+          "start_line": 4,
+          "end_line": 6
+        },
+        {
+          "value": "copyrighted by the Free Software Foundation",
+          "start_line": 428,
+          "end_line": 433
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "lgpl-2.1-plus",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Free Software Foundation, Inc.",
+            "count": 1
+          },
+          {
+            "value": "copyrighted by the Free Software Foundation",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Free Software Foundation, Inc.",
+            "count": 2
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src",
+      "type": "directory",
+      "name": "src",
+      "base_name": "src",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "lgpl-2.1-plus",
+            "count": 3
+          },
+          {
+            "value": null,
+            "count": 2
+          },
+          {
+            "value": "public-domain",
+            "count": 2
+          },
+          {
+            "value": "cc-by-2.5",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 3
+          },
+          {
+            "value": "Copyright (c) Brian Goetz and Tim Peierls",
+            "count": 1
+          },
+          {
+            "value": "Copyright JBoss Inc., and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Copyright Red Hat Middleware LLC, and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Copyright Red Hat, Inc. and individual contributors",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 3
+          },
+          {
+            "value": "Brian Goetz and Tim Peierls",
+            "count": 1
+          },
+          {
+            "value": "JBoss Inc., and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Red Hat Middleware LLC, and individual contributors",
+            "count": 1
+          },
+          {
+            "value": "Red Hat, Inc. and individual contributors",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": "Bela Ban",
+            "count": 4
+          },
+          {
+            "value": null,
+            "count": 1
+          },
+          {
+            "value": "Brian Stansberry",
+            "count": 1
+          },
+          {
+            "value": "Chris Mills (millsy@jboss.com)",
+            "count": 1
+          },
+          {
+            "value": "Robert Harder",
+            "count": 1
+          },
+          {
+            "value": "rob@iharder.net",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "Java",
+            "count": 7
+          }
+        ]
+      },
+      "files_count": 7,
+      "dirs_count": 0,
+      "size_count": 152090,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/FixedMembershipToken.java",
+      "type": "file",
+      "name": "FixedMembershipToken.java",
+      "base_name": "FixedMembershipToken",
+      "extension": ".java",
+      "size": 5144,
+      "date": "2017-10-26",
+      "sha1": "5901f73dcc78155a1a2c7b5663a3a11fba400b19",
+      "md5": "aca9640ec8beee21b098bcf8ecc91442",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "lgpl-2.1-plus",
+          "score": 100.0,
+          "short_name": "LGPL 2.1 or later",
+          "category": "Copyleft Limited",
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:lgpl-2.1-plus",
+          "spdx_license_key": "LGPL-2.1-or-later",
+          "spdx_url": "https://spdx.org/licenses/LGPL-2.1-or-later",
+          "start_line": 7,
+          "end_line": 20,
+          "matched_rule": {
+            "identifier": "lgpl-2.1-plus_59.RULE",
+            "license_expression": "lgpl-2.1-plus",
+            "licenses": [
+              "lgpl-2.1-plus"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 127,
+            "matched_length": 127,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "This is free software; you can redistribute it and/or modify it\n * under the terms of the GNU Lesser General Public License as\n * published by the Free Software Foundation; either version 2.1 of\n * the License, or (at your option) any later version.\n *\n * This software is distributed in the hope that it will be useful,\n * but WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU\n * Lesser General Public License for more details.\n *\n * You should have received a copy of the GNU Lesser General Public\n * License along with this software; if not, write to the Free\n * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA\n * 02110-1301 USA, or see the FSF site: http://www.fsf.org"
+        }
+      ],
+      "license_expressions": [
+        "lgpl-2.1-plus"
+      ],
+      "holders": [
+        {
+          "value": "JBoss Inc., and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright 2005, JBoss Inc., and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "authors": [
+        {
+          "value": "Chris Mills (millsy@jboss.com)",
+          "start_line": 51,
+          "end_line": 51
+        }
+      ],
+      "package_manifest": null,
+      "emails": [
+        {
+          "email": "millsy@jboss.com",
+          "start_line": 51,
+          "end_line": 51
+        }
+      ],
+      "urls": [
+        {
+          "url": "http://www.fsf.org/",
+          "start_line": 20,
+          "end_line": 20
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "lgpl-2.1-plus",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright JBoss Inc., and individual contributors",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "JBoss Inc., and individual contributors",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": "Chris Mills (millsy@jboss.com)",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "Java",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/GuardedBy.java",
+      "type": "file",
+      "name": "GuardedBy.java",
+      "base_name": "GuardedBy",
+      "extension": ".java",
+      "size": 813,
+      "date": "2017-10-26",
+      "sha1": "981d67087e65e9a44957c026d4b10817cf77d966",
+      "md5": "c5064400f759d3e81771005051d17dc1",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "cc-by-2.5",
+          "score": 70.0,
+          "short_name": "CC-BY-2.5",
+          "category": "Permissive",
+          "owner": "Creative Commons",
+          "homepage_url": "http://creativecommons.org/licenses/by/2.5/",
+          "text_url": "http://creativecommons.org/licenses/by/2.5/legalcode",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:cc-by-2.5",
+          "spdx_license_key": "CC-BY-2.5",
+          "spdx_url": "https://spdx.org/licenses/CC-BY-2.5",
+          "start_line": 10,
+          "end_line": 11,
+          "matched_rule": {
+            "identifier": "cc-by-2.5_4.RULE",
+            "license_expression": "cc-by-2.5",
+            "licenses": [
+              "cc-by-2.5"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 14,
+            "matched_length": 14,
+            "match_coverage": 100.0,
+            "rule_relevance": 70
+          },
+          "matched_text": "Released under the Creative Commons Attribution License\n * (http://creativecommons.org/licenses/by/2.5"
+        }
+      ],
+      "license_expressions": [
+        "cc-by-2.5"
+      ],
+      "holders": [
+        {
+          "value": "Brian Goetz and Tim Peierls",
+          "start_line": 9,
+          "end_line": 11
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2005 Brian Goetz and Tim Peierls",
+          "start_line": 9,
+          "end_line": 11
+        }
+      ],
+      "authors": [
+        {
+          "value": "Bela Ban",
+          "start_line": 15,
+          "end_line": 17
+        }
+      ],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://creativecommons.org/licenses/by/2.5",
+          "start_line": 11,
+          "end_line": 11
+        },
+        {
+          "url": "http://www.jcip.net/",
+          "start_line": 12,
+          "end_line": 12
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "cc-by-2.5",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Brian Goetz and Tim Peierls",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Brian Goetz and Tim Peierls",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": "Bela Ban",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "Java",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/ImmutableReference.java",
+      "type": "file",
+      "name": "ImmutableReference.java",
+      "base_name": "ImmutableReference",
+      "extension": ".java",
+      "size": 1838,
+      "date": "2017-10-26",
+      "sha1": "30f56b876d5576d9869e2c5c509b08db57110592",
+      "md5": "48ca3c72fb9a65c771a321222f118b88",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "lgpl-2.1-plus",
+          "score": 100.0,
+          "short_name": "LGPL 2.1 or later",
+          "category": "Copyleft Limited",
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:lgpl-2.1-plus",
+          "spdx_license_key": "LGPL-2.1-or-later",
+          "spdx_url": "https://spdx.org/licenses/LGPL-2.1-or-later",
+          "start_line": 7,
+          "end_line": 20,
+          "matched_rule": {
+            "identifier": "lgpl-2.1-plus_59.RULE",
+            "license_expression": "lgpl-2.1-plus",
+            "licenses": [
+              "lgpl-2.1-plus"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 127,
+            "matched_length": 127,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "This is free software; you can redistribute it and/or modify it\n * under the terms of the GNU Lesser General Public License as\n * published by the Free Software Foundation; either version 2.1 of\n * the License, or (at your option) any later version.\n *\n * This software is distributed in the hope that it will be useful,\n * but WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU\n * Lesser General Public License for more details.\n *\n * You should have received a copy of the GNU Lesser General Public\n * License along with this software; if not, write to the Free\n * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA\n * 02110-1301 USA, or see the FSF site: http://www.fsf.org"
+        }
+      ],
+      "license_expressions": [
+        "lgpl-2.1-plus"
+      ],
+      "holders": [
+        {
+          "value": "Red Hat, Inc. and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright 2010, Red Hat, Inc. and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "authors": [
+        {
+          "value": "Brian Stansberry",
+          "start_line": 29,
+          "end_line": 29
+        }
+      ],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://www.fsf.org/",
+          "start_line": 20,
+          "end_line": 20
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "lgpl-2.1-plus",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright Red Hat, Inc. and individual contributors",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Red Hat, Inc. and individual contributors",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": "Brian Stansberry",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "Java",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/RATE_LIMITER.java",
+      "type": "file",
+      "name": "RATE_LIMITER.java",
+      "base_name": "RATE_LIMITER",
+      "extension": ".java",
+      "size": 3692,
+      "date": "2017-10-26",
+      "sha1": "a8087e5d50da3273536ebda9b87b77aa4ff55deb",
+      "md5": "4626bdbc48871b55513e1a12991c61a8",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [
+        {
+          "value": "Bela Ban",
+          "start_line": 16,
+          "end_line": 17
+        }
+      ],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": "Bela Ban",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "Java",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/RouterStub.java",
+      "type": "file",
+      "name": "RouterStub.java",
+      "base_name": "RouterStub",
+      "extension": ".java",
+      "size": 9913,
+      "date": "2017-10-26",
+      "sha1": "c1f6818f8ee7bddcc9f444bc94c099729d716d52",
+      "md5": "eecfe23494acbcd8088c93bc1e83c7f2",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [
+        {
+          "value": "Bela Ban",
+          "start_line": 23,
+          "end_line": 24
+        }
+      ],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "https://jira.jboss.org/jira/browse/JGRP-1151",
+          "start_line": 232,
+          "end_line": 232
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": "Bela Ban",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "Java",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/RouterStubManager.java",
+      "type": "file",
+      "name": "RouterStubManager.java",
+      "base_name": "RouterStubManager",
+      "extension": ".java",
+      "size": 8162,
+      "date": "2017-10-26",
+      "sha1": "eb419dc94cfe11ca318a3e743a7f9f080e70c751",
+      "md5": "20bee9631b7c82a45c250e095352aec7",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "lgpl-2.1-plus",
+          "score": 100.0,
+          "short_name": "LGPL 2.1 or later",
+          "category": "Copyleft Limited",
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:lgpl-2.1-plus",
+          "spdx_license_key": "LGPL-2.1-or-later",
+          "spdx_url": "https://spdx.org/licenses/LGPL-2.1-or-later",
+          "start_line": 7,
+          "end_line": 20,
+          "matched_rule": {
+            "identifier": "lgpl-2.1-plus_59.RULE",
+            "license_expression": "lgpl-2.1-plus",
+            "licenses": [
+              "lgpl-2.1-plus"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 127,
+            "matched_length": 127,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "This is free software; you can redistribute it and/or modify it\n * under the terms of the GNU Lesser General Public License as\n * published by the Free Software Foundation; either version 2.1 of\n * the License, or (at your option) any later version.\n *\n * This software is distributed in the hope that it will be useful,\n * but WITHOUT ANY WARRANTY; without even the implied warranty of\n * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU\n * Lesser General Public License for more details.\n *\n * You should have received a copy of the GNU Lesser General Public\n * License along with this software; if not, write to the Free\n * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA\n * 02110-1301 USA, or see the FSF site: http://www.fsf.org"
+        }
+      ],
+      "license_expressions": [
+        "lgpl-2.1-plus"
+      ],
+      "holders": [
+        {
+          "value": "Red Hat Middleware LLC, and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright 2009, Red Hat Middleware LLC, and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://www.fsf.org/",
+          "start_line": 20,
+          "end_line": 20
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "lgpl-2.1-plus",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright Red Hat Middleware LLC, and individual contributors",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Red Hat Middleware LLC, and individual contributors",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "Java",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/S3_PING.java",
+      "type": "file",
+      "name": "S3_PING.java",
+      "base_name": "S3_PING",
+      "extension": ".java",
+      "size": 122528,
+      "date": "2017-10-26",
+      "sha1": "08dba9986f69719970ead3592dc565465164df0d",
+      "md5": "83d8324f37d0e3f120bc89865cf0bd39",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "public-domain",
+          "score": 10.0,
+          "short_name": "Public Domain",
+          "category": "Public Domain",
+          "owner": "Unspecified",
+          "homepage_url": "http://www.linfo.org/publicdomain.html",
+          "text_url": "",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:public-domain",
+          "spdx_license_key": "",
+          "spdx_url": "",
+          "start_line": 1649,
+          "end_line": 1649,
+          "matched_rule": {
+            "identifier": "public-domain_79.RULE",
+            "license_expression": "public-domain",
+            "licenses": [
+              "public-domain"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 2,
+            "matched_length": 2,
+            "match_coverage": 100.0,
+            "rule_relevance": 10
+          },
+          "matched_text": "public domain"
+        },
+        {
+          "key": "public-domain",
+          "score": 10.0,
+          "short_name": "Public Domain",
+          "category": "Public Domain",
+          "owner": "Unspecified",
+          "homepage_url": "http://www.linfo.org/publicdomain.html",
+          "text_url": "",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:public-domain",
+          "spdx_license_key": "",
+          "spdx_url": "",
+          "start_line": 1692,
+          "end_line": 1692,
+          "matched_rule": {
+            "identifier": "public-domain_79.RULE",
+            "license_expression": "public-domain",
+            "licenses": [
+              "public-domain"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 2,
+            "matched_length": 2,
+            "match_coverage": 100.0,
+            "rule_relevance": 10
+          },
+          "matched_text": "Public Domain"
+        }
+      ],
+      "license_expressions": [
+        "public-domain",
+        "public-domain"
+      ],
+      "holders": [],
+      "copyrights": [],
+      "authors": [
+        {
+          "value": "Bela Ban",
+          "start_line": 35,
+          "end_line": 38
+        },
+        {
+          "value": "Robert Harder",
+          "start_line": 1698,
+          "end_line": 1700
+        },
+        {
+          "value": "rob@iharder.net",
+          "start_line": 1698,
+          "end_line": 1700
+        }
+      ],
+      "package_manifest": null,
+      "emails": [
+        {
+          "email": "rob@iharder.net",
+          "start_line": 1699,
+          "end_line": 1699
+        }
+      ],
+      "urls": [
+        {
+          "url": "http://iharder.sourceforge.net/current/java/base64/",
+          "start_line": 1652,
+          "end_line": 1652
+        },
+        {
+          "url": "http://iharder.net/base64",
+          "start_line": 1695,
+          "end_line": 1695
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "public-domain",
+            "count": 2
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": "Bela Ban",
+            "count": 1
+          },
+          {
+            "value": "Robert Harder",
+            "count": 1
+          },
+          {
+            "value": "rob@iharder.net",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "Java",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib",
+      "type": "directory",
+      "name": "zlib",
+      "base_name": "zlib",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": true,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 10
+          },
+          {
+            "value": "boost-1.0",
+            "count": 3
+          },
+          {
+            "value": null,
+            "count": 2
+          },
+          {
+            "value": "cmr-no",
+            "count": 1
+          },
+          {
+            "value": "gpl-2.0-plus WITH ada-linking-exception",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Jean-loup Gailly",
+            "count": 3
+          },
+          {
+            "value": "Copyright (c) Jean-loup Gailly and Mark Adler",
+            "count": 3
+          },
+          {
+            "value": "Copyright (c) Mark Adler",
+            "count": 3
+          },
+          {
+            "value": null,
+            "count": 2
+          },
+          {
+            "value": "(c) Copyright Henrik Ravn",
+            "count": 2
+          },
+          {
+            "value": "Copyright (c) Christian Michelsen Research AS Advanced Computing",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) Dmitriy Anisimkov",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) by Henrik Ravn",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Henrik Ravn",
+            "count": 3
+          },
+          {
+            "value": "Jean-loup Gailly",
+            "count": 3
+          },
+          {
+            "value": "Jean-loup Gailly and Mark Adler",
+            "count": 3
+          },
+          {
+            "value": "Mark Adler",
+            "count": 3
+          },
+          {
+            "value": null,
+            "count": 2
+          },
+          {
+            "value": "Christian Michelsen Research AS Advanced Computing",
+            "count": 1
+          },
+          {
+            "value": "Dmitriy Anisimkov",
+            "count": 1
+          },
+          {
+            "value": "Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 14
+          },
+          {
+            "value": "Gilles Vollant",
+            "count": 1
+          },
+          {
+            "value": "Leonid Broukhis.",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 9
+          },
+          {
+            "value": null,
+            "count": 2
+          },
+          {
+            "value": "C#",
+            "count": 2
+          },
+          {
+            "value": "Ada",
+            "count": 1
+          },
+          {
+            "value": "C++",
+            "count": 1
+          },
+          {
+            "value": "GAS",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 16,
+      "dirs_count": 5,
+      "size_count": 268762,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/adler32.c",
+      "type": "file",
+      "name": "adler32.c",
+      "base_name": "adler32",
+      "extension": ".c",
+      "size": 4968,
+      "date": "2017-10-26",
+      "sha1": "0cff4808476ce0b5f6f0ebbc69ee2ab2a0eebe43",
+      "md5": "ae3bbb54820e1d49fb90cbba222e973f",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 60.0,
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 12,
+            "matched_length": 12,
+            "match_coverage": 100.0,
+            "rule_relevance": 60
+          },
+          "matched_text": "For conditions of distribution and use, see copyright notice in zlib.h"
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2011 Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Mark Adler",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Mark Adler",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/deflate.c",
+      "type": "file",
+      "name": "deflate.c",
+      "base_name": "deflate",
+      "extension": ".c",
+      "size": 71476,
+      "date": "2017-10-26",
+      "sha1": "7b4ace6d698c5dbbfb9a8f047f63228ca54d2e77",
+      "md5": "cd7826278ce9d9d9ed5abdefef50c3e2",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 60.0,
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 12,
+            "matched_length": 12,
+            "match_coverage": 100.0,
+            "rule_relevance": 60
+          },
+          "matched_text": "For conditions of distribution and use, see copyright notice in zlib.h"
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly and Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        },
+        {
+          "value": "Jean-loup Gailly and Mark Adler",
+          "start_line": 54,
+          "end_line": 55
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2013 Jean-loup Gailly and Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        },
+        {
+          "value": "Copyright 1995-2013 Jean-loup Gailly and Mark Adler",
+          "start_line": 54,
+          "end_line": 55
+        }
+      ],
+      "authors": [
+        {
+          "value": "Leonid Broukhis.",
+          "start_line": 34,
+          "end_line": 35
+        }
+      ],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://tools.ietf.org/html/rfc1951",
+          "start_line": 40,
+          "end_line": 40
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Jean-loup Gailly and Mark Adler",
+            "count": 2
+          }
+        ],
+        "holders": [
+          {
+            "value": "Jean-loup Gailly and Mark Adler",
+            "count": 2
+          }
+        ],
+        "authors": [
+          {
+            "value": "Leonid Broukhis.",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/deflate.h",
+      "type": "file",
+      "name": "deflate.h",
+      "base_name": "deflate",
+      "extension": ".h",
+      "size": 12774,
+      "date": "2017-10-26",
+      "sha1": "29ed3b8ca3927576e5889dea5880ca0052942c7d",
+      "md5": "7ceae74a13201f14c91623116af169c3",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 60.0,
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 12,
+            "matched_length": 12,
+            "match_coverage": 100.0,
+            "rule_relevance": 60
+          },
+          "matched_text": "For conditions of distribution and use, see copyright notice in zlib.h"
+        },
+        {
+          "key": "zlib",
+          "score": 100.0,
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 93,
+          "end_line": 94,
+          "matched_rule": {
+            "identifier": "zlib_21.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 29,
+            "matched_length": 29,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "A Pos is an index in the character window. We use short instead of int to\n * save space in the various tables. IPos is used only for parameter passing"
+        }
+      ],
+      "license_expressions": [
+        "zlib",
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2012 Jean-loup Gailly",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 2
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Jean-loup Gailly",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Jean-loup Gailly",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/zlib.h",
+      "type": "file",
+      "name": "zlib.h",
+      "base_name": "zlib",
+      "extension": ".h",
+      "size": 87883,
+      "date": "2017-10-26",
+      "sha1": "400d35465f179a4acacb5fe749e6ce20a0bbdb84",
+      "md5": "64d8a5180bd54ff5452886e4cbb21e14",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 100.0,
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 6,
+          "end_line": 23,
+          "matched_rule": {
+            "identifier": "zlib_17.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 145,
+            "matched_length": 145,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "This software is provided 'as-is', without any express or implied\n  warranty.  In no event will the authors be held liable for any damages\n  arising from the use of this software.\n\n  Permission is granted to anyone to use this software for any purpose,\n  including commercial applications, and to alter it and redistribute it\n  freely, subject to the following restrictions:\n\n  1. The origin of this software must not be misrepresented; you must not\n     claim that you wrote the original software. If you use this software\n     in a product, an acknowledgment in the product documentation would be\n     appreciated but is not required.\n  2. Altered source versions must be plainly marked as such, and must not be\n     misrepresented as being the original software.\n  3. This notice may not be removed or altered from any source distribution.\n\n  Jean-loup Gailly        Mark Adler\n  jloup@gzip.org          madler@alumni.caltech.edu"
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly and Mark Adler",
+          "start_line": 4,
+          "end_line": 4
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2013 Jean-loup Gailly and Mark Adler",
+          "start_line": 4,
+          "end_line": 4
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [
+        {
+          "email": "jloup@gzip.org",
+          "start_line": 23,
+          "end_line": 23
+        },
+        {
+          "email": "madler@alumni.caltech.edu",
+          "start_line": 23,
+          "end_line": 23
+        }
+      ],
+      "urls": [
+        {
+          "url": "http://tools.ietf.org/html/rfc1950",
+          "start_line": 27,
+          "end_line": 27
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Jean-loup Gailly and Mark Adler",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Jean-loup Gailly and Mark Adler",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/zutil.c",
+      "type": "file",
+      "name": "zutil.c",
+      "base_name": "zutil",
+      "extension": ".c",
+      "size": 7414,
+      "date": "2017-10-26",
+      "sha1": "e1af709bff21ae0d4331119a7fc4c19f82932043",
+      "md5": "fff257bc1656eb60fc585a7dc35f963d",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 60.0,
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 12,
+            "matched_length": 12,
+            "match_coverage": 100.0,
+            "rule_relevance": 60
+          },
+          "matched_text": "For conditions of distribution and use, see copyright notice in zlib.h"
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly.",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2005, 2010, 2011, 2012 Jean-loup Gailly.",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Jean-loup Gailly.",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Jean-loup Gailly.",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/zutil.h",
+      "type": "file",
+      "name": "zutil.h",
+      "base_name": "zutil",
+      "extension": ".h",
+      "size": 6766,
+      "date": "2017-10-26",
+      "sha1": "b909d27ef9ce51639f76b7ea6b62721e7d1b6bf7",
+      "md5": "04fcfbb961591c9452c4d0fd1525ffdf",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 60.0,
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 12,
+            "matched_length": 12,
+            "match_coverage": 100.0,
+            "rule_relevance": 60
+          },
+          "matched_text": "For conditions of distribution and use, see copyright notice in zlib.h"
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly.",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2013 Jean-loup Gailly.",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Jean-loup Gailly.",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Jean-loup Gailly.",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/ada",
+      "type": "directory",
+      "name": "ada",
+      "base_name": "ada",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "gpl-2.0-plus WITH ada-linking-exception",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Dmitriy Anisimkov",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Dmitriy Anisimkov",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "Ada",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 1,
+      "dirs_count": 0,
+      "size_count": 13594,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/ada/zlib.ads",
+      "type": "file",
+      "name": "zlib.ads",
+      "base_name": "zlib",
+      "extension": ".ads",
+      "size": 13594,
+      "date": "2017-10-26",
+      "sha1": "0245a91806d804bf9f0907a3a001a141e9adb61b",
+      "md5": "71de2670f2e588b51c62e7f6a9046399",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Ada",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "gpl-2.0-plus",
+          "score": 100.0,
+          "short_name": "GPL 2.0 or later",
+          "category": "Copyleft",
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:gpl-2.0-plus",
+          "spdx_license_key": "GPL-2.0-or-later",
+          "spdx_url": "https://spdx.org/licenses/GPL-2.0-or-later",
+          "start_line": 6,
+          "end_line": 25,
+          "matched_rule": {
+            "identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
+            "license_expression": "gpl-2.0-plus WITH ada-linking-exception",
+            "licenses": [
+              "gpl-2.0-plus",
+              "ada-linking-exception"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 179,
+            "matched_length": 179,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "This library is free software; you can redistribute it and/or modify    --\n--  it under the terms of the GNU General Public License as published by    --\n--  the Free Software Foundation; either version 2 of the License, or (at   --\n--  your option) any later version.                                         --\n--                                                                          --\n--  This library is distributed in the hope that it will be useful, but     --\n--  WITHOUT ANY WARRANTY; without even the implied warranty of              --\n--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU       --\n--  General Public License for more details.                                --\n--                                                                          --\n--  You should have received a copy of the GNU General Public License       --\n--  along with this library; if not, write to the Free Software Foundation, --\n--  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.          --\n--                                                                          --\n--  As a special exception, if other files instantiate generics from this   --\n--  unit, or you link this unit with other files to produce an executable,  --\n--  this  unit  does not  by itself cause  the resulting executable to be   --\n--  covered by the GNU General Public License. This exception does not      --\n--  however invalidate any other reasons why the executable file  might be  --\n--  covered by the  GNU Public License"
+        },
+        {
+          "key": "ada-linking-exception",
+          "score": 100.0,
+          "short_name": "Ada linking exception to GPL 2.0 or later",
+          "category": "Copyleft Limited",
+          "owner": "Dmitriy Anisimkov",
+          "homepage_url": "",
+          "text_url": "",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:ada-linking-exception",
+          "spdx_license_key": "",
+          "spdx_url": "",
+          "start_line": 6,
+          "end_line": 25,
+          "matched_rule": {
+            "identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
+            "license_expression": "gpl-2.0-plus WITH ada-linking-exception",
+            "licenses": [
+              "gpl-2.0-plus",
+              "ada-linking-exception"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 179,
+            "matched_length": 179,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "This library is free software; you can redistribute it and/or modify    --\n--  it under the terms of the GNU General Public License as published by    --\n--  the Free Software Foundation; either version 2 of the License, or (at   --\n--  your option) any later version.                                         --\n--                                                                          --\n--  This library is distributed in the hope that it will be useful, but     --\n--  WITHOUT ANY WARRANTY; without even the implied warranty of              --\n--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU       --\n--  General Public License for more details.                                --\n--                                                                          --\n--  You should have received a copy of the GNU General Public License       --\n--  along with this library; if not, write to the Free Software Foundation, --\n--  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.          --\n--                                                                          --\n--  As a special exception, if other files instantiate generics from this   --\n--  unit, or you link this unit with other files to produce an executable,  --\n--  this  unit  does not  by itself cause  the resulting executable to be   --\n--  covered by the GNU General Public License. This exception does not      --\n--  however invalidate any other reasons why the executable file  might be  --\n--  covered by the  GNU Public License"
+        }
+      ],
+      "license_expressions": [
+        "gpl-2.0-plus WITH ada-linking-exception"
+      ],
+      "holders": [
+        {
+          "value": "Dmitriy Anisimkov",
+          "start_line": 4,
+          "end_line": 4
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2002-2004 Dmitriy Anisimkov",
+          "start_line": 4,
+          "end_line": 4
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "gpl-2.0-plus WITH ada-linking-exception",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Dmitriy Anisimkov",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Dmitriy Anisimkov",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "Ada",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/dotzlib",
+      "type": "directory",
+      "name": "dotzlib",
+      "base_name": "dotzlib",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "boost-1.0",
+            "count": 3
+          },
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "(c) Copyright Henrik Ravn",
+            "count": 2
+          },
+          {
+            "value": null,
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) by Henrik Ravn",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Henrik Ravn",
+            "count": 3
+          },
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 4
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 2
+          },
+          {
+            "value": "C#",
+            "count": 2
+          }
+        ]
+      },
+      "files_count": 4,
+      "dirs_count": 0,
+      "size_count": 14257,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/dotzlib/AssemblyInfo.cs",
+      "type": "file",
+      "name": "AssemblyInfo.cs",
+      "base_name": "AssemblyInfo",
+      "extension": ".cs",
+      "size": 2500,
+      "date": "2017-10-26",
+      "sha1": "9f1db1177b2e9a014f72bb3cd80be17133e06d16",
+      "md5": "23d0d7c18846fc31655b6aa89b7c8038",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": "C#",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [
+        {
+          "value": "Henrik Ravn",
+          "start_line": 14,
+          "end_line": 16
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2004 by Henrik Ravn",
+          "start_line": 14,
+          "end_line": 16
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) by Henrik Ravn",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Henrik Ravn",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C#",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/dotzlib/ChecksumImpl.cs",
+      "type": "file",
+      "name": "ChecksumImpl.cs",
+      "base_name": "ChecksumImpl",
+      "extension": ".cs",
+      "size": 8040,
+      "date": "2017-10-26",
+      "sha1": "3807a0e24a57b92ea301559cab7307b8eab52c51",
+      "md5": "d01b3cb2e75da9b15f05b92b42f6bd33",
+      "mime_type": "text/plain",
+      "file_type": "ISO-8859 text, with CRLF line terminators",
+      "programming_language": "C#",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "boost-1.0",
+          "score": 92.59,
+          "short_name": "Boost 1.0",
+          "category": "Permissive",
+          "owner": "Boost",
+          "homepage_url": "http://www.boost.org/users/license.html",
+          "text_url": "http://www.boost.org/LICENSE_1_0.txt",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:boost-1.0",
+          "spdx_license_key": "BSL-1.0",
+          "spdx_url": "https://spdx.org/licenses/BSL-1.0",
+          "start_line": 4,
+          "end_line": 5,
+          "matched_rule": {
+            "identifier": "boost-1.0_1.RULE",
+            "license_expression": "boost-1.0",
+            "licenses": [
+              "boost-1.0"
+            ],
+            "matcher": "3-seq",
+            "rule_length": 27,
+            "matched_length": 25,
+            "match_coverage": 92.59,
+            "rule_relevance": 100
+          },
+          "matched_text": "the Boost Software License, Version 1.0.\n// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt"
+        }
+      ],
+      "license_expressions": [
+        "boost-1.0"
+      ],
+      "holders": [
+        {
+          "value": "Henrik Ravn",
+          "start_line": 2,
+          "end_line": 2
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "(c) Copyright Henrik Ravn 2004",
+          "start_line": 2,
+          "end_line": 2
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://www.boost.org/LICENSE_1_0.txt",
+          "start_line": 5,
+          "end_line": 5
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "boost-1.0",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "(c) Copyright Henrik Ravn",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Henrik Ravn",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C#",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/dotzlib/LICENSE_1_0.txt",
+      "type": "file",
+      "name": "LICENSE_1_0.txt",
+      "base_name": "LICENSE_1_0",
+      "extension": ".txt",
+      "size": 1359,
+      "date": "2017-10-26",
+      "sha1": "892b34f7865d90a6f949f50d95e49625a10bc7f0",
+      "md5": "81543b22c36f10d20ac9712f8d80ef8d",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "boost-1.0",
+          "score": 100.0,
+          "short_name": "Boost 1.0",
+          "category": "Permissive",
+          "owner": "Boost",
+          "homepage_url": "http://www.boost.org/users/license.html",
+          "text_url": "http://www.boost.org/LICENSE_1_0.txt",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:boost-1.0",
+          "spdx_license_key": "BSL-1.0",
+          "spdx_url": "https://spdx.org/licenses/BSL-1.0",
+          "start_line": 1,
+          "end_line": 23,
+          "matched_rule": {
+            "identifier": "boost-1.0.LICENSE",
+            "license_expression": "boost-1.0",
+            "licenses": [
+              "boost-1.0"
+            ],
+            "matcher": "1-hash",
+            "rule_length": 214,
+            "matched_length": 214,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "Boost Software License - Version 1.0 - August 17th, 2003\n\nPermission is hereby granted, free of charge, to any person or organization\nobtaining a copy of the software and accompanying documentation covered by\nthis license (the \"Software\") to use, reproduce, display, distribute,\nexecute, and transmit the Software, and to prepare derivative works of the\nSoftware, and to permit third-parties to whom the Software is furnished to\ndo so, all subject to the following:\n\nThe copyright notices in the Software and this entire statement, including\nthe above license grant, this restriction and the following disclaimer,\nmust be included in all copies of the Software, in whole or in part, and\nall derivative works of the Software, unless such copies or derivative\nworks are solely in the form of machine-executable object code generated by\na source language processor.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT\nSHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE\nFOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,\nARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\nDEALINGS IN THE SOFTWARE"
+        }
+      ],
+      "license_expressions": [
+        "boost-1.0"
+      ],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": true,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": true,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "boost-1.0",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/dotzlib/readme.txt",
+      "type": "file",
+      "name": "readme.txt",
+      "base_name": "readme",
+      "extension": ".txt",
+      "size": 2358,
+      "date": "2017-10-26",
+      "sha1": "b1229b826f0096808628474538cea8fec2922a9b",
+      "md5": "1f20f3168ee63d90de033edac2ce383c",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "boost-1.0",
+          "score": 77.78,
+          "short_name": "Boost 1.0",
+          "category": "Permissive",
+          "owner": "Boost",
+          "homepage_url": "http://www.boost.org/users/license.html",
+          "text_url": "http://www.boost.org/LICENSE_1_0.txt",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:boost-1.0",
+          "spdx_license_key": "BSL-1.0",
+          "spdx_url": "https://spdx.org/licenses/BSL-1.0",
+          "start_line": 57,
+          "end_line": 58,
+          "matched_rule": {
+            "identifier": "boost-1.0_1.RULE",
+            "license_expression": "boost-1.0",
+            "licenses": [
+              "boost-1.0"
+            ],
+            "matcher": "3-seq",
+            "rule_length": 27,
+            "matched_length": 21,
+            "match_coverage": 77.78,
+            "rule_relevance": 100
+          },
+          "matched_text": "Version 1.0.\n(See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt"
+        }
+      ],
+      "license_expressions": [
+        "boost-1.0"
+      ],
+      "holders": [
+        {
+          "value": "Henrik Ravn",
+          "start_line": 55,
+          "end_line": 55
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) Henrik Ravn 2004",
+          "start_line": 55,
+          "end_line": 55
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://www.boost.org/LICENSE_1_0.txt",
+          "start_line": 58,
+          "end_line": 58
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": true,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "boost-1.0",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Henrik Ravn",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Henrik Ravn",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/gcc_gvmat64",
+      "type": "directory",
+      "name": "gcc_gvmat64",
+      "base_name": "gcc_gvmat64",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": "Gilles Vollant",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "GAS",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 1,
+      "dirs_count": 0,
+      "size_count": 16413,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/gcc_gvmat64/gvmat64.S",
+      "type": "file",
+      "name": "gvmat64.S",
+      "base_name": "gvmat64",
+      "extension": ".S",
+      "size": 16413,
+      "date": "2017-10-26",
+      "sha1": "742603cba1af98a1432cc02efb019b1a5760adf2",
+      "md5": "5e772d7302475e5473d0c4c57b9861e8",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text, with CRLF line terminators",
+      "programming_language": "GAS",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 100.0,
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 17,
+          "end_line": 31,
+          "matched_rule": {
+            "identifier": "zlib.LICENSE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 133,
+            "matched_length": 133,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "This software is provided 'as-is', without any express or implied\n;  warranty.  In no event will the authors be held liable for any damages\n;  arising from the use of this software.\n;\n;  Permission is granted to anyone to use this software for any purpose,\n;  including commercial applications, and to alter it and redistribute it\n;  freely, subject to the following restrictions:\n;\n;  1. The origin of this software must not be misrepresented; you must not\n;     claim that you wrote the original software. If you use this software\n;     in a product, an acknowledgment in the product documentation would be\n;     appreciated but is not required.\n;  2. Altered source versions must be plainly marked as such, and must not be\n;     misrepresented as being the original software\n;  3. This notice may not be removed or altered from any source distribution"
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+          "start_line": 10,
+          "end_line": 10
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2010 Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+          "start_line": 10,
+          "end_line": 10
+        }
+      ],
+      "authors": [
+        {
+          "value": "Gilles Vollant",
+          "start_line": 12,
+          "end_line": 15
+        }
+      ],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://www.zlib.net/",
+          "start_line": 33,
+          "end_line": 33
+        },
+        {
+          "url": "http://www.winimage.com/zLibDll",
+          "start_line": 34,
+          "end_line": 34
+        },
+        {
+          "url": "http://www.muppetlabs.com/~breadbox/software/assembly.html",
+          "start_line": 35,
+          "end_line": 35
+        },
+        {
+          "url": "http://weblogs.asp.net/oldnewthing/archive/2004/01/14/58579.aspx",
+          "start_line": 172,
+          "end_line": 172
+        },
+        {
+          "url": "http://msdn.microsoft.com/library/en-us/kmarch/hh/kmarch/64bitAMD_8e951dd2-ee77-4728-8702-55ce4b5dd24a.xml.asp",
+          "start_line": 173,
+          "end_line": 173
+        },
+        {
+          "url": "http://www.x86-64.org/documentation/abi-0.99.pdf",
+          "start_line": 180,
+          "end_line": 180
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": "Gilles Vollant",
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "GAS",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/infback9",
+      "type": "directory",
+      "name": "infback9",
+      "base_name": "infback9",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 2
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Mark Adler",
+            "count": 2
+          }
+        ],
+        "holders": [
+          {
+            "value": "Mark Adler",
+            "count": 2
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 2
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 2
+          }
+        ]
+      },
+      "files_count": 2,
+      "dirs_count": 0,
+      "size_count": 23223,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/infback9/infback9.c",
+      "type": "file",
+      "name": "infback9.c",
+      "base_name": "infback9",
+      "extension": ".c",
+      "size": 21629,
+      "date": "2017-10-26",
+      "sha1": "17fb362c03755b12f2dda5b12a68cf38162674bd",
+      "md5": "23ff5edec0817da303cb1294c1e4205c",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 60.0,
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 12,
+            "matched_length": 12,
+            "match_coverage": 100.0,
+            "rule_relevance": 60
+          },
+          "matched_text": "For conditions of distribution and use, see copyright notice in zlib.h"
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2008 Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Mark Adler",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Mark Adler",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/infback9/infback9.h",
+      "type": "file",
+      "name": "infback9.h",
+      "base_name": "infback9",
+      "extension": ".h",
+      "size": 1594,
+      "date": "2017-10-26",
+      "sha1": "d0486a32b558dcaceded5f0746fad62e680a4734",
+      "md5": "52b1ed99960d3ed7ed60cd20295e64a8",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 60.0,
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 12,
+            "matched_length": 12,
+            "match_coverage": 100.0,
+            "rule_relevance": 60
+          },
+          "matched_text": "For conditions of distribution and use, see copyright notice in zlib.h"
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2003 Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "zlib",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Mark Adler",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Mark Adler",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/iostream2",
+      "type": "directory",
+      "name": "iostream2",
+      "base_name": "iostream2",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": null,
+            "count": 1
+          },
+          {
+            "value": "cmr-no",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          },
+          {
+            "value": "Copyright (c) Christian Michelsen Research AS Advanced Computing",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          },
+          {
+            "value": "Christian Michelsen Research AS Advanced Computing",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 2
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 1
+          },
+          {
+            "value": "C++",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 2,
+      "dirs_count": 0,
+      "size_count": 9994,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/iostream2/zstream.h",
+      "type": "file",
+      "name": "zstream.h",
+      "base_name": "zstream",
+      "extension": ".h",
+      "size": 9283,
+      "date": "2017-10-26",
+      "sha1": "fca4540d490fff36bb90fd801cf9cd8fc695bb17",
+      "md5": "a980b61c1e8be68d5cdb1236ba6b43e7",
+      "mime_type": "text/x-c++",
+      "file_type": "C++ source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "cmr-no",
+          "score": 100.0,
+          "short_name": "CMR License",
+          "category": "Permissive",
+          "owner": "CMR - Christian Michelsen Research AS",
+          "homepage_url": "",
+          "text_url": "",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:cmr-no",
+          "spdx_license_key": "",
+          "spdx_url": "",
+          "start_line": 9,
+          "end_line": 15,
+          "matched_rule": {
+            "identifier": "cmr-no.LICENSE",
+            "license_expression": "cmr-no",
+            "licenses": [
+              "cmr-no"
+            ],
+            "matcher": "2-aho",
+            "rule_length": 71,
+            "matched_length": 71,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          },
+          "matched_text": "Permission to use, copy, modify, distribute and sell this software\n * and its documentation for any purpose is hereby granted without fee,\n * provided that the above copyright notice appear in all copies and\n * that both that copyright notice and this permission notice appear\n * in supporting documentation.  Christian Michelsen Research AS makes no\n * representations about the suitability of this software for any\n * purpose.  It is provided \"as is\" without express or implied warranty"
+        }
+      ],
+      "license_expressions": [
+        "cmr-no"
+      ],
+      "holders": [
+        {
+          "value": "Christian Michelsen Research AS Advanced Computing",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1997 Christian Michelsen Research AS Advanced Computing",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [
+        {
+          "url": "http://www.cmr.no/",
+          "start_line": 7,
+          "end_line": 7
+        }
+      ],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": "cmr-no",
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": "Copyright (c) Christian Michelsen Research AS Advanced Computing",
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": "Christian Michelsen Research AS Advanced Computing",
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/iostream2/zstream_test.cpp",
+      "type": "file",
+      "name": "zstream_test.cpp",
+      "base_name": "zstream_test",
+      "extension": ".cpp",
+      "size": 711,
+      "date": "2017-10-26",
+      "sha1": "e18a6d55cbbd8b832f8d795530553467e5c74fcf",
+      "md5": "d32476bde4e6d5f889092fdff6f8cdb0",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C++",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "emails": [],
+      "urls": [],
+      "facets": [
+        "core"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "is_generated": false,
+      "packages": [],
+      "summary": {
+        "license_expressions": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "copyrights": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "holders": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "authors": [
+          {
+            "value": null,
+            "count": 1
+          }
+        ],
+        "programming_language": [
+          {
+            "value": "C++",
+            "count": 1
+          }
+        ]
+      },
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    }
+  ]
+}

--- a/tests/scancode/test_resource.py
+++ b/tests/scancode/test_resource.py
@@ -35,6 +35,9 @@ from os.path import join
 from commoncode.testcase import FileBasedTesting
 from commoncode.fileutils import parent_directory
 
+from scancode.cli_test_utils import load_json_result
+from scancode.cli_test_utils import run_scan_click
+
 from scancode.resource import Codebase
 from scancode.resource import get_path
 from scancode.resource import VirtualCodebase
@@ -603,11 +606,9 @@ class TestVirtualCodebase(FileBasedTesting):
     test_data_dir = join(dirname(__file__), 'data')
 
     def test_virtual_codebase_walk_defaults(self):
-        scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
-        results = list(virtual_codebase.walk())
+        test_file = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
+        codebase = VirtualCodebase(location=test_file)
+        results = list(codebase.walk())
         expected = [
             ('codebase', False),
               ('abc', True),
@@ -621,11 +622,9 @@ class TestVirtualCodebase(FileBasedTesting):
         assert expected == [(r.name, r.is_file) for r in results]
 
     def test_virtual_codebase_walk_topdown(self):
-        scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
-        results = list(virtual_codebase.walk(topdown=True))
+        test_file = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
+        codebase = VirtualCodebase(location=test_file)
+        results = list(codebase.walk(topdown=True))
         expected = [
             ('codebase', False),
               ('abc', True),
@@ -639,11 +638,9 @@ class TestVirtualCodebase(FileBasedTesting):
         assert expected == [(r.name, r.is_file) for r in results]
 
     def test_virtual_codebase_walk_bottomup(self):
-        scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
-        results = list(virtual_codebase.walk(topdown=False))
+        test_file = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
+        codebase = VirtualCodebase(location=test_file)
+        results = list(codebase.walk(topdown=False))
         expected = [
               ('abc', True),
               ('et131x.h', True),
@@ -658,9 +655,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_walk_skip_root_basic(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         results = list(virtual_codebase.walk(skip_root=True))
         expected = [
             ('abc', True),
@@ -675,9 +670,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_walk_filtered_with_filtered_root(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         virtual_codebase.root.is_filtered = True
         results = list(virtual_codebase.walk_filtered())
         expected = [
@@ -693,9 +686,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_walk_filtered_with_all_filtered(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         for res in virtual_codebase.walk():
             res.is_filtered = True
         results = list(virtual_codebase.walk_filtered())
@@ -704,18 +695,14 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_compute_counts_filtered_None(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         results = virtual_codebase.compute_counts(skip_filtered=True)
         expected = (5, 3, 2228)
         assert expected == results
 
     def test_virtual_codebase_compute_counts_filtered_None_with_size(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         for res in virtual_codebase.walk():
             if res.is_file:
                 res.size = 10
@@ -726,18 +713,14 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_compute_counts_filtered_None_with_cache(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         results = virtual_codebase.compute_counts(skip_filtered=True)
         expected = (5, 3, 2228)
         assert expected == results
 
     def test_virtual_codebase_compute_counts_filtered_all(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         for res in virtual_codebase.walk():
             res.is_filtered = True
         results = virtual_codebase.compute_counts(skip_filtered=True)
@@ -746,9 +729,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_compute_counts_filtered_all_with_cache(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         for res in virtual_codebase.walk():
             res.is_filtered = True
         results = virtual_codebase.compute_counts(skip_filtered=True)
@@ -757,9 +738,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_compute_counts_filtered_files(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         for res in virtual_codebase.walk():
             if res.is_file:
                 res.is_filtered = True
@@ -769,9 +748,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_compute_counts_filtered_dirs(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         for res in virtual_codebase.walk():
             if not res.is_file:
                 res.is_filtered = True
@@ -781,9 +758,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_walk_filtered_dirs(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         for res in virtual_codebase.walk():
             if not res.is_file:
                 res.is_filtered = True
@@ -800,9 +775,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_walk_filtered_skip_root(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         virtual_codebase.root.is_filtered = True
         results = list(virtual_codebase.walk_filtered(skip_root=True))
         expected = [
@@ -818,9 +791,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_walk_filtered_all_skip_root(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/virtual_codebase.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         for res in virtual_codebase.walk():
             res.is_filtered = True
         results = list(virtual_codebase.walk_filtered(skip_root=True))
@@ -829,9 +800,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_walk_skip_root_single_file(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/et131x.h.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         results = list(virtual_codebase.walk(skip_root=True))
         expected = [
             ('et131x.h', True)
@@ -840,9 +809,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_walk_filtered_with_skip_root_and_single_file_not_filtered(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/et131x.h.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         results = list(virtual_codebase.walk_filtered(skip_root=True))
         expected = [
             ('et131x.h', True)
@@ -851,9 +818,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_walk_filtered__with_skip_root_and_filtered_single_file(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/et131x.h.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         virtual_codebase.root.is_filtered = True
         results = list(virtual_codebase.walk_filtered(skip_root=True))
         expected = [
@@ -862,10 +827,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_walk_skip_root_single_file_with_children(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/et131x.h.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
-
+        virtual_codebase = VirtualCodebase(location=scan_data)
         c1 = virtual_codebase._create_resource('some child', parent=virtual_codebase.root, is_file=True)
         _c2 = virtual_codebase._create_resource('some child2', parent=c1, is_file=False)
         results = list(virtual_codebase.walk(skip_root=True))
@@ -876,10 +838,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_walk_filtered_with_skip_root_and_single_file_with_children(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/et131x.h.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
-
+        virtual_codebase = VirtualCodebase(location=scan_data)
         c1 = virtual_codebase._create_resource('some child', parent=virtual_codebase.root, is_file=True)
         c2 = virtual_codebase._create_resource('some child2', parent=c1, is_file=False)
         c2.is_filtered = True
@@ -897,9 +856,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase__create_resource_can_add_child_to_file(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/et131x.h.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         virtual_codebase._create_resource('some child', virtual_codebase.root, is_file=True)
         results = list(virtual_codebase.walk())
         expected = [('et131x.h', True), (u'some child', True)]
@@ -907,9 +864,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase__create_resource_can_add_child_to_dir(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/resource.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         virtual_codebase._create_resource('some child', virtual_codebase.root, is_file=False)
         results = list(virtual_codebase.walk())
         expected = [('resource', False), (u'some child', False)]
@@ -917,14 +872,12 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_get_resource(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/resource.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         assert virtual_codebase.root is virtual_codebase.get_resource(0)
 
     def test_virtual_codebase_can_process_minimal_resources_without_info(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/noinfo.json')
-        codebase = VirtualCodebase(json_scan_location=scan_data, plugin_attributes={})
+        codebase = VirtualCodebase(location=scan_data)
         expected = [
             OrderedDict([
                 (u'path', u'NOTICE'),
@@ -945,7 +898,7 @@ class TestVirtualCodebase(FileBasedTesting):
 
     def test_virtual_codebase_can_process_minimal_resources_with_only_path(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/only-path.json')
-        codebase = VirtualCodebase(json_scan_location=scan_data, plugin_attributes={})
+        codebase = VirtualCodebase(location=scan_data)
         expected = [OrderedDict([
             (u'path', u'NOTICE'),
             (u'type', u'file'),
@@ -953,16 +906,20 @@ class TestVirtualCodebase(FileBasedTesting):
         ])]
         assert expected == [r.to_dict() for r in codebase.walk()]
 
+
+class TestCodebaseLoweestCommonParent(FileBasedTesting):
+    test_data_dir = join(dirname(__file__), 'data')
+
     def test_lowest_common_parent_on_virtual_codebase(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/lcp.json')
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         lcp = virtual_codebase.lowest_common_parent()
         assert 'lcp/test1' == lcp.path
         assert 'test1' == lcp.name
 
     def test_virtual_codebase_has_default_for_plugin_attributes(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/only-path.json')
-        VirtualCodebase(json_scan_location=scan_data)
+        VirtualCodebase(location=scan_data)
 
     def test_lowest_common_parent_1(self):
         test_codebase = self.get_test_loc('resource/lcp/test1')
@@ -1031,9 +988,7 @@ class TestVirtualCodebaseCache(FileBasedTesting):
 
     def test_virtual_codebase_cache_default(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/cache2.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes)
+        virtual_codebase = VirtualCodebase(location=scan_data)
         assert virtual_codebase.temp_dir
         assert virtual_codebase.cache_dir
         virtual_codebase.cache_dir
@@ -1053,9 +1008,7 @@ class TestVirtualCodebaseCache(FileBasedTesting):
 
     def test_virtual_codebase_cache_all_in_memory(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/cache2.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes,
+        virtual_codebase = VirtualCodebase(location=scan_data,
                                            max_in_memory=0)
         for rid in virtual_codebase.resource_ids:
             if rid == 0:
@@ -1070,9 +1023,7 @@ class TestVirtualCodebaseCache(FileBasedTesting):
 
     def test_virtual_codebase_cache_all_on_disk(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/cache2.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes,
+        virtual_codebase = VirtualCodebase(location=scan_data,
                                            max_in_memory=-1)
         for rid in virtual_codebase.resource_ids:
             if rid == 0:
@@ -1087,9 +1038,7 @@ class TestVirtualCodebaseCache(FileBasedTesting):
 
     def test_virtual_codebase_cache_mixed_two_in_memory(self):
         scan_data = self.get_test_loc('resource/virtual_codebase/cache2.json')
-        attributes = {}
-        virtual_codebase = VirtualCodebase(json_scan_location=scan_data,
-                                           plugin_attributes=attributes,
+        virtual_codebase = VirtualCodebase(location=scan_data,
                                            max_in_memory=2)
         for rid in virtual_codebase.resource_ids:
             if rid == 0:
@@ -1104,3 +1053,22 @@ class TestVirtualCodebaseCache(FileBasedTesting):
                 assert virtual_codebase._exists_on_disk(rid)
 
         assert len(virtual_codebase.resource_ids) == len(list(virtual_codebase.walk()))
+
+
+class TestVirtualCodebaseCliFromJSON(FileBasedTesting):
+    test_data_dir = join(dirname(__file__), 'data')
+
+    def test_virtual_codebase_output_with_from_json_is_same_as_original(self):
+        test_file = self.get_test_loc('resource/virtual_idempotent/codebase.json')
+        result_file = self.get_temp_file('json')
+        args = ['--from-json', test_file, '--json-pp', result_file]
+        run_scan_click(args)
+        expected = load_json_result(test_file, strip_dates=True)
+        results = load_json_result(result_file, strip_dates=True)
+
+        keys_to_pop = 'scan_start', 'scancode_options', 'summary'
+        for k in keys_to_pop:
+            expected.pop(k, None)
+            results.pop(k, None)
+        import json
+        assert json.dumps(expected, indent=2) == json.dumps(results , indent=2)


### PR DESCRIPTION
This is a fix for #1144 
Some fields are skipped when using `--from-json`
This PR corrects the issue (except for the summary and header attributes)