### PR TITLE
To build universal wheel for typecode-libmagic

### DIFF
--- a/plugins/typecode-libmagic-manylinux1_x86_64/setup.cfg
+++ b/plugins/typecode-libmagic-manylinux1_x86_64/setup.cfg
@@ -1,5 +1,15 @@
 [metadata]
+# This includes the license file(s) in the wheel.
+# https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
 license_file = LICENSE.txt
-
+[bdist_wheel]
+# This flag says to generate wheels that support both Python 2 and Python
+# 3. If your code will not run unchanged on both Python 2 and 3, you will
+# need to generate separate wheels for each Python version that you
+# support. Removing this line (or setting universal to 0) will prevent
+# bdist_wheel from trying to make a universal wheel. For more see:
+# https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels
+universal=1
 [aliases]
-release = clean --all bdist_wheel --plat-name manylinux1_x86_64
+release = clean --all bdist_wheel 
+#to make platform indepedent


### PR DESCRIPTION
Currently it support python 2 only.By making universal it can be installed anywhere by pip and support Python 2 and 3 .
After it can be build by python setup.py bdist_wheel --universal in this repo.
We can also create source distribution by python3 setup.py sdist bdist_wheel
Reference-https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels
Signed-off-by: Abhishek Kumar abhishek.kasyap09@gmail.com