### PR TITLE
Add new proprietary license rules #1302

### DIFF
--- a/src/licensedcode/data/rules/proprietary_greensock_1.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_1.RULE
@@ -1,0 +1,3 @@
+Standard 'no charge' license: https://greensock.com/standard-license. 
+Club GreenSock members get more: https://greensock.com/licensing/. 
+Why GreenSock doesn't employ an MIT license: https://greensock.com/why-license/

--- a/src/licensedcode/data/rules/proprietary_greensock_1.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_1.yml
@@ -1,0 +1,2 @@
+license_expression: proprietary
+is_license_notice: yes

--- a/src/licensedcode/data/rules/proprietary_greensock_10.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_10.RULE
@@ -1,0 +1,2 @@
+"license": "Standard 'no charge' license: http://greensock.com/standard-license. Club GreenSock members get more: https://greensock.com/licensing/. 
+Why GreenSock doesn't employ an MIT license: https://greensock.com/why-license/",

--- a/src/licensedcode/data/rules/proprietary_greensock_10.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_10.yml
@@ -1,0 +1,2 @@
+license_expression: proprietary
+is_license_notice: yes

--- a/src/licensedcode/data/rules/proprietary_greensock_11.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_11.RULE
@@ -1,0 +1,2 @@
+"Standard 'no charge' license: http://greensock.com/standard-license. Club GreenSock members get more: https://greensock.com/licensing/. 
+Why GreenSock doesn't employ an MIT license: https://greensock.com/why-license/",

--- a/src/licensedcode/data/rules/proprietary_greensock_11.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_11.yml
@@ -1,0 +1,2 @@
+license_expression: proprietary
+is_license_notice: yes

--- a/src/licensedcode/data/rules/proprietary_greensock_12.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_12.RULE
@@ -1,0 +1,1 @@
+license": "Standard 'no charge' license: https://greensock.com/standard-license. Club GreenSock members get more: https://greensock.com/licensing/. Why GreenSock doesn't employ an MIT license: https://greensock.com/why-license/"

--- a/src/licensedcode/data/rules/proprietary_greensock_12.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_12.yml
@@ -1,0 +1,2 @@
+license_expression: proprietary
+is_license_notice: yes

--- a/src/licensedcode/data/rules/proprietary_greensock_13.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_13.RULE
@@ -1,0 +1,2 @@
+### License
+GreenSock's standard "no charge" license can be viewed at <a href="https://greensock.com/standard-license">http://greensock.com/standard-license https://greensock.com/club/">Club GreenSock  members are granted additional rights. See https://greensock.com/licensing/">http://greensock.com/licensing/ for details. Why doesn't GreenSock use an MIT (or similar) open source license, and why is that a **good** thing? This article explains it all: https://greensock.com/why-license/" http://greensock.com/why-license/

--- a/src/licensedcode/data/rules/proprietary_greensock_13.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_13.yml
@@ -1,0 +1,2 @@
+license_expression: proprietary
+is_license_notice: yes

--- a/src/licensedcode/data/rules/proprietary_greensock_14.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_14.RULE
@@ -1,0 +1,1 @@
+This work is subject to the terms in http://www.greensock.com/terms_of_use.html http://www.greensock.com/terms_of_use.html or for http://www.greensock.com/club/ Club GreenSock members, the software agreement that was issued with the membership.

--- a/src/licensedcode/data/rules/proprietary_greensock_14.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_14.yml
@@ -1,0 +1,2 @@
+license_expression: proprietary
+is_license_notice: yes

--- a/src/licensedcode/data/rules/proprietary_greensock_15.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_15.RULE
@@ -1,0 +1,1 @@
+See http://www.greensock.com/ for details

--- a/src/licensedcode/data/rules/proprietary_greensock_15.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_15.yml
@@ -1,0 +1,4 @@
+license_expression: proprietary
+is_license_notice: yes
+relevance: 90
+

--- a/src/licensedcode/data/rules/proprietary_greensock_16.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_16.RULE
@@ -1,0 +1,1 @@
+Standard "No Charge" GreenSock License

--- a/src/licensedcode/data/rules/proprietary_greensock_16.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_16.yml
@@ -1,0 +1,4 @@
+license_expression: proprietary
+is_license_notice: yes
+relevance: 90
+

--- a/src/licensedcode/data/rules/proprietary_greensock_17.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_17.RULE
@@ -1,0 +1,6 @@
+Greensock : Standard "No Charge" GreenSock License
+
+PLAIN ENGLISH SUMMARY:
+You may use the code at no charge in commercial or non-commercial apps, web sites, games, components, and other software as long as end users are not charged a fee of any kind to use your product or gain access to any part of it. If your client pays you a one-time fee to create the site/product, that's perfectly fine and qualifies under the "no charge" license. If end users are charged a usage/access/license fee, please sign up for a "Business Green" Club GreenSock membership which comes with a comprehensive commercial license. See http://greensock.com/club/ for details.
+Use at your own risk. No warranties are offered.
+Please respect the copyright.

--- a/src/licensedcode/data/rules/proprietary_greensock_17.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_17.yml
@@ -1,0 +1,3 @@
+license_expression: proprietary
+is_license_notice: yes
+

--- a/src/licensedcode/data/rules/proprietary_greensock_18.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_18.RULE
@@ -1,0 +1,1 @@
+Standard 'no charge' license

--- a/src/licensedcode/data/rules/proprietary_greensock_18.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_18.yml
@@ -1,0 +1,3 @@
+license_expression: proprietary
+is_license_notice: yes
+

--- a/src/licensedcode/data/rules/proprietary_greensock_2.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_2.RULE
@@ -1,0 +1,2 @@
+ * This work is subject to the terms at http://greensock.com/standard-license or for
+ * Club GreenSock members, the software agreement that was issued with your membership.

--- a/src/licensedcode/data/rules/proprietary_greensock_2.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_2.yml
@@ -1,0 +1,2 @@
+license_expression: proprietary
+is_license_notice: yes

--- a/src/licensedcode/data/rules/proprietary_greensock_3.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_3.RULE
@@ -1,0 +1,1 @@
+http://greensock.com/standard-license

--- a/src/licensedcode/data/rules/proprietary_greensock_3.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_3.yml
@@ -1,0 +1,4 @@
+license_expression: proprietary
+is_license_notice: yes
+relevance: 90
+

--- a/src/licensedcode/data/rules/proprietary_greensock_4.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_4.RULE
@@ -1,0 +1,1 @@
+http://www.greensock.com/terms_of_use.html 

--- a/src/licensedcode/data/rules/proprietary_greensock_4.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_4.yml
@@ -1,0 +1,4 @@
+license_expression: proprietary
+is_license_notice: yes
+relevance: 90
+

--- a/src/licensedcode/data/rules/proprietary_greensock_5.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_5.RULE
@@ -1,0 +1,5 @@
+PLAIN ENGLISH SUMMARY:
+
+    You may use the code at no charge in commercial or non-commercial apps, web sites, games, components, and other software as long as end users are not charged a fee of any kind to use your product or gain access to any part of it. If your client pays you a one-time fee to create the site/product, that's perfectly fine and qualifies under the "no charge" license. If end users are charged a usage/access/license fee, please sign up for a "Business Green" Club GreenSock membership which comes with a comprehensive commercial license. See http://greensock.com/club/ for details.
+    Use at your own risk. No warranties are offered.
+    Please respect the copyright.

--- a/src/licensedcode/data/rules/proprietary_greensock_5.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_5.yml
@@ -1,0 +1,3 @@
+license_expression: proprietary
+is_license_notice: yes
+

--- a/src/licensedcode/data/rules/proprietary_greensock_6.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_6.RULE
@@ -1,0 +1,40 @@
+LEGALESE:
+
+This is a legal agreement between you (either an individual or a single entity) and GreenSock, Inc. ("GREENSOCK") for the proprietary GreenSock code known as TweenLite, TweenMax, TweenNano, TimelineLite, TimelineMax, and other copyrighted code that is available for download at http://www.greensock.com (this code and documentation, as well as any updates which may at GREENSOCK's sole discretion be provided to you from time to time, are referred to in this Agreement as "PROGRAM"). By downloading, copying, or otherwise using the PROGRAM, you agree to the terms and conditions of this Agreement. If you do not agree to the terms and conditions of this Agreement, please do not download or use the PROGRAM.
+I. LICENSE
+
+A. Subject to the terms and conditions of this Agreement, GREENSOCK hereby grants you a non-exclusive, worldwide, non-transferable right to use the PROGRAM in apps, web sites, games, components and other software applications ("Developed Works") for which the end user is NOT charged any fees. If you would like to use the code in a commercially licensed Developed Work for which end users are charged a fee (either for usage or access), simply sign up for the appropriate "Business Green" Club GreenSock membership at http://www.greensock.com/club/.
+II. LIMITATION OF LICENSE AND RESTRICTIONS
+
+A. You agree that you will not sell, rent, or license the PROGRAM's source code or any derivative works thereof to any third party without the prior written consent of GREENSOCK. Distribution of the PROGRAM as part of your Developed Work is acceptable so long as it is used exclusively as a part of your Developed Work. You agree not to modify or delete GREENSOCK'S existing copyright notices located in the source code.
+
+B. You may use, duplicate, and distribute the compiled object code as embedded in Developed Works created by you, either for your own use or for distribution to a third party so long as end users of the Developed Work are not charged a fee for usage of or access to any portion of the Developed Work. Please see http://www.greensock.com/licensing/ for descriptions of Developed Works that qualify for the "No Charge" license.
+
+C. You may make modifications to the source code exclusively for your own use in order to perform bug fixes or other minor edits required to operate the PROGRAM as originally intended.
+III. CONSIDERATION
+
+A. The license rights granted to you under this Agreement are at no charge, but only in the following circumstances: If on your own behalf or on behalf of a third party you incorporate the PROGRAM into a web site, app, game, program or any component thereof (collectively, "Developed Work"), which in the case of a web site, must be accessible to internet users without payment of a fee of any kind, and in the case of a software application, game, program or component, neither you nor anyone to whom you distribute the Developed Work charges a user a fee of any kind to use such Developed Work or application, game, program or component into which such Developed Work is embedded. The foregoing shall apply regardless of whether you are paid to create such Developed Work.
+
+B. In the event your intended use of the PROGRAM does not meet the criteria for the "no charge" license rights set forth in the immediately preceding paragraph, then you are not licensed to use the PROGRAM under this Agreement and must license the PROGRAM under GREENSOCK'S separate fee-based Software License Agreement which is granted to "Business Green" Club GreenSock members (see http://greensock.com/club/ for details).
+
+C. You may make modifications to the source code exclusively for your own use in order to perform bug fixes or other minor edits required to operate the PROGRAM as originally intended.
+IV. TITLE AND OWNERSHIP
+
+The PROGRAM is licensed, not sold, and is protected by copyright laws and international treaty provisions. You acknowledge that no title to the intellectual property in the PROGRAM is transferred to you. You further acknowledge that title and full ownership rights to the PROGRAM, including all intellectual property rights therein, will remain the exclusive property of GREENSOCK and you will not acquire any rights to the PROGRAM except as expressly set forth in this Agreement. You agree that any copies of the PROGRAM you make will contain the same proprietary notices which appear on and in the PROGRAM. You agree that GREENSOCK may identify you as a licensee unless you make a written request otherwise. GREENSOCK hereby grants to you the right to disclose that your product, game, software application, component, or other Developed Work makes use of GREENSOCK code (for example, "Powered by TweenLite").
+V. DISCLAIMER OF WARRANTY AND LIMITATION OF LIABILITY
+
+A. THE PROGRAM IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. GREENSOCK DOES NOT WARRANT THAT THE FUNCTIONS CONTAINED IN THE PROGRAM WILL MEET YOUR REQUIREMENTS OR THAT OPERATION WILL BE UNINTERRUPTED OR ERROR FREE. GREENSOCK shall not be liable for special, indirect, incidental, or consequential damages with respect to any claim on account of or arising from this Agreement or use of the PROGRAM, even if GREENSOCK has been or is hereafter advised of the possibility of such damages. Because some states do not allow certain exclusions or limitations on implied warranties or of liability for consequential or incidental damages, the above exclusions may not apply to you. In no event, however, will GREENSOCK be liable to you, under any theory of recovery, in an amount in excess of $250. Notwithstanding anything else in this agreement, you agree to indemnify GREENSOCK, its assignees, and licensees, and hold each of them harmless from and against any and all claims, losses, damages, and expenses, including legal fees arising out of or resulting from any negligent act or omission by you.
+
+B. GREENSOCK may, at its sole discretion, provide support services related to the PROGRAM, but has no obligation to do so.
+VI. TERMINATION
+
+If you at any time fail to abide by the terms of this Agreement, GREENSOCK shall have the right to immediately terminate the license granted herein and pursue any other legal or equitable remedies available.
+VII. MISCELLANEOUS
+
+A. This Agreement shall be construed in accordance with the laws of the State of Illinois. In the event of any dispute between you and GREENSOCK with respect to this Agreement, we both agree that if we cannot resolve the dispute in good faith discussion, either of us may submit the dispute for resolution to arbitration with the American Arbitration Association before a single arbitrator using the AAA Rules for Commercial Arbitration. The arbitrator's decision is final and can be enforced in any court with jurisdiction over such matters.
+
+B. This agreement represents the complete and exclusive statement of the agreement between GREENSOCK and you and supersedes all prior agreements, proposals, representations and other communications, verbal or written, between them with respect to use of the program. This agreement may be modified only with the mutual written approval of authorized representatives of the parties.
+
+C. The terms and conditions of this Agreement shall prevail notwithstanding any different, conflicting, or additional terms or conditions which may appear in any purchase order or other document submitted by you. You agree that such additional or inconsistent terms are deemed rejected by GREENSOCK.
+
+D. GREENSOCK and you agree that any xerographically or electronically reproduced copy of this Agreement shall have the same legal force and effect as any copy bearing original signatures of the parties.

--- a/src/licensedcode/data/rules/proprietary_greensock_6.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_6.yml
@@ -1,0 +1,2 @@
+license_expression: proprietary
+is_license_text: yes

--- a/src/licensedcode/data/rules/proprietary_greensock_7.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_7.RULE
@@ -1,0 +1,1 @@
+This work is subject to the terms in http://www.greensock.com/terms_of_use.html or for Club GreenSock members, the software agreement that was issued with the membership.

--- a/src/licensedcode/data/rules/proprietary_greensock_7.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_7.yml
@@ -1,0 +1,2 @@
+license_expression: proprietary
+is_license_notice: yes

--- a/src/licensedcode/data/rules/proprietary_greensock_8.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_8.RULE
@@ -1,0 +1,1 @@
+http://www.greensock.com

--- a/src/licensedcode/data/rules/proprietary_greensock_8.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_8.yml
@@ -1,0 +1,4 @@
+license_expression: proprietary
+is_license_notice: yes
+relevance: 90
+

--- a/src/licensedcode/data/rules/proprietary_greensock_9.RULE
+++ b/src/licensedcode/data/rules/proprietary_greensock_9.RULE
@@ -1,0 +1,2 @@
+is subject to the terms at http://greensock.com/standard-license or for
+ * Club GreenSock members, the software agreement that was issued with your membership.

--- a/src/licensedcode/data/rules/proprietary_greensock_9.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_9.yml
@@ -1,0 +1,2 @@
+license_expression: proprietary
+is_license_notice: yes


### PR DESCRIPTION
The greensock license is treated as a proprietary license for now.

Reported-by: @jonasob in #1302
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>