### PR TITLE
Remove unused function parameter

### DIFF
--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -187,7 +187,7 @@ def is_node_modules(location):
             and fileutils.file_name(location).lower() == 'node_modules')
 
 
-def parse(location, check_is_package=True):
+def parse(location):
     """
     Return a Package object from a package.json file or None.
     """


### PR DESCRIPTION
This PR removes an unused function parameter `check_is_package` when parsing npm's `package.json` files.

Signed-off-by: Ritiek Malhotra <ritiekmalhotra123@gmail.com>