### PR TITLE
Add Support python3 to ipaddress module

### DIFF
--- a/plugins/extractcode-7z-macosx_10_9_intel/setup.cfg
+++ b/plugins/extractcode-7z-macosx_10_9_intel/setup.cfg
@@ -7,6 +7,6 @@ license_file = LICENSE.txt
 # support. Removing this line (or setting universal to 0) will prevent
 # bdist_wheel from trying to make a universal wheel. For more see:
 # https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels
-universal=1
+universal = 1
 [aliases]
 release = clean --all  bdist_wheel --plat-name macosx_10_9_intel

--- a/plugins/extractcode-7z-macosx_10_9_intel/setup.cfg
+++ b/plugins/extractcode-7z-macosx_10_9_intel/setup.cfg
@@ -1,5 +1,12 @@
 [metadata]
 license_file = LICENSE.txt
-
+[bdist_wheel]
+# This flag says to generate wheels that support both Python 2 and Python
+# 3. If your code will not run unchanged on both Python 2 and 3, you will
+# need to generate separate wheels for each Python version that you
+# support. Removing this line (or setting universal to 0) will prevent
+# bdist_wheel from trying to make a universal wheel. For more see:
+# https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels
+universal=1
 [aliases]
 release = clean --all  bdist_wheel --plat-name macosx_10_9_intel

--- a/setup.py
+++ b/setup.py
@@ -121,13 +121,13 @@ setup(
         'open source', 'scan', 'license', 'package', 'dependency',
         'copyright', 'filetype', 'author', 'extract', 'licensing',
     ],
-    python_requires='>=2.7,<3',    
+    python_requires='>=2.7,<4',    
     install_requires=[
         # cluecode
         # Some nltk version ranges are buggy
         'nltk >= 3.2, < 4.0',
         'publicsuffix2',
-        'py2-ipaddress >= 2.0, <3.5',
+        'ipaddress',
         'url >= 0.1.4, < 0.1.6',
         'fingerprints == 0.5.4',
 

--- a/setup.py
+++ b/setup.py
@@ -127,8 +127,8 @@ setup(
         # Some nltk version ranges are buggy
         'nltk >= 3.2, < 4.0',
         'publicsuffix2',
-        'py2-ipaddress >= 2.0, <3.5;python_version<"3.4"'
-        'ipaddress',
+        'py2-ipaddress >= 2.0, <3.5;python_version<"3"'
+        'ipaddress;python_version>"3"',
         'url >= 0.1.4, < 0.1.6',
         'fingerprints == 0.5.4',
 

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
         'nltk >= 3.2, < 4.0',
         'publicsuffix2',
         'py2-ipaddress >= 2.0, <3.5;python_version<"3"'
-        'ipaddress;python_version>"3"',
+        'ipaddress',
         'url >= 0.1.4, < 0.1.6',
         'fingerprints == 0.5.4',
 

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         'open source', 'scan', 'license', 'package', 'dependency',
         'copyright', 'filetype', 'author', 'extract', 'licensing',
     ],
-    python_requires='>=2.7,<3',    
+    python_requires='>=2.7,<4',    
     install_requires=[
         # cluecode
         # Some nltk version ranges are buggy

--- a/setup.py
+++ b/setup.py
@@ -121,14 +121,18 @@ setup(
         'open source', 'scan', 'license', 'package', 'dependency',
         'copyright', 'filetype', 'author', 'extract', 'licensing',
     ],
-    python_requires='>=2.7,<4',    
+    python_requires='>=2.7,<3',    
     install_requires=[
         # cluecode
         # Some nltk version ranges are buggy
         'nltk >= 3.2, < 4.0',
         'publicsuffix2',
+<<<<<<< HEAD
         'py2-ipaddress >= 2.0, <3.5;python_version<"3"',
         'ipaddress',
+=======
+        'py2-ipaddress >= 2.0, <3.5',
+>>>>>>> parent of 9a9e4dd9b... Add Support python3 to ipaddress module
         'url >= 0.1.4, < 0.1.6',
         'fingerprints == 0.5.4',
 

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         'open source', 'scan', 'license', 'package', 'dependency',
         'copyright', 'filetype', 'author', 'extract', 'licensing',
     ],
-    python_requires='>=2.7,<4',    
+    python_requires='>=2.7,<3',    
     install_requires=[
         # cluecode
         # Some nltk version ranges are buggy

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
         # Some nltk version ranges are buggy
         'nltk >= 3.2, < 4.0',
         'publicsuffix2',
-        'py2-ipaddress >= 2.0, <3.5;python_version<"3"'
+        'py2-ipaddress >= 2.0, <3.5;python_version<"3"',
         'ipaddress',
         'url >= 0.1.4, < 0.1.6',
         'fingerprints == 0.5.4',

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ setup(
         # Some nltk version ranges are buggy
         'nltk >= 3.2, < 4.0',
         'publicsuffix2',
+        'py2-ipaddress >= 2.0, <3.5;python_version<"3.4"'
         'ipaddress',
         'url >= 0.1.4, < 0.1.6',
         'fingerprints == 0.5.4',

--- a/setup.py
+++ b/setup.py
@@ -121,18 +121,14 @@ setup(
         'open source', 'scan', 'license', 'package', 'dependency',
         'copyright', 'filetype', 'author', 'extract', 'licensing',
     ],
-    python_requires='>=2.7,<3',    
+    python_requires='>=2.7,<4',    
     install_requires=[
         # cluecode
         # Some nltk version ranges are buggy
         'nltk >= 3.2, < 4.0',
         'publicsuffix2',
-<<<<<<< HEAD
         'py2-ipaddress >= 2.0, <3.5;python_version<"3"',
         'ipaddress',
-=======
-        'py2-ipaddress >= 2.0, <3.5',
->>>>>>> parent of 9a9e4dd9b... Add Support python3 to ipaddress module
         'url >= 0.1.4, < 0.1.6',
         'fingerprints == 0.5.4',
 


### PR DESCRIPTION
Since py2-ipaddress does not support python3.So we add PyPI dependency which is compatible with both python2/3. 

Signed-off-by: Abhishek Kumar abhishek.kasyap09@gmail.com