### PR TITLE
Add a license for the `PSK` contributions to OpenSSL

### DIFF
--- a/src/licensedcode/data/licenses/openssl-nokia-psk-contribution.LICENSE
+++ b/src/licensedcode/data/licenses/openssl-nokia-psk-contribution.LICENSE
@@ -1,0 +1,22 @@
+The portions of the attached software ("Contribution") is developed by
+Nokia Corporation and is licensed pursuant to the OpenSSL open source
+license.
+
+The Contribution, originally written by Mika Kousa and Pasi Eronen of
+Nokia Corporation, consists of the "PSK" (Pre-Shared Key) ciphersuites
+support (see RFC 4279) to OpenSSL.
+
+No patent licenses or other rights except those expressly stated in
+the OpenSSL open source license shall be deemed granted or received
+expressly, by implication, estoppel, or otherwise.
+
+No assurances are provided by Nokia that the Contribution does not
+infringe the patent or other intellectual property rights of any third
+party or that the license provides you with all the necessary rights
+to make use of the Contribution.
+
+THE SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. IN
+ADDITION TO THE DISCLAIMERS INCLUDED IN THE LICENSE, NOKIA
+SPECIFICALLY DISCLAIMS ANY LIABILITY FOR CLAIMS BROUGHT BY YOU OR ANY
+OTHER ENTITY BASED ON INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS OR
+OTHERWISE.

--- a/src/licensedcode/data/licenses/openssl-nokia-psk-contribution.yml
+++ b/src/licensedcode/data/licenses/openssl-nokia-psk-contribution.yml
@@ -1,0 +1,5 @@
+key: openssl-nokia-psk-contribution
+name: OpenSSL Nokia PSK (Pre-Shared Key) Contribution
+short_name: OpenSSL Nokia PSK Contribution
+category: Permissive
+owner: Nokia

--- a/tests/licensedcode/data/licenses/openssl-nokia-psk-contribution.txt
+++ b/tests/licensedcode/data/licenses/openssl-nokia-psk-contribution.txt
@@ -1,0 +1,24 @@
+Copyright 2005 Nokia. All rights reserved.
+
+The portions of the attached software ("Contribution") is developed by
+Nokia Corporation and is licensed pursuant to the OpenSSL open source
+license.
+
+The Contribution, originally written by Mika Kousa and Pasi Eronen of
+Nokia Corporation, consists of the "PSK" (Pre-Shared Key) ciphersuites
+support (see RFC 4279) to OpenSSL.
+
+No patent licenses or other rights except those expressly stated in
+the OpenSSL open source license shall be deemed granted or received
+expressly, by implication, estoppel, or otherwise.
+
+No assurances are provided by Nokia that the Contribution does not
+infringe the patent or other intellectual property rights of any third
+party or that the license provides you with all the necessary rights
+to make use of the Contribution.
+
+THE SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. IN
+ADDITION TO THE DISCLAIMERS INCLUDED IN THE LICENSE, NOKIA
+SPECIFICALLY DISCLAIMS ANY LIABILITY FOR CLAIMS BROUGHT BY YOU OR ANY
+OTHER ENTITY BASED ON INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS OR
+OTHERWISE.

--- a/tests/licensedcode/data/licenses/openssl-nokia-psk-contribution.yml
+++ b/tests/licensedcode/data/licenses/openssl-nokia-psk-contribution.yml
@@ -1,0 +1,2 @@
+license_expressions:
+    - openssl-nokia-psk-contribution


### PR DESCRIPTION
Add the proprietary Nokia license (text) used for the `Pre-Shared Key`
contributions to OpenSSL by Nokia, see

https://github.com/openssl/openssl/commit/ddac1974