### PR TITLE
Add openssl SPDX identifier

### DIFF
--- a/src/licensedcode/data/licenses/openssl.yml
+++ b/src/licensedcode/data/licenses/openssl.yml
@@ -5,9 +5,8 @@ category: Permissive
 owner: OpenSSL
 homepage_url: http://openssl.org/source/license.html
 notes: |-
-    This is the OpenSSL license proper, without the SSLEay part. The SPDX
-    OpenSSL identifier does not apply here. Instead it matches the openssl-
-    ssleay license.
+    This is the OpenSSL license proper, without the SSLEay part.
+spdx_license_key: OpenSSL
 faq_url: http://www.openssl.org/support/faq.html
 other_urls:
     - http://www.openssl.org/source/license.html


### PR DESCRIPTION
OpenSSL SPDX identifier is listed in the SPDX License List: https://spdx.org/licenses/