### PR TITLE
Raising exception on Python 3.X #295

### DIFF
--- a/src/commoncode/fileutils.py
+++ b/src/commoncode/fileutils.py
@@ -499,7 +499,7 @@ def copytree(src, dst):
             errors.append((srcname, dstname, str(why)))
 
     if errors:
-        raise shutil.Error, errors
+        raise shutil.Error(errors)
 
 
 def copyfile(src, dst):
@@ -540,7 +540,7 @@ def copytime(src, dst):
     if hasattr(os, 'utime'):
         try:
             os.utime(dst, (st.st_atime, st.st_mtime))
-        except OSError, why:
+        except OSError as why:
             if WindowsError is not None and isinstance(why, WindowsError):
                 # File access times cannot be copied on Windows
                 pass

--- a/tests/extractcode/test_archive.py
+++ b/tests/extractcode/test_archive.py
@@ -379,7 +379,7 @@ class BaseArchiveTestCase(FileBasedTesting):
         excClass = excInstance.__class__
         try:
             callableObj(*args, **kwargs)
-        except excClass, e:
+        except excClass as e:
             self.assertEqual(str(excInstance), str(e))
         else:
             if hasattr(excClass, '__name__'):
@@ -813,7 +813,7 @@ class TestZip(BaseArchiveTestCase):
         test_dir = self.get_temp_dir()
         try:
             archive.extract_zip(test_file, test_dir)
-        except libarchive2.ArchiveError, ae:
+        except libarchive2.ArchiveError as ae:
             assert 'Invalid central directory signature' in str(ae)
 
         # fails because of https://github.com/libarchive/libarchive/issues/545
@@ -829,7 +829,7 @@ class TestZip(BaseArchiveTestCase):
         test_dir = self.get_temp_dir()
         try:
             archive.extract_zip(test_file, test_dir)
-        except libarchive2.ArchiveError, ae:
+        except libarchive2.ArchiveError as ae:
             assert 'Invalid central directory signature' in str(ae)
         # fails because of https://github.com/libarchive/libarchive/issues/545
         result = os.path.join(test_dir, 'f1')
@@ -2020,7 +2020,7 @@ class TestSevenZip(BaseArchiveTestCase):
         test_dir = self.get_temp_dir()
         try:
             archive.extract_7z(test_file, test_dir)
-        except libarchive2.ArchiveError, e:
+        except libarchive2.ArchiveError as e:
             assert 'Damaged 7-Zip archive' in e.msg
 
     def test_extract_7z_basic_with_space_in_file_name(self):


### PR DESCRIPTION
Since 'raise ValueError, str' is used on Python 2.X. Therefore, to use raise exception on python 3.X ,we use it as 'raise ValueError(str)'.

Signed-off-by: Abhishek Kumar <abhishek.kasyap09@gmail.com>