### PR TITLE
Detect description and author fields from Cargo.toml manifest

### DIFF
--- a/src/packagedcode/cargo.py
+++ b/src/packagedcode/cargo.py
@@ -137,6 +137,10 @@ def build_package(package_data):
 
 
 def party_mapper(party, package, party_type):
+    """
+    Update package parties with party of `party_type` and return package.
+    https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field-optional
+    """
     for auth in party:
         name, email = parse_person(auth)
         package.parties.append(models.Party(
@@ -144,10 +148,27 @@ def party_mapper(party, package, party_type):
             name=name,
             role=party_type,
             email=email))
+
     return package
 
 
 def parse_person(person):
+    """
+    https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field-optional
+    A "person" is an object with an optional "name" or "email" field.
+
+    A person can be in the form:
+      "author": "Isaac Z. Schlueter <i@izs.me>"
+
+    For example:
+    >>> parse_person('Barney Rubble <b@rubble.com>')
+    (u'Barney Rubble', u'b@rubble.com')
+    >>> parse_person('Barney Rubble')
+    (u'Barney Rubble', None)
+    >>> parse_person('<b@rubble.com>')
+    (None, u'b@rubble.com')
+    """
+
     parsed = person_parser(person)
     if not parsed:
         name = None

--- a/src/packagedcode/cargo.py
+++ b/src/packagedcode/cargo.py
@@ -110,13 +110,6 @@ def build_package(package_data):
     if description:
         description = description.strip()
 
-    # TODO: Remove this ordered_dict_map once cargo.py is able to handle
-    # the appropriate data (source_packages, dependencies, etc..)
-    # At the moment, this is only useful for making tests pass
-    ordered_dict_map = {}
-    for key in ('source_packages', 'dependencies', 'keywords'):
-        ordered_dict_map[key] = OrderedDict()
-
     authors = core_package_data.get('authors')
     parties = list(party_mapper(authors, party_role='author'))
 
@@ -125,7 +118,6 @@ def build_package(package_data):
         version=version,
         description=description,
         parties=parties,
-        **ordererd_dict_map,
     )
 
     return package

--- a/src/packagedcode/cargo.py
+++ b/src/packagedcode/cargo.py
@@ -120,7 +120,7 @@ def build_package(package_data):
     package = RustCargoCrate(
         name=name,
         version=version,
-        description=description,
+        description=description.strip(),
         **ordered_dict_map
     )
 

--- a/src/packagedcode/cargo.py
+++ b/src/packagedcode/cargo.py
@@ -59,9 +59,9 @@ class RustCargoCrate(models.Package):
     metafiles = ('Cargo.toml',)
     default_type = 'cargo'
     default_primary_language = 'Rust'
-    default_web_baseurl = "https://crates.io/"
-    default_download_baseurl = "https://crates.io/api/v1/"
-    default_api_baseurl = "https://crates.io/api/v1/"
+    default_web_baseurl = "https://crates.io"
+    default_download_baseurl = "https://crates.io/api/v1"
+    default_api_baseurl = "https://crates.io/api/v1"
 
     @classmethod
     def recognize(cls, location):

--- a/src/packagedcode/cargo.py
+++ b/src/packagedcode/cargo.py
@@ -95,9 +95,7 @@ def parse(location):
     if not is_cargo_toml(location):
         return
 
-    with io.open(location, encoding='utf-8') as loc:
-        package_data = toml.load(location, _dict=OrderedDict)
-
+    package_data = toml.load(location, _dict=OrderedDict)
     return build_package(package_data)
 
 

--- a/src/packagedcode/cargo.py
+++ b/src/packagedcode/cargo.py
@@ -109,6 +109,8 @@ def build_package(package_data):
     name = package_data.get('package').get('name')
     version = package_data.get('package').get('version')
     description = package_data.get('package').get('description')
+    if description:
+        description = description.strip()
 
     # TODO: Remove this ordered_dict_map once cargo.py is able to handle
     # the appropriate data (source_packages, dependencies, etc..)
@@ -120,7 +122,7 @@ def build_package(package_data):
     package = RustCargoCrate(
         name=name,
         version=version,
-        description=description.strip(),
+        description=description,
         **ordered_dict_map
     )
 
@@ -128,7 +130,7 @@ def build_package(package_data):
         ('authors', partial(party_mapper, party_type="author")),
     ]
     for source, func in field_mappers:
-        value = package_data.get('package').get(source)
+        value = package_data.get('package').get(source, [])
         func(value, package)
 
     return package

--- a/src/packagedcode/cargo.py
+++ b/src/packagedcode/cargo.py
@@ -59,9 +59,9 @@ class RustCargoCrate(models.Package):
     metafiles = ('Cargo.toml',)
     default_type = 'cargo'
     default_primary_language = 'Rust'
-    default_web_baseurl = "https://crates.io"
-    default_download_baseurl = "https://crates.io/api/v1"
-    default_api_baseurl = "https://crates.io/api/v1"
+    default_web_baseurl = 'https://crates.io'
+    default_download_baseurl = 'https://crates.io/api/v1'
+    default_api_baseurl = 'https://crates.io/api/v1'
 
     @classmethod
     def recognize(cls, location):
@@ -106,9 +106,10 @@ def build_package(package_data):
     Return a Pacakge object from a package data mapping or None.
     """
 
-    name = package_data.get('package').get('name')
-    version = package_data.get('package').get('version')
-    description = package_data.get('package').get('description')
+    core_package_data = package_data.get('package', {})
+    name = core_package_data.get('name')
+    version = core_package_data.get('version')
+    description = core_package_data.get('description')
     if description:
         description = description.strip()
 
@@ -116,7 +117,7 @@ def build_package(package_data):
     # the appropriate data (source_packages, dependencies, etc..)
     # At the moment, this is only useful for making tests pass
     ordered_dict_map = {}
-    for key in ("source_packages", "dependencies", "keywords"):
+    for key in ('source_packages', 'dependencies', 'keywords'):
         ordered_dict_map[key] = OrderedDict()
 
     package = RustCargoCrate(
@@ -127,10 +128,10 @@ def build_package(package_data):
     )
 
     field_mappers = [
-        ('authors', partial(party_mapper, party_type="author")),
+        ('authors', partial(party_mapper, party_type='author')),
     ]
     for source, func in field_mappers:
-        value = package_data.get('package').get(source, [])
+        value = core_package_data.get(source, [])
         func(value, package)
 
     return package

--- a/src/packagedcode/cargo.py
+++ b/src/packagedcode/cargo.py
@@ -108,6 +108,7 @@ def build_package(package_data):
 
     name = package_data.get('package').get('name')
     version = package_data.get('package').get('version')
+    description = package_data.get('package').get('description')
 
     # TODO: Remove this ordered_dict_map once cargo.py is able to handle
     # the appropriate data (source_packages, dependencies, etc..)
@@ -119,6 +120,7 @@ def build_package(package_data):
     package = RustCargoCrate(
         name=name,
         version=version,
+        description=description,
         **ordered_dict_map
     )
 

--- a/tests/packagedcode/data/cargo/clap/Cargo.toml.expected
+++ b/tests/packagedcode/data/cargo/clap/Cargo.toml.expected
@@ -17,7 +17,7 @@
      "url": null
    }
  ],
- "keywords": {},
+ "keywords": [],
  "homepage_url": null,
  "download_url": null,
  "size": null,
@@ -33,9 +33,9 @@
  "declared_license": null,
  "notice_text": null,
  "manifest_path": null,
- "dependencies": {},
+ "dependencies": [],
  "contains_source_code": null,
- "source_packages": {},
+ "source_packages": [],
  "purl": "pkg:cargo/clap@2.32.0",
  "repository_homepage_url": "https://crates.io/crates/clap",
  "repository_download_url": "https://crates.io/api/v1/crates/clap/2.32.0/download",

--- a/tests/packagedcode/data/cargo/clap/Cargo.toml.expected
+++ b/tests/packagedcode/data/cargo/clap/Cargo.toml.expected
@@ -6,9 +6,17 @@
  "qualifiers": null,
  "subpath": null,
  "primary_language": "Rust",
- "description": null,
+ "description": "A simple to use, efficient, and full featured  Command Line Argument Parser",
  "release_date": null,
- "parties": {},
+ "parties": [
+   {
+     "type": "person",
+     "role": "author",
+     "name": "Kevin K.",
+     "email": "kbknapp@gmail.com",
+     "url": null
+   }
+ ],
  "keywords": {},
  "homepage_url": null,
  "download_url": null,
@@ -29,7 +37,7 @@
  "contains_source_code": null,
  "source_packages": {},
  "purl": "pkg:cargo/clap@2.32.0",
- "repository_homepage_url": "https://crates.io//crates/clap",
- "repository_download_url": "https://crates.io/api/v1//crates/clap/2.32.0/download",
- "api_data_url": "https://crates.io/api/v1//crates/clap"
+ "repository_homepage_url": "https://crates.io/crates/clap",
+ "repository_download_url": "https://crates.io/api/v1/crates/clap/2.32.0/download",
+ "api_data_url": "https://crates.io/api/v1/crates/clap"
 }

--- a/tests/packagedcode/data/cargo/clippy/Cargo.toml.expected
+++ b/tests/packagedcode/data/cargo/clippy/Cargo.toml.expected
@@ -45,7 +45,7 @@
      "url": null
    }
  ],
- "keywords": {},
+ "keywords": [],
  "homepage_url": null,
  "download_url": null,
  "size": null,
@@ -61,9 +61,9 @@
  "declared_license": null,
  "notice_text": null,
  "manifest_path": null,
- "dependencies": {},
+ "dependencies": [],
  "contains_source_code": null,
- "source_packages": {},
+ "source_packages": [],
  "purl": "pkg:cargo/clippy@0.0.212",
  "repository_homepage_url": "https://crates.io/crates/clippy",
  "repository_download_url": "https://crates.io/api/v1/crates/clippy/0.0.212/download",

--- a/tests/packagedcode/data/cargo/clippy/Cargo.toml.expected
+++ b/tests/packagedcode/data/cargo/clippy/Cargo.toml.expected
@@ -6,9 +6,45 @@
  "qualifiers": null,
  "subpath": null,
  "primary_language": "Rust",
- "description": null,
+ "description": "A bunch of helpful lints to avoid common pitfalls in Rust",
  "release_date": null,
- "parties": {},
+ "parties": [
+   {
+     "type": "person",
+     "role": "author",
+     "name": "Manish Goregaokar",
+     "email": "manishsmail@gmail.com",
+     "url": null
+   },
+   {
+     "type": "person",
+     "role": "author",
+     "name": "Andre Bogus",
+     "email": "bogusandre@gmail.com",
+     "url": null
+   },
+   {
+     "type": "person",
+     "role": "author",
+     "name": "Georg Brandl",
+     "email": "georg@python.org",
+     "url": null
+   },
+   {
+     "type": "person",
+     "role": "author",
+     "name": "Martin Carton",
+     "email": "cartonmartin@gmail.com",
+     "url": null
+   },
+   {
+     "type": "person",
+     "role": "author",
+     "name": "Oliver Schneider",
+     "email": "clippy-iethah7aipeen8neex1a@oli-obk.de",
+     "url": null
+   }
+ ],
  "keywords": {},
  "homepage_url": null,
  "download_url": null,
@@ -29,7 +65,7 @@
  "contains_source_code": null,
  "source_packages": {},
  "purl": "pkg:cargo/clippy@0.0.212",
- "repository_homepage_url": "https://crates.io//crates/clippy",
- "repository_download_url": "https://crates.io/api/v1//crates/clippy/0.0.212/download",
- "api_data_url": "https://crates.io/api/v1//crates/clippy"
+ "repository_homepage_url": "https://crates.io/crates/clippy",
+ "repository_download_url": "https://crates.io/api/v1/crates/clippy/0.0.212/download",
+ "api_data_url": "https://crates.io/api/v1/crates/clippy"
 }

--- a/tests/packagedcode/data/cargo/mdbook/Cargo.toml.expected
+++ b/tests/packagedcode/data/cargo/mdbook/Cargo.toml.expected
@@ -6,9 +6,31 @@
  "qualifiers": null,
  "subpath": null,
  "primary_language": "Rust",
- "description": null,
+ "description": "Create books from markdown files",
  "release_date": null,
- "parties": {},
+ "parties": [
+   {
+     "type": "person",
+     "role": "author",
+     "name": "Mathieu David",
+     "email": "mathieudavid@mathieudavid.org",
+     "url": null
+   },
+   {
+     "type": "person",
+     "role": "author",
+     "name": "Michael-F-Bryan",
+     "email": "michaelfbryan@gmail.com",
+      "url": null
+   },
+   {
+     "type": "person",
+     "role": "author",
+     "name": "Matt Ickstadt",
+     "email": "mattico8@gmail.com",
+     "url": null
+   }
+ ],
  "keywords": {},
  "homepage_url": null,
  "download_url": null,
@@ -29,7 +51,7 @@
  "contains_source_code": null,
  "source_packages": {},
  "purl": "pkg:cargo/mdbook@0.2.4-alpha.0",
- "repository_homepage_url": "https://crates.io//crates/mdbook",
- "repository_download_url": "https://crates.io/api/v1//crates/mdbook/0.2.4-alpha.0/download",
- "api_data_url": "https://crates.io/api/v1//crates/mdbook"
+ "repository_homepage_url": "https://crates.io/crates/mdbook",
+ "repository_download_url": "https://crates.io/api/v1/crates/mdbook/0.2.4-alpha.0/download",
+ "api_data_url": "https://crates.io/api/v1/crates/mdbook"
 }

--- a/tests/packagedcode/data/cargo/mdbook/Cargo.toml.expected
+++ b/tests/packagedcode/data/cargo/mdbook/Cargo.toml.expected
@@ -31,7 +31,7 @@
      "url": null
    }
  ],
- "keywords": {},
+ "keywords": [],
  "homepage_url": null,
  "download_url": null,
  "size": null,
@@ -47,9 +47,9 @@
  "declared_license": null,
  "notice_text": null,
  "manifest_path": null,
- "dependencies": {},
+ "dependencies": [],
  "contains_source_code": null,
- "source_packages": {},
+ "source_packages": [],
  "purl": "pkg:cargo/mdbook@0.2.4-alpha.0",
  "repository_homepage_url": "https://crates.io/crates/mdbook",
  "repository_download_url": "https://crates.io/api/v1/crates/mdbook/0.2.4-alpha.0/download",

--- a/tests/packagedcode/data/cargo/rustfmt/Cargo.toml.expected
+++ b/tests/packagedcode/data/cargo/rustfmt/Cargo.toml.expected
@@ -6,9 +6,24 @@
  "qualifiers": null,
  "subpath": null,
  "primary_language": "Rust",
- "description": null,
+ "description": "Tool to find and fix Rust formatting issues",
  "release_date": null,
- "parties": {},
+ "parties": [
+   {
+      "type": "person",
+      "role": "author",
+      "name": "Nicholas Cameron",
+      "email": "ncameron@mozilla.com",
+      "url": null
+   },
+   {
+      "type": "person",
+      "role": "author",
+      "name": "The Rustfmt developers",
+      "email": null,
+      "url": null
+   }
+ ],
  "keywords": {},
  "homepage_url": null,
  "download_url": null,
@@ -29,7 +44,7 @@
  "contains_source_code": null,
  "source_packages": {},
  "purl": "pkg:cargo/rustfmt-nightly@1.0.3",
- "repository_homepage_url": "https://crates.io//crates/rustfmt-nightly",
- "repository_download_url": "https://crates.io/api/v1//crates/rustfmt-nightly/1.0.3/download",
- "api_data_url": "https://crates.io/api/v1//crates/rustfmt-nightly"
+ "repository_homepage_url": "https://crates.io/crates/rustfmt-nightly",
+ "repository_download_url": "https://crates.io/api/v1/crates/rustfmt-nightly/1.0.3/download",
+ "api_data_url": "https://crates.io/api/v1/crates/rustfmt-nightly"
 }

--- a/tests/packagedcode/data/cargo/rustfmt/Cargo.toml.expected
+++ b/tests/packagedcode/data/cargo/rustfmt/Cargo.toml.expected
@@ -24,7 +24,7 @@
       "url": null
    }
  ],
- "keywords": {},
+ "keywords": [],
  "homepage_url": null,
  "download_url": null,
  "size": null,
@@ -40,9 +40,9 @@
  "declared_license": null,
  "notice_text": null,
  "manifest_path": null,
- "dependencies": {},
+ "dependencies": [],
  "contains_source_code": null,
- "source_packages": {},
+ "source_packages": [],
  "purl": "pkg:cargo/rustfmt-nightly@1.0.3",
  "repository_homepage_url": "https://crates.io/crates/rustfmt-nightly",
  "repository_download_url": "https://crates.io/api/v1/crates/rustfmt-nightly/1.0.3/download",

--- a/tests/packagedcode/data/cargo/rustup/Cargo.toml.expected
+++ b/tests/packagedcode/data/cargo/rustup/Cargo.toml.expected
@@ -6,9 +6,17 @@
  "qualifiers": null,
  "subpath": null,
  "primary_language": "Rust",
- "description": null,
+ "description": "Manage multiple rust installations with ease",
  "release_date": null,
- "parties": {},
+ "parties": [
+    {
+      "type": "person",
+      "role": "author",
+      "name": "Diggory Blake",
+      "email": "diggsey@googlemail.com",
+      "url": null
+    }
+ ],
  "keywords": {},
  "homepage_url": null,
  "download_url": null,
@@ -29,7 +37,7 @@
  "contains_source_code": null,
  "source_packages": {},
  "purl": "pkg:cargo/rustup@1.17.0",
- "repository_homepage_url": "https://crates.io//crates/rustup",
- "repository_download_url": "https://crates.io/api/v1//crates/rustup/1.17.0/download",
- "api_data_url": "https://crates.io/api/v1//crates/rustup"
+ "repository_homepage_url": "https://crates.io/crates/rustup",
+ "repository_download_url": "https://crates.io/api/v1/crates/rustup/1.17.0/download",
+ "api_data_url": "https://crates.io/api/v1/crates/rustup"
 }

--- a/tests/packagedcode/data/cargo/rustup/Cargo.toml.expected
+++ b/tests/packagedcode/data/cargo/rustup/Cargo.toml.expected
@@ -17,7 +17,7 @@
       "url": null
     }
  ],
- "keywords": {},
+ "keywords": [],
  "homepage_url": null,
  "download_url": null,
  "size": null,
@@ -33,9 +33,9 @@
  "declared_license": null,
  "notice_text": null,
  "manifest_path": null,
- "dependencies": {},
+ "dependencies": [],
  "contains_source_code": null,
- "source_packages": {},
+ "source_packages": [],
  "purl": "pkg:cargo/rustup@1.17.0",
  "repository_homepage_url": "https://crates.io/crates/rustup",
  "repository_download_url": "https://crates.io/api/v1/crates/rustup/1.17.0/download",


### PR DESCRIPTION
Closes #1424 and addresses #1436.

scancode can now parse description and author fields from Cargo.toml manifest and deal with some edge cases when authors or description are not mentioned under Cargo.toml.

This should be ready to merge if everything looks good!