### PR TITLE
Adding python3 support to string literals

### DIFF
--- a/etc/conf/dev/base.py
+++ b/etc/conf/dev/base.py
@@ -14,7 +14,7 @@ def setup_dev_mode():
     """
     from scancode_config import scancode_root_dir
     with open(os.path.join(scancode_root_dir, 'SCANCODE_DEV_MODE'), 'wb') as sdm:
-        sdm.write('This is a tag file to notify that ScanCode is used in development mode.')
+        sdm.write(b'This is a tag file to notify that ScanCode is used in development mode.')
 
 
 def setup_vscode():


### PR DESCRIPTION
It makes string compatible with both version of python 2/3.

Signed-off-by: Abhishek Kumar abhishek.kasyap09@gmail.com