### PR TITLE
licensedcode: Remove the spdx_license_key from here-proprietary

### DIFF
--- a/src/licensedcode/data/licenses/here-proprietary.yml
+++ b/src/licensedcode/data/licenses/here-proprietary.yml
@@ -3,5 +3,3 @@ name: HERE Proprietary License
 short_name: HERE Proprietary
 category: Commercial
 owner: HERE Global B.V.
-spdx_license_key: LicenseRef-Proprietary-HERE
-


### PR DESCRIPTION
This is not a "core" SPDX license. While one could form an SPDX license
idstring out of any license by prefixing it with "LicenseRef-", we
currently don't do that for any of the other "non-core" SPDX /
proprietary licenses. Also, users might actually use the presence of
"spdx_license_key" to determine whether a license is a "core" SPDX
license or not. Thus, remove "spdx_license_key" from here again.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>