### PR TITLE
Fix-up the license text inside the `bsl-*.LICENSE` files

### DIFF
--- a/src/licensedcode/data/licenses/bsl-1.0.LICENSE
+++ b/src/licensedcode/data/licenses/bsl-1.0.LICENSE
@@ -1,80 +1,31 @@
-Business Source License 1.1
+Business Source License 1.0
 
-License text copyright © 2017 MariaDB Corporation Ab, All Rights Reserved.
-"Business Source License" is a trademark of MariaDB Corporation Ab.
+Licensor:  MariaDB Corporation Ab
 
-Terms
+Software: MariaDB MaxScale™ v.2.0.  The Software is © 2016 MariaDB Corporation Ab
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited production
-use.
+Use Limitation: Usage of the software is free when your application uses the Software with a total of less than three database server instances for production purposes.
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under the
-terms of the Change License, and the rights granted in the paragraph above
-terminate.
+Change Date: 2019-01-01
 
-If your use of the Licensed Work does not comply with the requirements currently
-in effect as described in this License, you must purchase a commercial license
-from the Licensor, its affiliated entities, or authorized resellers, or you must
-refrain from using the Licensed Work.
+Change License:  Version 2 or later of the GNU General Public License as published by the Free Software Foundation.
 
-All copies of the original and modified Licensed Work, and derivative works of
-the Licensed Work, are subject to this License. This License applies separately
-for each version of the Licensed Work and the Change Date may vary for each
-version of the Licensed Work released by Licensor.
+For information about  alternative licensing arrangements for the Software, please visit:  https://mariadb.com/products/mariadb-enterprise
 
-You must conspicuously display this License on each original or modified copy of
-the Licensed Work. If you receive the Licensed Work in original or modified form
-from a third party, the terms and conditions set forth in this License apply to
-your use of that work.
+ 
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other versions
-of the Licensed Work.
+You are granted limited license to the Software under this Business Source License.  Please read this Business Source License carefully, particularly the Use Limitation set forth above.  
 
-This License does not grant you any right in any trademark or logo of Licensor
-or its affiliates (provided that you may use a trademark or logo of Licensor as
-expressly required by this License).
+Subject to the Use Limitation, Licensor grants you a non-exclusive, worldwide (subject to applicable laws) license to copy, modify, display, use, create derivative works, and redistribute the Software until the Change Date. If your use of the Software exceeds, or will exceed, the foregoing limitations you MUST obtain alternative licensing terms for the Software directly from Licensor, its affiliated entities, or authorized resellers.  For the avoidance of doubt, prior to the Change Date, there is no Use Limitations for non-production purposes.
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
-"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
-OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.MariaDB hereby
-grants you permission to use this License’s text to license your works, and to
-refer to it using the trademark "Business Source License", as long as you comply
-with the Covenants of Licensor below.
+After the Change Date, this Business Source License will convert to the Change License and your use of the Software, including modified versions of the Software, will be governed by such Change License.
 
-Covenants of Licensor
+All copies of original and modified Software, and derivative works of the Software, are subject to this Business Source License.   This Business Source License applies separately for each version of the Software and the Change Date will vary for each version of the Software released by Licensor.
 
-In consideration of the right to use this License’s text and the "Business
-Source License" name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+You must conspicuously display this Business Source License on each original or modified copy of the Software. If you receive the Software in original or modified form from a third party, the restrictions set forth in this Business Source License apply to your use of such Software.
 
-    1. To specify as the Change License the GPL Version 2.0 or any later
-    version, or a license that is compatible with GPL Version 2.0 or a later
-    version, where "compatible" means that software provided under the Change
-    License can be included in a program with software provided under GPL
-    Version 2.0 or a later version. Licensor may specify additional Change
-    Licenses without limitation.
+Any use of the Software in violation of this Business Source License will automatically terminate your rights under this Business Source License for the current and all future versions of the Software.
 
-    2. To either: (a) specify an additional grant of rights to use that does not
-    impose any additional restriction on the right granted in this License, as
-    the Additional Use Grant; or (b) insert the text "None".
+You may not use the marks or logos of Licensor or its affiliates for commercial purposes without prior written consent from Licensor.
 
-    3. To specify a Change Date.
-
-    4. Not to modify this License in any other way.
-
-Notice
-
-The Business Source License (this document, or the "License") is not an Open
-Source license. However, the Licensed Work will eventually be made available
-under an Open Source License, as stated in this License.
-
-For more information on the use of the Business Source License for MariaDB
-products, please visit the MariaDB Business Source License FAQ.
-For more information on the use of the Business Source License generally, please
-visit the Adopting and Developing Business Source License FAQ.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE SOFTWARE AND ALL SERVICES PROVIDED BY LICENSOR OR ITS AFFILIATES UNDER OR IN CONNECTION WITH WITH THIS BUSINESS SOURCE LICENSE ARE PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS. YOU EXPRESSLY WAIVE ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, TITLE, SYSTEM INTEGRATION, AND ACCURACY OF INFORMATIONAL CONTENT.

--- a/src/licensedcode/data/licenses/bsl-1.1.LICENSE
+++ b/src/licensedcode/data/licenses/bsl-1.1.LICENSE
@@ -1,31 +1,80 @@
-Business Source License 1.0
+Business Source License 1.1
 
-Licensor:  MariaDB Corporation Ab
+License text copyright © 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
-Software: MariaDB MaxScale™ v.2.0.  The Software is © 2016 MariaDB Corporation Ab
+Terms
 
-Use Limitation: Usage of the software is free when your application uses the Software with a total of less than three database server instances for production purposes.
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production
+use.
 
-Change Date: 2019-01-01
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under the
+terms of the Change License, and the rights granted in the paragraph above
+terminate.
 
-Change License:  Version 2 or later of the GNU General Public License as published by the Free Software Foundation.
+If your use of the Licensed Work does not comply with the requirements currently
+in effect as described in this License, you must purchase a commercial license
+from the Licensor, its affiliated entities, or authorized resellers, or you must
+refrain from using the Licensed Work.
 
-For information about  alternative licensing arrangements for the Software, please visit:  https://mariadb.com/products/mariadb-enterprise
+All copies of the original and modified Licensed Work, and derivative works of
+the Licensed Work, are subject to this License. This License applies separately
+for each version of the Licensed Work and the Change Date may vary for each
+version of the Licensed Work released by Licensor.
 
- 
+You must conspicuously display this License on each original or modified copy of
+the Licensed Work. If you receive the Licensed Work in original or modified form
+from a third party, the terms and conditions set forth in this License apply to
+your use of that work.
 
-You are granted limited license to the Software under this Business Source License.  Please read this Business Source License carefully, particularly the Use Limitation set forth above.  
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other versions
+of the Licensed Work.
 
-Subject to the Use Limitation, Licensor grants you a non-exclusive, worldwide (subject to applicable laws) license to copy, modify, display, use, create derivative works, and redistribute the Software until the Change Date. If your use of the Software exceeds, or will exceed, the foregoing limitations you MUST obtain alternative licensing terms for the Software directly from Licensor, its affiliated entities, or authorized resellers.  For the avoidance of doubt, prior to the Change Date, there is no Use Limitations for non-production purposes.
+This License does not grant you any right in any trademark or logo of Licensor
+or its affiliates (provided that you may use a trademark or logo of Licensor as
+expressly required by this License).
 
-After the Change Date, this Business Source License will convert to the Change License and your use of the Software, including modified versions of the Software, will be governed by such Change License.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN
+"AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.MariaDB hereby
+grants you permission to use this License’s text to license your works, and to
+refer to it using the trademark "Business Source License", as long as you comply
+with the Covenants of Licensor below.
 
-All copies of original and modified Software, and derivative works of the Software, are subject to this Business Source License.   This Business Source License applies separately for each version of the Software and the Change Date will vary for each version of the Software released by Licensor.
+Covenants of Licensor
 
-You must conspicuously display this Business Source License on each original or modified copy of the Software. If you receive the Software in original or modified form from a third party, the restrictions set forth in this Business Source License apply to your use of such Software.
+In consideration of the right to use this License’s text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
 
-Any use of the Software in violation of this Business Source License will automatically terminate your rights under this Business Source License for the current and all future versions of the Software.
+    1. To specify as the Change License the GPL Version 2.0 or any later
+    version, or a license that is compatible with GPL Version 2.0 or a later
+    version, where "compatible" means that software provided under the Change
+    License can be included in a program with software provided under GPL
+    Version 2.0 or a later version. Licensor may specify additional Change
+    Licenses without limitation.
 
-You may not use the marks or logos of Licensor or its affiliates for commercial purposes without prior written consent from Licensor.
+    2. To either: (a) specify an additional grant of rights to use that does not
+    impose any additional restriction on the right granted in this License, as
+    the Additional Use Grant; or (b) insert the text "None".
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE SOFTWARE AND ALL SERVICES PROVIDED BY LICENSOR OR ITS AFFILIATES UNDER OR IN CONNECTION WITH WITH THIS BUSINESS SOURCE LICENSE ARE PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS. YOU EXPRESSLY WAIVE ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, TITLE, SYSTEM INTEGRATION, AND ACCURACY OF INFORMATIONAL CONTENT.
+    3. To specify a Change Date.
+
+    4. Not to modify this License in any other way.
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+For more information on the use of the Business Source License for MariaDB
+products, please visit the MariaDB Business Source License FAQ.
+For more information on the use of the Business Source License generally, please
+visit the Adopting and Developing Business Source License FAQ.


### PR DESCRIPTION
The license texts for the `Business Source License` version 1.0 and 1.1
were accidentally interchanged. Swap the contents of the two corresponding
files in order to have the right text in the right files.

See also:

https://enterprise.dejacode.com/licenses/public/bsl-1.0/#license-text
https://enterprise.dejacode.com/licenses/public/bsl-1.1/#license-text