### PR TITLE
Fix 'license detection tests' collection on Windows

### DIFF
--- a/tests/licensedcode/test_detection_datadriven.py
+++ b/tests/licensedcode/test_detection_datadriven.py
@@ -87,7 +87,7 @@ class LicenseTest(object):
         self.data_file = data_file
         self.test_file = test_file
         if self.test_file:
-            _, _, self.test_file_name = test_file.partition('licensedcode/data/')
+            _, _, self.test_file_name = test_file.partition(os.path.join('licensedcode', 'data') + os.sep)
 
         data = {}
         if self.data_file:


### PR DESCRIPTION
The problem was that the `test_file_name` attribute generation was using a naive approach which only worked on Linux, resulting in all test methods having the same name (`test_detection`).

This PR fixes the problem by producing native path names using `os.path` functions:

```
$ py.test -vvs tests/licensedcode/test_detection_datadriven.py --collect-only
...
collecting ... collected 1762 items
```

Fix #1182
Fix pytest-dev/pytest#4006