### PR TITLE
Do not use py2-ipaddress on Python3 #295

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
         # Some nltk version ranges are buggy
         'nltk >= 3.2, < 4.0',
         'publicsuffix2',
-        'py2-ipaddress >= 2.0, <3.5',
+        'py2-ipaddress >= 2.0, <3.5;python_version<"3"',
         'url >= 0.1.4, < 0.1.6',
         'fingerprints == 0.5.4',
 


### PR DESCRIPTION
The py2-ipaddress library is a backport of the Python 3 ipadress built-in module. Therefore it is not needed on Python 3



Signed-off-by: Abhishek-Dev09 <abhishek.kasyap09@gmail.com>