### PR TITLE
Fix typo in _init_.py documentation

### DIFF
--- a/src/commoncode/__init__.py
+++ b/src/commoncode/__init__.py
@@ -29,7 +29,7 @@ from __future__ import unicode_literals
 
 def set_re_max_cache(max_cache=1000000):
     """
-    Set re and fnmatch _MAXCACHE to 1Million ietms to cache compiled regex
+    Set re and fnmatch _MAXCACHE to 1Million items to cache compiled regex
     aggressively. Their default is a maximum of 100 items and many utilities and
     libraries use a lot of regexes: therefore 100 is not enough to benefit from
     caching.


### PR DESCRIPTION
Fixed a small typo in _init_.py documentation from ietms to items.