### PR TITLE
Rename data.json to data.js

### DIFF
--- a/src/formattedcode/output_html.py
+++ b/src/formattedcode/output_html.py
@@ -294,7 +294,7 @@ def create_html_app_assets(results, output_file):
         # write json data
         # FIXME: this should a regular JSON scan format
         root_path, assets_dir = get_html_app_files_dirs(output_file)
-        with io.open(join(root_path, assets_dir, 'data.json'), 'wb') as f:
+        with io.open(join(root_path, assets_dir, 'data.js'), 'wb') as f:
             f.write(b'data=')
             simplejson.dump(results, f, iterable_as_array=True)
 

--- a/src/formattedcode/templates/html-app/template.html
+++ b/src/formattedcode/templates/html-app/template.html
@@ -108,7 +108,7 @@
   <script src="{{ assets_dir }}/chart.js"></script>
   <script src="{{ assets_dir }}/scancode_jstree.js"></script>
   <script src="{{ assets_dir }}/scancode_datatable.js"></script>
-  <script type="text/javascript" src="{{ assets_dir }}/data.json"></script>
+  <script type="text/javascript" src="{{ assets_dir }}/data.js"></script>
   <script type="text/javascript">
       var dataArray = data;
       var currNodeData = null;

--- a/tests/formattedcode/test_output_csv.py
+++ b/tests/formattedcode/test_output_csv.py
@@ -47,7 +47,7 @@ test_env.test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
 def load_scan(json_input):
     """
     Return a list of scan results loaded from a json_input, either in
-    ScanCode standard JSON format or the data.json html-app format.
+    ScanCode standard JSON format or the data.js html-app format.
     """
     with io.open(json_input, encoding='utf-8') as jsonf:
         scan = jsonf.read()

--- a/tests/formattedcode/test_output_templated.py
+++ b/tests/formattedcode/test_output_templated.py
@@ -45,8 +45,8 @@ def test_paths_are_posix_paths_in_html_app_format_output():
     test_dir = test_env.get_test_loc('templated/simple')
     result_file = test_env.get_temp_file(extension='html', file_name='test_html')
     run_scan_click(['--copyright', test_dir, '--html-app', result_file])
-    # the data we want to test is in the data.json file
-    data_file = os.path.join(fileutils.parent_directory(result_file), 'test_html_files', 'data.json')
+    # the data we want to test is in the data.js file
+    data_file = os.path.join(fileutils.parent_directory(result_file), 'test_html_files', 'data.js')
     with io.open(data_file, encoding='utf-8') as res:
         results = res.read()
     assert '/copyright_acme_c-c.c' in results


### PR DESCRIPTION
The file data.json in the html-app isn't a valid json. It contains a js
variable containing a valid json, so basically the file ending should
be js.

When I want to open the html app via the Jenkins HTML publisher plugin,
I get the following error in the Chrome console:
Refused to execute script from 'https://.../report_files/data.json'
because its MIME type ('application/json') is not executable, and strict
MIME type checking is enabled.

This commit fixes that issue.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>