### PR TITLE
Use "exception as e" on Python 3 #295

### DIFF
--- a/src/commoncode/fileutils.py
+++ b/src/commoncode/fileutils.py
@@ -127,14 +127,14 @@ def create_dir(location):
 
         # avoid multi-process TOCTOU conditions when creating dirs
         # the directory may have been created since the exist check
-        except WindowsError, e:
+        except WindowsError as e:
             # [Error 183] Cannot create a file when that file already exists
             if e and e.winerror == 183:
                 if not os.path.isdir(location):
                     raise
             else:
                 raise
-        except (IOError, OSError), o:
+        except (IOError, OSError) as o:
             if o.errno == errno.EEXIST:
                 if not os.path.isdir(location):
                     raise
@@ -493,9 +493,9 @@ def copytree(src, dst):
                 copyfile(srcname, dstname)
         # catch the Error from the recursive copytree so that we can
         # continue with other files
-        except shutil.Error, err:
+        except shutil.Error as err:
             errors.extend(err.args[0])
-        except EnvironmentError, why:
+        except EnvironmentError as why:
             errors.append((srcname, dstname, str(why)))
 
     if errors:

--- a/src/extractcode/extract.py
+++ b/src/extractcode/extract.py
@@ -188,7 +188,7 @@ def extract_file(location, target, kinds=extractcode.default_kinds, verbose=Fals
             warnings.extend(warns)
             fileutils.copytree(tmp_tgt, target)
             fileutils.delete(tmp_tgt)
-        except Exception, e:
+        except Exception as e:
             errors = [str(e).strip(' \'"')]
             if verbose:
                 errors.append(traceback.format_exc())

--- a/src/extractcode/libarchive2.py
+++ b/src/extractcode/libarchive2.py
@@ -242,7 +242,7 @@ class Archive(object):
                     if r == ARCHIVE_EOF:
                         return
                     entry = Entry(self, entry_struct)
-                except ArchiveWarning, aw:
+                except ArchiveWarning as aw:
                     if not entry:
                         entry = Entry(self, entry_struct)
                     if aw.msg and aw.msg not in entry.warnings:
@@ -400,7 +400,7 @@ class Entry(object):
             os.utime(unique_path, (self.time, self.time))
             return target_path
 
-        except ArchiveWarning, aw:
+        except ArchiveWarning as aw:
             msg = aw.args and '\n'.join(aw.args) or 'No message provided.'
             if msg not in self.warnings:
                 self.warnings.append(msg)

--- a/src/formattedcode/output_html.py
+++ b/src/formattedcode/output_html.py
@@ -329,7 +329,7 @@ def create_html_app(output_file, results, version, scanned_path):  # NOQA
             f.write(b'data=')
             simplejson.dump(results, f, iterable_as_array=True)
 
-    except HtmlAppAssetCopyWarning, w:
+    except HtmlAppAssetCopyWarning as w:
         raise w
 
     except Exception as e:  # NOQA

--- a/src/licensedcode/models.py
+++ b/src/licensedcode/models.py
@@ -273,7 +273,7 @@ class License(object):
 
                 setattr(self, k, v)
 
-        except Exception, e:
+        except Exception as e:
             # this is a rare case: fail loudly
             print()
             print('#############################')
@@ -1028,7 +1028,7 @@ class Rule(object):
         try:
             with io.open(self.data_file, encoding='utf-8') as f:
                 data = saneyaml.load(f.read())
-        except Exception, e:
+        except Exception as e:
             print('#############################')
             print('INVALID LICENSE RULE FILE:', 'file://' + self.data_file)
             print('#############################')

--- a/src/packagedcode/gemfile_lock.py
+++ b/src/packagedcode/gemfile_lock.py
@@ -469,7 +469,7 @@ class GemfileLockParser(object):
         # for bundler: not finding one is an error
         try:
             gem = self.all_gems[name]
-        except KeyError, e:
+        except KeyError as e:
             gem = Gem(name)
             self.all_gems[name] = gem
             if name != 'bundler' and TRACE:

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -209,7 +209,7 @@ Try 'scancode --help' for help on options and arguments.'''
 try:
     # IMPORTANT: this discovers, loads and validates all available plugins
     plugin_classes, plugin_options = PluginManager.load_plugins()
-except ImportError, e:
+except ImportError as e:
     echo_stderr('========================================================================')
     echo_stderr('ERROR: Unable to import ScanCode plugins.'.upper())
     echo_stderr('Check your installation configuration (setup.py) or re-install/re-configure ScanCode.')

--- a/src/scancode_config.py
+++ b/src/scancode_config.py
@@ -70,14 +70,14 @@ def _create_dir(location):
 
     # avoid multi-process TOCTOU conditions when creating dirs
     # the directory may have been created since the exist check
-    except WindowsError, e:
+    except WindowsError as e:
         # [Error 183] Cannot create a file when that file already exists
         if e and e.winerror == 183:
             if not os.path.isdir(location):
                 raise
         else:
             raise
-    except (IOError, OSError), o:
+    except (IOError, OSError) as o:
         if o.errno == errno.EEXIST:
             if not os.path.isdir(location):
                 raise

--- a/tests/cluecode/data/authors/author_avinash-BitVector_py.py
+++ b/tests/cluecode/data/authors/author_avinash-BitVector_py.py
@@ -1770,7 +1770,7 @@ if __name__ == '__main__':
             print "%s is in %s" % (bv2, bv1)
         else:
             print "%s is not in %s" % (bv2, bv1)
-    except ValueError, arg:
+    except ValueError as arg:
         print "Error Message: " + str(arg)
 
     print "\nTest the size modifier when a bit vector is initialized with the intVal method:"

--- a/tests/cluecode/data/authors/author_avinash_kak-BitVector_py.py
+++ b/tests/cluecode/data/authors/author_avinash_kak-BitVector_py.py
@@ -1770,7 +1770,7 @@ if __name__ == '__main__':
             print "%s is in %s" % (bv2, bv1)
         else:
             print "%s is not in %s" % (bv2, bv1)
-    except ValueError, arg:
+    except ValueError as arg:
         print "Error Message: " + str(arg)
 
     print "\nTest the size modifier when a bit vector is initialized with the intVal method:"

--- a/tests/cluecode/data/copyrights/psf_in_python-BitVector_py.py
+++ b/tests/cluecode/data/copyrights/psf_in_python-BitVector_py.py
@@ -1770,7 +1770,7 @@ if __name__ == '__main__':
             print "%s is in %s" % (bv2, bv1)
         else:
             print "%s is not in %s" % (bv2, bv1)
-    except ValueError, arg:
+    except ValueError as arg:
         print "Error Message: " + str(arg)
 
     print "\nTest the size modifier when a bit vector is initialized with the intVal method:"

--- a/tests/cluecode/data/finder/url/BeautifulSoup.py
+++ b/tests/cluecode/data/finder/url/BeautifulSoup.py
@@ -1783,7 +1783,7 @@ class UnicodeDammit:
             u = self._toUnicode(markup, proposed)
             self.markup = u
             self.originalEncoding = proposed
-        except Exception, e:
+        except Exception as e:
             # print "That didn't work!"
             # print e
             return None

--- a/tests/cluecode/data/finder/url/no-scheme.py
+++ b/tests/cluecode/data/finder/url/no-scheme.py
@@ -1770,7 +1770,7 @@ if __name__ == '__main__':
             print "%s is in %s" % (bv2, bv1)
         else:
             print "%s is not in %s" % (bv2, bv1)
-    except ValueError, arg:
+    except ValueError as arg:
         print "Error Message: " + str(arg)
 
     print "\nTest the size modifier when a bit vector is initialized with the intVal method:"

--- a/tests/extractcode/test_archive.py
+++ b/tests/extractcode/test_archive.py
@@ -439,7 +439,7 @@ class BaseArchiveTestCase(FileBasedTesting):
     def assertExceptionContains(self, text, callableObj, *args, **kwargs):
         try:
             callableObj(*args, **kwargs)
-        except Exception, e:
+        except Exception as e:
             if text not in str(e):
                 raise self.failureException(
                        'Exception %(e)r raised, '
@@ -1027,7 +1027,7 @@ class TestZip(BaseArchiveTestCase):
         test_dir = self.get_temp_dir()
         try:
             archive.extract_zip(test_file, test_dir)
-        except Exception, e:
+        except Exception as e:
             assert isinstance(e, ExtractErrorFailedToExtract)
             assert 'Password protected archive, unable to extract' in str(e)
 

--- a/tests/packagedcode/test_freebsd.py
+++ b/tests/packagedcode/test_freebsd.py
@@ -77,7 +77,7 @@ class TestFreeBSD(PackageTester):
         test_file = self.get_test_loc('freebsd/not_yaml/+COMPACT_MANIFEST')
         try:
             freebsd.parse(test_file)
-        except saneyaml.YAMLError, e:
+        except saneyaml.YAMLError as e:
             assert 'while parsing a block node' in str(e)
 
     def test_parse_invalid_metafile(self):

--- a/tests/packagedcode/test_npm.py
+++ b/tests/packagedcode/test_npm.py
@@ -141,7 +141,7 @@ class TestNpm(PackageTester):
         test_file = self.get_test_loc('npm/invalid/package.json')
         try:
             npm.parse(test_file)
-        except ValueError, e:
+        except ValueError as e:
             assert 'No JSON object could be decoded' in str(e)
 
     def test_parse_keywords(self):


### PR DESCRIPTION
Since 'Exception, e' is used on python 2.X .Therefore it is not needed on Python 3.X .

Signed-off-by: Abhishek Kumar <abhishek.kasyap09@gmail.com>