### PR TITLE
Simplify calling output plugins from code #1148

### DIFF
--- a/src/formattedcode/output_spdx.py
+++ b/src/formattedcode/output_spdx.py
@@ -147,7 +147,8 @@ class SpdxTvOutput(OutputPlugin):
     def is_enabled(self, spdx_tv, info, **kwargs):
         return spdx_tv and info
 
-    def process_codebase(self, codebase, input, spdx_tv, **kwargs):  # NOQA
+    def process_codebase(self, codebase, spdx_tv, **kwargs):
+        input = kwargs.get('input', '')  # NOQA
         results = self.get_results(codebase, **kwargs)
         _files_count, version, notice, _scan_start, _options = get_headings(codebase)
         write_spdx(spdx_tv, results, version, notice, input, as_tagvalue=True)
@@ -168,7 +169,8 @@ class SpdxRdfOutput(OutputPlugin):
     def is_enabled(self, spdx_rdf, info, **kwargs):
         return spdx_rdf and info
 
-    def process_codebase(self, codebase, input, spdx_rdf, **kwargs):  # NOQA
+    def process_codebase(self, codebase, spdx_rdf, **kwargs):
+        input = kwargs.get('input', '')  # NOQA
         results = self.get_results(codebase, **kwargs)
         _files_count, version, notice, _scan_start, _options = get_headings(codebase)
         write_spdx(spdx_rdf, results, version, notice, input, as_tagvalue=False)

--- a/src/plugincode/output.py
+++ b/src/plugincode/output.py
@@ -81,21 +81,26 @@ class OutputPlugin(CodebasePlugin):
     Base plugin class for scan output formatters all output plugins must extend.
     """
 
-    def process_codebase(self, codebase, **kwargs):
+    def process_codebase(self, codebase, output, **kwargs):
         """
-        Write scan output for the `codebase`.
+        Write `codebase` to the `output` file-like object (which could be a
+        sys.stdout or a StringIO).
+
+        Note: each subclass is using a differnt arg name for `output`
         """
         raise NotImplementedError
 
     @classmethod
-    def get_results(cls, codebase, info, full_root, strip_root, timing, **kwargs):
+    def get_results(cls, codebase, **kwargs):
         """
         Return an iterable of serialized scan results from a codebase.
         """
         # FIXME: serialization SHOULD NOT be needed: only some format need it
         # (e.g. JSON) and only these should serialize
-        with_info = info or getattr(codebase, 'with_info', False)
-        serializer = partial(Resource.to_dict, with_info=with_info, with_timing=timing)
+        timing = kwargs.get('timing', False)
+        info = kwargs.get('info', False) or getattr(codebase, 'with_info', False)
+        strip_root = kwargs.get('strip_root', False)
+        serializer = partial(Resource.to_dict, with_info=info, with_timing=timing)
         resources = codebase.walk_filtered(topdown=True, skip_root=strip_root)
         return imap(serializer, resources)
 

--- a/src/scancode/resource.py
+++ b/src/scancode/resource.py
@@ -128,9 +128,9 @@ class LogEntry(object):
     should create a LogEntry and append it to the codebase logentries list.
     """
     tool = String(help='Tool used such as scancode-toolkit.')
-    tool_version = String(help='Tool version used such as v1.2.3.')
+    tool_version = String(default='', help='Tool version used such as v1.2.3.')
     options = Mapping(help='Mapping of key/values describing the options used with this tool.')
-    notice = String(help='Notice text for this tool.')
+    notice = String(default='', help='Notice text for this tool.')
     start_timestamp = String(help='Start timestamp for this log entry.')
     end_timestamp = String(help='End timestamp for this log entry.')
     message = String(help='Message text.')

--- a/tests/formattedcode/data/reuse/vb.json
+++ b/tests/formattedcode/data/reuse/vb.json
@@ -1,0 +1,3104 @@
+{
+  "scancode_notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+  "scancode_version": "2.9.3.post37.712e0a192.dirty.20181009060429",
+  "scancode_options": {
+    "input": "samples/",
+    "--classify": true,
+    "--copyright": true,
+    "--info": true,
+    "--json-pp": "vb.json",
+    "--license": true,
+    "--license-clarity-score": true,
+    "--package": true,
+    "--processes": "6",
+    "--summary": true,
+    "--summary-key-files": true
+  },
+  "scan_start": "2018-10-09T062146.778586",
+  "files_count": 33,
+  "summary": {
+    "license_expressions": [
+      {
+        "value": "zlib",
+        "count": 10
+      },
+      {
+        "value": null,
+        "count": 7
+      },
+      {
+        "value": "lgpl-2.1-plus",
+        "count": 5
+      },
+      {
+        "value": "boost-1.0",
+        "count": 3
+      },
+      {
+        "value": "public-domain",
+        "count": 2
+      },
+      {
+        "value": "apache-1.1",
+        "count": 1
+      },
+      {
+        "value": "apache-2.0",
+        "count": 1
+      },
+      {
+        "value": "cc-by-2.5",
+        "count": 1
+      },
+      {
+        "value": "cmr-no",
+        "count": 1
+      },
+      {
+        "value": "cpl-1.0",
+        "count": 1
+      },
+      {
+        "value": "gpl-2.0-plus WITH ada-linking-exception",
+        "count": 1
+      },
+      {
+        "value": "jboss-eula",
+        "count": 1
+      },
+      {
+        "value": "mit",
+        "count": 1
+      }
+    ],
+    "copyrights": [
+      {
+        "value": null,
+        "count": 10
+      },
+      {
+        "value": "Copyright (c) Jean-loup Gailly",
+        "count": 3
+      },
+      {
+        "value": "Copyright (c) Jean-loup Gailly and Mark Adler",
+        "count": 3
+      },
+      {
+        "value": "Copyright (c) Mark Adler",
+        "count": 3
+      },
+      {
+        "value": "(c) Copyright Henrik Ravn",
+        "count": 2
+      },
+      {
+        "value": "Copyright (c) Free Software Foundation, Inc.",
+        "count": 2
+      },
+      {
+        "value": "copyrighted by the Free Software Foundation",
+        "count": 2
+      },
+      {
+        "value": "Copyright (c) - The Legion Of The Bouncy Castle (http://www.bouncycastle.org)",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) Brian Goetz and Tim Peierls",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) Christian Michelsen Research AS Advanced Computing",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) Dmitriy Anisimkov",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) The Apache Software Foundation.",
+        "count": 1
+      },
+      {
+        "value": "Copyright (c) by Henrik Ravn",
+        "count": 1
+      },
+      {
+        "value": "Copyright JBoss Inc., and individual contributors",
+        "count": 1
+      },
+      {
+        "value": "Copyright Red Hat Middleware LLC, and individual contributors",
+        "count": 1
+      },
+      {
+        "value": "Copyright Red Hat, Inc.",
+        "count": 1
+      },
+      {
+        "value": "Copyright Red Hat, Inc. and individual contributors",
+        "count": 1
+      }
+    ],
+    "holders": [
+      {
+        "value": null,
+        "count": 10
+      },
+      {
+        "value": "Free Software Foundation, Inc.",
+        "count": 4
+      },
+      {
+        "value": "Henrik Ravn",
+        "count": 3
+      },
+      {
+        "value": "Jean-loup Gailly",
+        "count": 3
+      },
+      {
+        "value": "Jean-loup Gailly and Mark Adler",
+        "count": 3
+      },
+      {
+        "value": "Mark Adler",
+        "count": 3
+      },
+      {
+        "value": "Brian Goetz and Tim Peierls",
+        "count": 1
+      },
+      {
+        "value": "Christian Michelsen Research AS Advanced Computing",
+        "count": 1
+      },
+      {
+        "value": "Dmitriy Anisimkov",
+        "count": 1
+      },
+      {
+        "value": "JBoss Inc., and individual contributors",
+        "count": 1
+      },
+      {
+        "value": "Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+        "count": 1
+      },
+      {
+        "value": "Red Hat Middleware LLC, and individual contributors",
+        "count": 1
+      },
+      {
+        "value": "Red Hat, Inc.",
+        "count": 1
+      },
+      {
+        "value": "Red Hat, Inc. and individual contributors",
+        "count": 1
+      },
+      {
+        "value": "The Apache Software Foundation.",
+        "count": 1
+      },
+      {
+        "value": "The Legion Of The Bouncy Castle",
+        "count": 1
+      }
+    ],
+    "authors": [
+      {
+        "value": null,
+        "count": 24
+      },
+      {
+        "value": "Bela Ban",
+        "count": 4
+      },
+      {
+        "value": "Brian Stansberry",
+        "count": 1
+      },
+      {
+        "value": "Chris Mills (millsy@jboss.com)",
+        "count": 1
+      },
+      {
+        "value": "Gilles Vollant",
+        "count": 1
+      },
+      {
+        "value": "Leonid Broukhis.",
+        "count": 1
+      },
+      {
+        "value": "Robert Harder",
+        "count": 1
+      },
+      {
+        "value": "rob@iharder.net",
+        "count": 1
+      },
+      {
+        "value": "the Apache Software Foundation (http://www.apache.org/).",
+        "count": 1
+      }
+    ],
+    "programming_language": [
+      {
+        "value": null,
+        "count": 11
+      },
+      {
+        "value": "C",
+        "count": 9
+      },
+      {
+        "value": "Java",
+        "count": 7
+      },
+      {
+        "value": "C#",
+        "count": 2
+      },
+      {
+        "value": "Ada",
+        "count": 1
+      },
+      {
+        "value": "C++",
+        "count": 1
+      },
+      {
+        "value": "GAS",
+        "count": 1
+      },
+      {
+        "value": "JavaScript+Lasso",
+        "count": 1
+      }
+    ]
+  },
+  "license_score": {
+    "score": 13,
+    "has_top_level_declared_licenses": false,
+    "file_level_license_and_copyright_coverage": 0.53125,
+    "has_consistent_key_and_file_level_license": false,
+    "has_all_spdx_licenses": false,
+    "has_all_license_texts": false
+  },
+  "summary_of_key_files": {
+    "license_expressions": [
+      {
+        "value": null,
+        "count": 1
+      }
+    ],
+    "copyrights": [
+      {
+        "value": null,
+        "count": 1
+      }
+    ],
+    "holders": [
+      {
+        "value": null,
+        "count": 1
+      }
+    ],
+    "authors": [
+      {
+        "value": null,
+        "count": 1
+      }
+    ],
+    "programming_language": [
+      {
+        "value": null,
+        "count": 1
+      }
+    ]
+  },
+  "files": [
+    {
+      "path": "samples",
+      "type": "directory",
+      "name": "samples",
+      "base_name": "samples",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": true,
+      "packages": [],
+      "files_count": 33,
+      "dirs_count": 10,
+      "size_count": 1161083,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/README",
+      "type": "file",
+      "name": "README",
+      "base_name": "README",
+      "extension": "",
+      "size": 236,
+      "date": "2017-10-26",
+      "sha1": "2e07e32c52d607204fad196052d70e3d18fb8636",
+      "md5": "effc6856ef85a9250fb1a470792b3f38",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": true,
+      "is_top_level": true,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/screenshot.png",
+      "type": "file",
+      "name": "screenshot.png",
+      "base_name": "screenshot",
+      "extension": ".png",
+      "size": 622754,
+      "date": "2017-10-26",
+      "sha1": "01ff4b1de0bc6c75c9cca6e46c80c1802d6976d4",
+      "md5": "b6ef5a90777147423c98b42a6a25e57a",
+      "mime_type": "image/png",
+      "file_type": "PNG image data, 2880 x 1666, 8-bit/color RGB, non-interlaced",
+      "programming_language": null,
+      "is_binary": true,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": true,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": true,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/arch",
+      "type": "directory",
+      "name": "arch",
+      "base_name": "arch",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": true,
+      "packages": [],
+      "files_count": 1,
+      "dirs_count": 0,
+      "size_count": 28103,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/arch/zlib.tar.gz",
+      "type": "file",
+      "name": "zlib.tar.gz",
+      "base_name": "zlib",
+      "extension": ".tar.gz",
+      "size": 28103,
+      "date": "2017-10-26",
+      "sha1": "576f0ccfe534d7f5ff5d6400078d3c6586de3abd",
+      "md5": "20b2370751abfc08bb3556c1d8114b5a",
+      "mime_type": "application/x-gzip",
+      "file_type": "gzip compressed data, last modified: Wed Jul 15 09:08:19 2015, from Unix",
+      "programming_language": null,
+      "is_binary": true,
+      "is_text": false,
+      "is_archive": true,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups",
+      "type": "directory",
+      "name": "JGroups",
+      "base_name": "JGroups",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": true,
+      "packages": [],
+      "files_count": 14,
+      "dirs_count": 2,
+      "size_count": 241228,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/EULA",
+      "type": "file",
+      "name": "EULA",
+      "base_name": "EULA",
+      "extension": "",
+      "size": 8156,
+      "date": "2017-10-26",
+      "sha1": "eb232aa0424eca9c4136904e6143b72aaa9cf4de",
+      "md5": "0be0aceb8296727efff0ac0bf8e6bdb3",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "JavaScript+Lasso",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "jboss-eula",
+          "score": 100.0,
+          "name": "JBoss EULA",
+          "short_name": "JBoss EULA",
+          "category": "Proprietary Free",
+          "is_exception": false,
+          "owner": "JBoss Community",
+          "homepage_url": "",
+          "text_url": "http://repository.jboss.org/licenses/jbossorg-eula.txt",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:jboss-eula",
+          "spdx_license_key": "",
+          "spdx_url": "",
+          "start_line": 3,
+          "end_line": 108,
+          "matched_rule": {
+            "identifier": "jboss-eula.LICENSE",
+            "license_expression": "jboss-eula",
+            "licenses": [
+              "jboss-eula"
+            ],
+            "is_license_text": true,
+            "is_license_notice": false,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "jboss-eula"
+      ],
+      "holders": [
+        {
+          "value": "Red Hat, Inc.",
+          "start_line": 104,
+          "end_line": 104
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright 2006 Red Hat, Inc.",
+          "start_line": 104,
+          "end_line": 104
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": true,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/LICENSE",
+      "type": "file",
+      "name": "LICENSE",
+      "base_name": "LICENSE",
+      "extension": "",
+      "size": 26430,
+      "date": "2017-10-26",
+      "sha1": "e60c2e780886f95df9c9ee36992b8edabec00bcc",
+      "md5": "7fbc338309ac38fefcd64b04bb903e34",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "lgpl-2.1-plus",
+          "score": 100.0,
+          "name": "GNU Lesser General Public License 2.1 or later",
+          "short_name": "LGPL 2.1 or later",
+          "category": "Copyleft Limited",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:lgpl-2.1-plus",
+          "spdx_license_key": "LGPL-2.1-or-later",
+          "spdx_url": "https://spdx.org/licenses/LGPL-2.1-or-later",
+          "start_line": 1,
+          "end_line": 502,
+          "matched_rule": {
+            "identifier": "lgpl-2.1-plus_2.RULE",
+            "license_expression": "lgpl-2.1-plus",
+            "licenses": [
+              "lgpl-2.1-plus"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "lgpl-2.1-plus"
+      ],
+      "holders": [
+        {
+          "value": "Free Software Foundation, Inc.",
+          "start_line": 4,
+          "end_line": 6
+        },
+        {
+          "value": "the Free Software Foundation",
+          "start_line": 428,
+          "end_line": 433
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1991, 1999 Free Software Foundation, Inc.",
+          "start_line": 4,
+          "end_line": 6
+        },
+        {
+          "value": "copyrighted by the Free Software Foundation",
+          "start_line": 428,
+          "end_line": 433
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": true,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses",
+      "type": "directory",
+      "name": "licenses",
+      "base_name": "licenses",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 5,
+      "dirs_count": 0,
+      "size_count": 54552,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses/apache-1.1.txt",
+      "type": "file",
+      "name": "apache-1.1.txt",
+      "base_name": "apache-1.1",
+      "extension": ".txt",
+      "size": 2885,
+      "date": "2017-10-26",
+      "sha1": "6b5608d35c3e304532af43db8bbfc5947bef46a6",
+      "md5": "276982197c941f4cbf3d218546e17ae2",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "apache-1.1",
+          "score": 100.0,
+          "name": "Apache License 1.1",
+          "short_name": "Apache 1.1",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "Apache Software Foundation",
+          "homepage_url": "http://www.apache.org/licenses/",
+          "text_url": "http://apache.org/licenses/LICENSE-1.1",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-1.1",
+          "spdx_license_key": "Apache-1.1",
+          "spdx_url": "https://spdx.org/licenses/Apache-1.1",
+          "start_line": 2,
+          "end_line": 56,
+          "matched_rule": {
+            "identifier": "apache-1.1.SPDX.RULE",
+            "license_expression": "apache-1.1",
+            "licenses": [
+              "apache-1.1"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "apache-1.1"
+      ],
+      "holders": [
+        {
+          "value": "The Apache Software Foundation.",
+          "start_line": 4,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2000 The Apache Software Foundation.",
+          "start_line": 4,
+          "end_line": 5
+        }
+      ],
+      "authors": [
+        {
+          "value": "the Apache Software Foundation (http://www.apache.org/).",
+          "start_line": 21,
+          "end_line": 23
+        }
+      ],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses/apache-2.0.txt",
+      "type": "file",
+      "name": "apache-2.0.txt",
+      "base_name": "apache-2.0",
+      "extension": ".txt",
+      "size": 11560,
+      "date": "2017-10-26",
+      "sha1": "47b573e3824cd5e02a1a3ae99e2735b49e0256e4",
+      "md5": "d273d63619c9aeaf15cdaf76422c4f87",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "apache-2.0",
+          "score": 100.0,
+          "name": "Apache License 2.0",
+          "short_name": "Apache 2.0",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "Apache Software Foundation",
+          "homepage_url": "http://www.apache.org/licenses/",
+          "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+          "spdx_license_key": "Apache-2.0",
+          "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+          "start_line": 2,
+          "end_line": 202,
+          "matched_rule": {
+            "identifier": "apache-2.0.LICENSE",
+            "license_expression": "apache-2.0",
+            "licenses": [
+              "apache-2.0"
+            ],
+            "is_license_text": true,
+            "is_license_notice": false,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "apache-2.0"
+      ],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses/bouncycastle.txt",
+      "type": "file",
+      "name": "bouncycastle.txt",
+      "base_name": "bouncycastle",
+      "extension": ".txt",
+      "size": 1186,
+      "date": "2017-10-26",
+      "sha1": "74facb0e9a734479f9cd893b5be3fe1bf651b760",
+      "md5": "9fffd8de865a5705969f62b128381f85",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "mit",
+          "score": 98.8,
+          "name": "MIT License",
+          "short_name": "MIT License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "MIT",
+          "homepage_url": "http://opensource.org/licenses/mit-license.php",
+          "text_url": "http://opensource.org/licenses/mit-license.php",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:mit",
+          "spdx_license_key": "MIT",
+          "spdx_url": "https://spdx.org/licenses/MIT",
+          "start_line": 3,
+          "end_line": 18,
+          "matched_rule": {
+            "identifier": "mit_160.RULE",
+            "license_expression": "mit",
+            "licenses": [
+              "mit"
+            ],
+            "is_license_text": true,
+            "is_license_notice": false,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "mit"
+      ],
+      "holders": [
+        {
+          "value": "The Legion Of The Bouncy Castle",
+          "start_line": 5,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2000 - 2006 The Legion Of The Bouncy Castle (http://www.bouncycastle.org)",
+          "start_line": 5,
+          "end_line": 5
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses/cpl-1.0.txt",
+      "type": "file",
+      "name": "cpl-1.0.txt",
+      "base_name": "cpl-1.0",
+      "extension": ".txt",
+      "size": 11987,
+      "date": "2017-10-26",
+      "sha1": "681cf776bcd79752543d42490ec7ed22a29fd888",
+      "md5": "9a6d2c9ae73d59eb3dd38e3909750d14",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "cpl-1.0",
+          "score": 99.94,
+          "name": "Common Public License 1.0",
+          "short_name": "CPL 1.0",
+          "category": "Copyleft Limited",
+          "is_exception": false,
+          "owner": "IBM",
+          "homepage_url": "http://www.eclipse.org/legal/cpl-v10.html",
+          "text_url": "http://www.eclipse.org/legal/cpl-v10.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:cpl-1.0",
+          "spdx_license_key": "CPL-1.0",
+          "spdx_url": "https://spdx.org/licenses/CPL-1.0",
+          "start_line": 1,
+          "end_line": 212,
+          "matched_rule": {
+            "identifier": "cpl-1.0.SPDX.RULE",
+            "license_expression": "cpl-1.0",
+            "licenses": [
+              "cpl-1.0"
+            ],
+            "is_license_text": true,
+            "is_license_notice": false,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "cpl-1.0"
+      ],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/licenses/lgpl.txt",
+      "type": "file",
+      "name": "lgpl.txt",
+      "base_name": "lgpl",
+      "extension": ".txt",
+      "size": 26934,
+      "date": "2017-10-26",
+      "sha1": "8f1a637d2e2ed1bdb9eb01a7dccb5c12cc0557e1",
+      "md5": "f14599a2f089f6ff8c97e2baa4e3d575",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "lgpl-2.1-plus",
+          "score": 100.0,
+          "name": "GNU Lesser General Public License 2.1 or later",
+          "short_name": "LGPL 2.1 or later",
+          "category": "Copyleft Limited",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:lgpl-2.1-plus",
+          "spdx_license_key": "LGPL-2.1-or-later",
+          "spdx_url": "https://spdx.org/licenses/LGPL-2.1-or-later",
+          "start_line": 1,
+          "end_line": 502,
+          "matched_rule": {
+            "identifier": "lgpl-2.1-plus_2.RULE",
+            "license_expression": "lgpl-2.1-plus",
+            "licenses": [
+              "lgpl-2.1-plus"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "lgpl-2.1-plus"
+      ],
+      "holders": [
+        {
+          "value": "Free Software Foundation, Inc.",
+          "start_line": 4,
+          "end_line": 6
+        },
+        {
+          "value": "the Free Software Foundation",
+          "start_line": 428,
+          "end_line": 433
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1991, 1999 Free Software Foundation, Inc.",
+          "start_line": 4,
+          "end_line": 6
+        },
+        {
+          "value": "copyrighted by the Free Software Foundation",
+          "start_line": 428,
+          "end_line": 433
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src",
+      "type": "directory",
+      "name": "src",
+      "base_name": "src",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 7,
+      "dirs_count": 0,
+      "size_count": 152090,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/FixedMembershipToken.java",
+      "type": "file",
+      "name": "FixedMembershipToken.java",
+      "base_name": "FixedMembershipToken",
+      "extension": ".java",
+      "size": 5144,
+      "date": "2017-10-26",
+      "sha1": "5901f73dcc78155a1a2c7b5663a3a11fba400b19",
+      "md5": "aca9640ec8beee21b098bcf8ecc91442",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "lgpl-2.1-plus",
+          "score": 100.0,
+          "name": "GNU Lesser General Public License 2.1 or later",
+          "short_name": "LGPL 2.1 or later",
+          "category": "Copyleft Limited",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:lgpl-2.1-plus",
+          "spdx_license_key": "LGPL-2.1-or-later",
+          "spdx_url": "https://spdx.org/licenses/LGPL-2.1-or-later",
+          "start_line": 7,
+          "end_line": 20,
+          "matched_rule": {
+            "identifier": "lgpl-2.1-plus_59.RULE",
+            "license_expression": "lgpl-2.1-plus",
+            "licenses": [
+              "lgpl-2.1-plus"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "lgpl-2.1-plus"
+      ],
+      "holders": [
+        {
+          "value": "JBoss Inc., and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright 2005, JBoss Inc., and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "authors": [
+        {
+          "value": "Chris Mills (millsy@jboss.com)",
+          "start_line": 51,
+          "end_line": 51
+        }
+      ],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/GuardedBy.java",
+      "type": "file",
+      "name": "GuardedBy.java",
+      "base_name": "GuardedBy",
+      "extension": ".java",
+      "size": 813,
+      "date": "2017-10-26",
+      "sha1": "981d67087e65e9a44957c026d4b10817cf77d966",
+      "md5": "c5064400f759d3e81771005051d17dc1",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "cc-by-2.5",
+          "score": 82.0,
+          "name": "Creative Commons Attribution License 2.5",
+          "short_name": "CC-BY-2.5",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "Creative Commons",
+          "homepage_url": "http://creativecommons.org/licenses/by/2.5/",
+          "text_url": "http://creativecommons.org/licenses/by/2.5/legalcode",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:cc-by-2.5",
+          "spdx_license_key": "CC-BY-2.5",
+          "spdx_url": "https://spdx.org/licenses/CC-BY-2.5",
+          "start_line": 10,
+          "end_line": 11,
+          "matched_rule": {
+            "identifier": "cc-by-2.5_4.RULE",
+            "license_expression": "cc-by-2.5",
+            "licenses": [
+              "cc-by-2.5"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "cc-by-2.5"
+      ],
+      "holders": [
+        {
+          "value": "Brian Goetz and Tim Peierls",
+          "start_line": 9,
+          "end_line": 11
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2005 Brian Goetz and Tim Peierls",
+          "start_line": 9,
+          "end_line": 11
+        }
+      ],
+      "authors": [
+        {
+          "value": "Bela Ban",
+          "start_line": 15,
+          "end_line": 17
+        }
+      ],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/ImmutableReference.java",
+      "type": "file",
+      "name": "ImmutableReference.java",
+      "base_name": "ImmutableReference",
+      "extension": ".java",
+      "size": 1838,
+      "date": "2017-10-26",
+      "sha1": "30f56b876d5576d9869e2c5c509b08db57110592",
+      "md5": "48ca3c72fb9a65c771a321222f118b88",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "lgpl-2.1-plus",
+          "score": 100.0,
+          "name": "GNU Lesser General Public License 2.1 or later",
+          "short_name": "LGPL 2.1 or later",
+          "category": "Copyleft Limited",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:lgpl-2.1-plus",
+          "spdx_license_key": "LGPL-2.1-or-later",
+          "spdx_url": "https://spdx.org/licenses/LGPL-2.1-or-later",
+          "start_line": 7,
+          "end_line": 20,
+          "matched_rule": {
+            "identifier": "lgpl-2.1-plus_59.RULE",
+            "license_expression": "lgpl-2.1-plus",
+            "licenses": [
+              "lgpl-2.1-plus"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "lgpl-2.1-plus"
+      ],
+      "holders": [
+        {
+          "value": "Red Hat, Inc. and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright 2010, Red Hat, Inc. and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "authors": [
+        {
+          "value": "Brian Stansberry",
+          "start_line": 29,
+          "end_line": 29
+        }
+      ],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/RATE_LIMITER.java",
+      "type": "file",
+      "name": "RATE_LIMITER.java",
+      "base_name": "RATE_LIMITER",
+      "extension": ".java",
+      "size": 3692,
+      "date": "2017-10-26",
+      "sha1": "a8087e5d50da3273536ebda9b87b77aa4ff55deb",
+      "md5": "4626bdbc48871b55513e1a12991c61a8",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [
+        {
+          "value": "Bela Ban",
+          "start_line": 16,
+          "end_line": 17
+        }
+      ],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/RouterStub.java",
+      "type": "file",
+      "name": "RouterStub.java",
+      "base_name": "RouterStub",
+      "extension": ".java",
+      "size": 9913,
+      "date": "2017-10-26",
+      "sha1": "c1f6818f8ee7bddcc9f444bc94c099729d716d52",
+      "md5": "eecfe23494acbcd8088c93bc1e83c7f2",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [
+        {
+          "value": "Bela Ban",
+          "start_line": 23,
+          "end_line": 24
+        }
+      ],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/RouterStubManager.java",
+      "type": "file",
+      "name": "RouterStubManager.java",
+      "base_name": "RouterStubManager",
+      "extension": ".java",
+      "size": 8162,
+      "date": "2017-10-26",
+      "sha1": "eb419dc94cfe11ca318a3e743a7f9f080e70c751",
+      "md5": "20bee9631b7c82a45c250e095352aec7",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "lgpl-2.1-plus",
+          "score": 100.0,
+          "name": "GNU Lesser General Public License 2.1 or later",
+          "short_name": "LGPL 2.1 or later",
+          "category": "Copyleft Limited",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:lgpl-2.1-plus",
+          "spdx_license_key": "LGPL-2.1-or-later",
+          "spdx_url": "https://spdx.org/licenses/LGPL-2.1-or-later",
+          "start_line": 7,
+          "end_line": 20,
+          "matched_rule": {
+            "identifier": "lgpl-2.1-plus_59.RULE",
+            "license_expression": "lgpl-2.1-plus",
+            "licenses": [
+              "lgpl-2.1-plus"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "lgpl-2.1-plus"
+      ],
+      "holders": [
+        {
+          "value": "Red Hat Middleware LLC, and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright 2009, Red Hat Middleware LLC, and individual contributors",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/JGroups/src/S3_PING.java",
+      "type": "file",
+      "name": "S3_PING.java",
+      "base_name": "S3_PING",
+      "extension": ".java",
+      "size": 122528,
+      "date": "2017-10-26",
+      "sha1": "08dba9986f69719970ead3592dc565465164df0d",
+      "md5": "83d8324f37d0e3f120bc89865cf0bd39",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Java",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "public-domain",
+          "score": 11.0,
+          "name": "Public Domain",
+          "short_name": "Public Domain",
+          "category": "Public Domain",
+          "is_exception": false,
+          "owner": "Unspecified",
+          "homepage_url": "http://www.linfo.org/publicdomain.html",
+          "text_url": "",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:public-domain",
+          "spdx_license_key": "",
+          "spdx_url": "",
+          "start_line": 1649,
+          "end_line": 1649,
+          "matched_rule": {
+            "identifier": "public-domain_79.RULE",
+            "license_expression": "public-domain",
+            "licenses": [
+              "public-domain"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false
+          }
+        },
+        {
+          "key": "public-domain",
+          "score": 11.0,
+          "name": "Public Domain",
+          "short_name": "Public Domain",
+          "category": "Public Domain",
+          "is_exception": false,
+          "owner": "Unspecified",
+          "homepage_url": "http://www.linfo.org/publicdomain.html",
+          "text_url": "",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:public-domain",
+          "spdx_license_key": "",
+          "spdx_url": "",
+          "start_line": 1692,
+          "end_line": 1692,
+          "matched_rule": {
+            "identifier": "public-domain_79.RULE",
+            "license_expression": "public-domain",
+            "licenses": [
+              "public-domain"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "public-domain",
+        "public-domain"
+      ],
+      "holders": [],
+      "copyrights": [],
+      "authors": [
+        {
+          "value": "Bela Ban",
+          "start_line": 35,
+          "end_line": 38
+        },
+        {
+          "value": "Robert Harder",
+          "start_line": 1698,
+          "end_line": 1700
+        },
+        {
+          "value": "rob@iharder.net",
+          "start_line": 1698,
+          "end_line": 1700
+        }
+      ],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib",
+      "type": "directory",
+      "name": "zlib",
+      "base_name": "zlib",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": true,
+      "packages": [],
+      "files_count": 16,
+      "dirs_count": 5,
+      "size_count": 268762,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/adler32.c",
+      "type": "file",
+      "name": "adler32.c",
+      "base_name": "adler32",
+      "extension": ".c",
+      "size": 4968,
+      "date": "2017-10-26",
+      "sha1": "0cff4808476ce0b5f6f0ebbc69ee2ab2a0eebe43",
+      "md5": "ae3bbb54820e1d49fb90cbba222e973f",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 70.0,
+          "name": "ZLIB License",
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2011 Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/deflate.c",
+      "type": "file",
+      "name": "deflate.c",
+      "base_name": "deflate",
+      "extension": ".c",
+      "size": 71476,
+      "date": "2017-10-26",
+      "sha1": "7b4ace6d698c5dbbfb9a8f047f63228ca54d2e77",
+      "md5": "cd7826278ce9d9d9ed5abdefef50c3e2",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 70.0,
+          "name": "ZLIB License",
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly and Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        },
+        {
+          "value": "Jean-loup Gailly and Mark Adler",
+          "start_line": 54,
+          "end_line": 55
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2013 Jean-loup Gailly and Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        },
+        {
+          "value": "Copyright 1995-2013 Jean-loup Gailly and Mark Adler",
+          "start_line": 54,
+          "end_line": 55
+        }
+      ],
+      "authors": [
+        {
+          "value": "Leonid Broukhis.",
+          "start_line": 34,
+          "end_line": 35
+        }
+      ],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/deflate.h",
+      "type": "file",
+      "name": "deflate.h",
+      "base_name": "deflate",
+      "extension": ".h",
+      "size": 12774,
+      "date": "2017-10-26",
+      "sha1": "29ed3b8ca3927576e5889dea5880ca0052942c7d",
+      "md5": "7ceae74a13201f14c91623116af169c3",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 70.0,
+          "name": "ZLIB License",
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false
+          }
+        },
+        {
+          "key": "zlib",
+          "score": 100.0,
+          "name": "ZLIB License",
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 93,
+          "end_line": 94,
+          "matched_rule": {
+            "identifier": "zlib_21.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "zlib",
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2012 Jean-loup Gailly",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/zlib.h",
+      "type": "file",
+      "name": "zlib.h",
+      "base_name": "zlib",
+      "extension": ".h",
+      "size": 87883,
+      "date": "2017-10-26",
+      "sha1": "400d35465f179a4acacb5fe749e6ce20a0bbdb84",
+      "md5": "64d8a5180bd54ff5452886e4cbb21e14",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 100.0,
+          "name": "ZLIB License",
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 6,
+          "end_line": 23,
+          "matched_rule": {
+            "identifier": "zlib_17.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "is_license_text": true,
+            "is_license_notice": false,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly and Mark Adler",
+          "start_line": 4,
+          "end_line": 4
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2013 Jean-loup Gailly and Mark Adler",
+          "start_line": 4,
+          "end_line": 4
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/zutil.c",
+      "type": "file",
+      "name": "zutil.c",
+      "base_name": "zutil",
+      "extension": ".c",
+      "size": 7414,
+      "date": "2017-10-26",
+      "sha1": "e1af709bff21ae0d4331119a7fc4c19f82932043",
+      "md5": "fff257bc1656eb60fc585a7dc35f963d",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 70.0,
+          "name": "ZLIB License",
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly.",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2005, 2010, 2011, 2012 Jean-loup Gailly.",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/zutil.h",
+      "type": "file",
+      "name": "zutil.h",
+      "base_name": "zutil",
+      "extension": ".h",
+      "size": 6766,
+      "date": "2017-10-26",
+      "sha1": "b909d27ef9ce51639f76b7ea6b62721e7d1b6bf7",
+      "md5": "04fcfbb961591c9452c4d0fd1525ffdf",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 70.0,
+          "name": "ZLIB License",
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly.",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2013 Jean-loup Gailly.",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/ada",
+      "type": "directory",
+      "name": "ada",
+      "base_name": "ada",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 1,
+      "dirs_count": 0,
+      "size_count": 13594,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/ada/zlib.ads",
+      "type": "file",
+      "name": "zlib.ads",
+      "base_name": "zlib",
+      "extension": ".ads",
+      "size": 13594,
+      "date": "2017-10-26",
+      "sha1": "0245a91806d804bf9f0907a3a001a141e9adb61b",
+      "md5": "71de2670f2e588b51c62e7f6a9046399",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Ada",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "gpl-2.0-plus",
+          "score": 100.0,
+          "name": "GNU General Public License 2.0 or later",
+          "short_name": "GPL 2.0 or later",
+          "category": "Copyleft",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:gpl-2.0-plus",
+          "spdx_license_key": "GPL-2.0-or-later",
+          "spdx_url": "https://spdx.org/licenses/GPL-2.0-or-later",
+          "start_line": 6,
+          "end_line": 25,
+          "matched_rule": {
+            "identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
+            "license_expression": "gpl-2.0-plus WITH ada-linking-exception",
+            "licenses": [
+              "gpl-2.0-plus",
+              "ada-linking-exception"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        },
+        {
+          "key": "ada-linking-exception",
+          "score": 100.0,
+          "name": "Ada linking exception to GPL 2.0 or later",
+          "short_name": "Ada linking exception to GPL 2.0 or later",
+          "category": "Copyleft Limited",
+          "is_exception": true,
+          "owner": "Dmitriy Anisimkov",
+          "homepage_url": "",
+          "text_url": "",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:ada-linking-exception",
+          "spdx_license_key": "",
+          "spdx_url": "",
+          "start_line": 6,
+          "end_line": 25,
+          "matched_rule": {
+            "identifier": "gpl-2.0-plus_with_ada-linking-exception_1.RULE",
+            "license_expression": "gpl-2.0-plus WITH ada-linking-exception",
+            "licenses": [
+              "gpl-2.0-plus",
+              "ada-linking-exception"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "gpl-2.0-plus WITH ada-linking-exception"
+      ],
+      "holders": [
+        {
+          "value": "Dmitriy Anisimkov",
+          "start_line": 4,
+          "end_line": 4
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2002-2004 Dmitriy Anisimkov",
+          "start_line": 4,
+          "end_line": 4
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/dotzlib",
+      "type": "directory",
+      "name": "dotzlib",
+      "base_name": "dotzlib",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 4,
+      "dirs_count": 0,
+      "size_count": 14257,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/dotzlib/AssemblyInfo.cs",
+      "type": "file",
+      "name": "AssemblyInfo.cs",
+      "base_name": "AssemblyInfo",
+      "extension": ".cs",
+      "size": 2500,
+      "date": "2017-10-26",
+      "sha1": "9f1db1177b2e9a014f72bb3cd80be17133e06d16",
+      "md5": "23d0d7c18846fc31655b6aa89b7c8038",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": "C#",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [
+        {
+          "value": "Henrik Ravn",
+          "start_line": 14,
+          "end_line": 16
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2004 by Henrik Ravn",
+          "start_line": 14,
+          "end_line": 16
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/dotzlib/ChecksumImpl.cs",
+      "type": "file",
+      "name": "ChecksumImpl.cs",
+      "base_name": "ChecksumImpl",
+      "extension": ".cs",
+      "size": 8040,
+      "date": "2017-10-26",
+      "sha1": "3807a0e24a57b92ea301559cab7307b8eab52c51",
+      "md5": "d01b3cb2e75da9b15f05b92b42f6bd33",
+      "mime_type": "text/plain",
+      "file_type": "ISO-8859 text, with CRLF line terminators",
+      "programming_language": "C#",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "boost-1.0",
+          "score": 92.59,
+          "name": "Boost Software License 1.0",
+          "short_name": "Boost 1.0",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "Boost",
+          "homepage_url": "http://www.boost.org/users/license.html",
+          "text_url": "http://www.boost.org/LICENSE_1_0.txt",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:boost-1.0",
+          "spdx_license_key": "BSL-1.0",
+          "spdx_url": "https://spdx.org/licenses/BSL-1.0",
+          "start_line": 4,
+          "end_line": 5,
+          "matched_rule": {
+            "identifier": "boost-1.0_1.RULE",
+            "license_expression": "boost-1.0",
+            "licenses": [
+              "boost-1.0"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "boost-1.0"
+      ],
+      "holders": [
+        {
+          "value": "Henrik Ravn",
+          "start_line": 2,
+          "end_line": 2
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "(c) Copyright Henrik Ravn 2004",
+          "start_line": 2,
+          "end_line": 2
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/dotzlib/LICENSE_1_0.txt",
+      "type": "file",
+      "name": "LICENSE_1_0.txt",
+      "base_name": "LICENSE_1_0",
+      "extension": ".txt",
+      "size": 1359,
+      "date": "2017-10-26",
+      "sha1": "892b34f7865d90a6f949f50d95e49625a10bc7f0",
+      "md5": "81543b22c36f10d20ac9712f8d80ef8d",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "boost-1.0",
+          "score": 100.0,
+          "name": "Boost Software License 1.0",
+          "short_name": "Boost 1.0",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "Boost",
+          "homepage_url": "http://www.boost.org/users/license.html",
+          "text_url": "http://www.boost.org/LICENSE_1_0.txt",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:boost-1.0",
+          "spdx_license_key": "BSL-1.0",
+          "spdx_url": "https://spdx.org/licenses/BSL-1.0",
+          "start_line": 1,
+          "end_line": 23,
+          "matched_rule": {
+            "identifier": "boost-1.0.LICENSE",
+            "license_expression": "boost-1.0",
+            "licenses": [
+              "boost-1.0"
+            ],
+            "is_license_text": true,
+            "is_license_notice": false,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "boost-1.0"
+      ],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": true,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/dotzlib/readme.txt",
+      "type": "file",
+      "name": "readme.txt",
+      "base_name": "readme",
+      "extension": ".txt",
+      "size": 2358,
+      "date": "2017-10-26",
+      "sha1": "b1229b826f0096808628474538cea8fec2922a9b",
+      "md5": "1f20f3168ee63d90de033edac2ce383c",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with CRLF line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "boost-1.0",
+          "score": 77.78,
+          "name": "Boost Software License 1.0",
+          "short_name": "Boost 1.0",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "Boost",
+          "homepage_url": "http://www.boost.org/users/license.html",
+          "text_url": "http://www.boost.org/LICENSE_1_0.txt",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:boost-1.0",
+          "spdx_license_key": "BSL-1.0",
+          "spdx_url": "https://spdx.org/licenses/BSL-1.0",
+          "start_line": 57,
+          "end_line": 58,
+          "matched_rule": {
+            "identifier": "boost-1.0_1.RULE",
+            "license_expression": "boost-1.0",
+            "licenses": [
+              "boost-1.0"
+            ],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "boost-1.0"
+      ],
+      "holders": [
+        {
+          "value": "Henrik Ravn",
+          "start_line": 55,
+          "end_line": 55
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) Henrik Ravn 2004",
+          "start_line": 55,
+          "end_line": 55
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": true,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/gcc_gvmat64",
+      "type": "directory",
+      "name": "gcc_gvmat64",
+      "base_name": "gcc_gvmat64",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 1,
+      "dirs_count": 0,
+      "size_count": 16413,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/gcc_gvmat64/gvmat64.S",
+      "type": "file",
+      "name": "gvmat64.S",
+      "base_name": "gvmat64",
+      "extension": ".S",
+      "size": 16413,
+      "date": "2017-10-26",
+      "sha1": "742603cba1af98a1432cc02efb019b1a5760adf2",
+      "md5": "5e772d7302475e5473d0c4c57b9861e8",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text, with CRLF line terminators",
+      "programming_language": "GAS",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 100.0,
+          "name": "ZLIB License",
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 17,
+          "end_line": 31,
+          "matched_rule": {
+            "identifier": "zlib.LICENSE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "is_license_text": true,
+            "is_license_notice": false,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+          "start_line": 10,
+          "end_line": 10
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2010 Jean-loup Gailly, Brian Raiter and Gilles Vollant.",
+          "start_line": 10,
+          "end_line": 10
+        }
+      ],
+      "authors": [
+        {
+          "value": "Gilles Vollant",
+          "start_line": 12,
+          "end_line": 15
+        }
+      ],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/infback9",
+      "type": "directory",
+      "name": "infback9",
+      "base_name": "infback9",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 2,
+      "dirs_count": 0,
+      "size_count": 23223,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/infback9/infback9.c",
+      "type": "file",
+      "name": "infback9.c",
+      "base_name": "infback9",
+      "extension": ".c",
+      "size": 21629,
+      "date": "2017-10-26",
+      "sha1": "17fb362c03755b12f2dda5b12a68cf38162674bd",
+      "md5": "23ff5edec0817da303cb1294c1e4205c",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 70.0,
+          "name": "ZLIB License",
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1995-2008 Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/infback9/infback9.h",
+      "type": "file",
+      "name": "infback9.h",
+      "base_name": "infback9",
+      "extension": ".h",
+      "size": 1594,
+      "date": "2017-10-26",
+      "sha1": "d0486a32b558dcaceded5f0746fad62e680a4734",
+      "md5": "52b1ed99960d3ed7ed60cd20295e64a8",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "zlib",
+          "score": 70.0,
+          "name": "ZLIB License",
+          "short_name": "ZLIB License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "zlib",
+          "homepage_url": "http://www.zlib.net/",
+          "text_url": "http://www.gzip.org/zlib/zlib_license.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:zlib",
+          "spdx_license_key": "Zlib",
+          "spdx_url": "https://spdx.org/licenses/Zlib",
+          "start_line": 3,
+          "end_line": 3,
+          "matched_rule": {
+            "identifier": "zlib_5.RULE",
+            "license_expression": "zlib",
+            "licenses": [
+              "zlib"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "zlib"
+      ],
+      "holders": [
+        {
+          "value": "Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 2003 Mark Adler",
+          "start_line": 2,
+          "end_line": 3
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/iostream2",
+      "type": "directory",
+      "name": "iostream2",
+      "base_name": "iostream2",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 2,
+      "dirs_count": 0,
+      "size_count": 9994,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/iostream2/zstream.h",
+      "type": "file",
+      "name": "zstream.h",
+      "base_name": "zstream",
+      "extension": ".h",
+      "size": 9283,
+      "date": "2017-10-26",
+      "sha1": "fca4540d490fff36bb90fd801cf9cd8fc695bb17",
+      "md5": "a980b61c1e8be68d5cdb1236ba6b43e7",
+      "mime_type": "text/x-c++",
+      "file_type": "C++ source, ASCII text",
+      "programming_language": "C",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "cmr-no",
+          "score": 100.0,
+          "name": "Christian Michelsen Research AS License",
+          "short_name": "CMR License",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "CMR - Christian Michelsen Research AS",
+          "homepage_url": "",
+          "text_url": "",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:cmr-no",
+          "spdx_license_key": "",
+          "spdx_url": "",
+          "start_line": 9,
+          "end_line": 15,
+          "matched_rule": {
+            "identifier": "cmr-no.LICENSE",
+            "license_expression": "cmr-no",
+            "licenses": [
+              "cmr-no"
+            ],
+            "is_license_text": true,
+            "is_license_notice": false,
+            "is_license_reference": false,
+            "is_license_tag": false
+          }
+        }
+      ],
+      "license_expressions": [
+        "cmr-no"
+      ],
+      "holders": [
+        {
+          "value": "Christian Michelsen Research AS Advanced Computing",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) 1997 Christian Michelsen Research AS Advanced Computing",
+          "start_line": 3,
+          "end_line": 5
+        }
+      ],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "samples/zlib/iostream2/zstream_test.cpp",
+      "type": "file",
+      "name": "zstream_test.cpp",
+      "base_name": "zstream_test",
+      "extension": ".cpp",
+      "size": 711,
+      "date": "2017-10-26",
+      "sha1": "e18a6d55cbbd8b832f8d795530553467e5c74fcf",
+      "md5": "d32476bde4e6d5f889092fdff6f8cdb0",
+      "mime_type": "text/x-c",
+      "file_type": "C source, ASCII text",
+      "programming_language": "C++",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "holders": [],
+      "copyrights": [],
+      "authors": [],
+      "package_manifest": null,
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": false,
+      "packages": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    }
+  ]
+}

--- a/tests/formattedcode/test_output_json.py
+++ b/tests/formattedcode/test_output_json.py
@@ -34,6 +34,7 @@ from scancode.cli_test_utils import check_json_scan
 from scancode.cli_test_utils import run_scan_click
 from scancode.cli_test_utils import load_json_result
 
+
 test_env = FileDrivenTesting()
 test_env.test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -44,7 +45,7 @@ def test_json_pretty_print():
     args = ['-clip', test_dir, '--json-pp', result_file]
     run_scan_click(args)
     expected = test_env.get_test_loc('json/simple-expected.jsonpp')
-    check_json_scan(test_env.get_test_loc(expected), result_file, strip_dates=True, regen=False)
+    check_json_scan(expected, result_file, strip_dates=True, regen=False)
 
 
 def test_json_compact():
@@ -54,7 +55,7 @@ def test_json_compact():
     with open(result_file, 'rb') as res:
         assert len(res.read().splitlines()) == 1
     expected = test_env.get_test_loc('json/simple-expected.json')
-    check_json_scan(test_env.get_test_loc(expected), result_file, strip_dates=True, regen=False)
+    check_json_scan(expected, result_file, strip_dates=True, regen=False)
 
 
 def test_scan_output_does_not_truncate_copyright_json():
@@ -62,7 +63,7 @@ def test_scan_output_does_not_truncate_copyright_json():
     result_file = test_env.get_temp_file('test.json')
     run_scan_click(['-clip', '--strip-root', test_dir, '--json-pp', result_file])
     expected = test_env.get_test_loc('json/tree/expected.json')
-    check_json_scan(test_env.get_test_loc(expected), result_file, strip_dates=True, regen=False)
+    check_json_scan(expected, result_file, strip_dates=True, regen=False)
 
 
 def test_scan_output_does_not_truncate_copyright_with_json_to_stdout():
@@ -71,7 +72,7 @@ def test_scan_output_does_not_truncate_copyright_with_json_to_stdout():
     args = ['-clip', '--strip-root', test_dir, '--json-pp', result_file]
     run_scan_click(args)
     expected = test_env.get_test_loc('json/tree/expected.json')
-    check_json_scan(test_env.get_test_loc(expected), result_file, strip_dates=True, regen=False)
+    check_json_scan(expected, result_file, strip_dates=True, regen=False)
 
 
 def test_scan_output_for_timestamp():
@@ -79,4 +80,4 @@ def test_scan_output_for_timestamp():
     result_file = test_env.get_temp_file('json')
     run_scan_click(['-clip', test_dir, '--json', result_file])
     result_json = load_json_result(result_file)
-    assert "scan_start" in result_json
+    assert 'scan_start' in result_json

--- a/tests/formattedcode/test_reuse_output_plugins.py
+++ b/tests/formattedcode/test_reuse_output_plugins.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2017 nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/scancode-toolkit/
+# The ScanCode software is licensed under the Apache License version 2.0.
+# Data generated with ScanCode require an acknowledgment.
+# ScanCode is a trademark of nexB Inc.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with ScanCode or any ScanCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  ScanCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  ScanCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/scancode-toolkit/ for support and download.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+import os
+
+from commoncode.testcase import FileDrivenTesting
+
+
+test_env = FileDrivenTesting()
+test_env.test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
+
+
+def check_plugin(plugin_class):
+    # this is the result of this scan:
+    # ./scancode -clip --summary --license-clarity-score --summary-key-files
+    # --classify  samples/ --json-pp vb.json -n
+    test_file = test_env.get_test_loc('reuse/vb.json')
+    from scancode.resource import VirtualCodebase
+    cb = VirtualCodebase(test_file)
+
+    result_file = test_env.get_temp_file('reuse')
+    op = plugin_class()
+
+    with open(result_file, 'wb') as out:
+        op.process_codebase(cb, out)
+
+    with open(result_file, 'rb') as inp:
+        assert b'zlib' in inp.read()
+
+
+def test_can_call_json_output_from_regular_code_with_virtualcodebase():
+    from formattedcode.output_json import JsonCompactOutput as plug
+    check_plugin(plug)
+
+
+def test_can_call_jsonpp_output_from_regular_code_with_virtualcodebase():
+    from formattedcode.output_json import JsonPrettyOutput as plug
+    check_plugin(plug)
+
+
+def test_can_call_jsonlines_output_from_regular_code_with_virtualcodebase():
+    from formattedcode.output_jsonlines import JsonLinesOutput as plug
+    check_plugin(plug)
+
+
+def test_can_call_spdxtv_output_from_regular_code_with_virtualcodebase():
+    from formattedcode.output_spdx import SpdxTvOutput as plug
+    check_plugin(plug)
+
+
+def test_can_call_spdxrdf_output_from_regular_code_with_virtualcodebase():
+    from formattedcode.output_spdx import SpdxRdfOutput as plug
+    check_plugin(plug)
+
+
+def test_can_call_html_output_from_regular_code_with_virtualcodebase():
+    from formattedcode.output_html import  HtmlOutput as plug
+    check_plugin(plug)


### PR DESCRIPTION
This provides a cleaner way to reuse output plugins from a Codebase when using ScanCode as a library
See #1148

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>