### PR TITLE
Import "types" & "urllib2" on python 3.X  #295

### DIFF
--- a/etc/scripts/openhub_scraper.py
+++ b/etc/scripts/openhub_scraper.py
@@ -26,7 +26,11 @@
 import io
 import json
 import os
-import urllib2
+
+try:
+    from urlib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 
 from bs4 import BeautifulSoup
 
@@ -57,7 +61,7 @@ def parse_webpage(url, page_no):
     Parses the given webpage using 'BeautifulSoup' and returns html content of
     that webpage.
     """
-    page = urllib2.urlopen(url + page_no)
+    page = urlopen(url + page_no)
     parsed_page = BeautifulSoup(page, 'html.parser')
     return parsed_page
 

--- a/src/commoncode/fetch.py
+++ b/src/commoncode/fetch.py
@@ -76,11 +76,14 @@ def ping_url(url):
     """
     Returns True is `url` is reachable.
     """
-    import urllib2
+    try:
+       from urlib.request import urlopen
+    except ImportError:
+       from urllib2 import urlopen
 
     # FIXME: if there is no 200 HTTP status, then the ULR may not be reachable.
     try:
-        urllib2.urlopen(url)
+        urlopen(url)
     except Exception:
         return False
     else:

--- a/src/commoncode/functional.py
+++ b/src/commoncode/functional.py
@@ -25,7 +25,7 @@
 from __future__ import absolute_import, print_function
 
 import functools
-from types import ListType, TupleType, GeneratorType
+from types import *
 from array import array
 
 

--- a/src/commoncode/functional.py
+++ b/src/commoncode/functional.py
@@ -25,7 +25,7 @@
 from __future__ import absolute_import, print_function
 
 import functools
-from types import *
+from types import GeneratorType
 from array import array
 
 
@@ -53,7 +53,7 @@ def flatten(seq):
     """
     r = []
     for x in seq:
-        if isinstance(x, (ListType, TupleType)):
+        if isinstance(x, (list, tuple)):
             r.extend(flatten(x))
         elif isinstance(x, GeneratorType):
             r.extend(flatten(list(x)))
@@ -102,7 +102,7 @@ def memoize(fun):
         if kwargs:
             return fun(*args, **kwargs)
         # convert any list args to a tuple
-        args = tuple(tuple(arg) if isinstance(arg, (ListType, tuple, array)) else arg
+        args = tuple(tuple(arg) if isinstance(arg, (list, tuple, array)) else arg
                      for arg in args)
         try:
             return memos[args]

--- a/src/scancode/__init__.py
+++ b/src/scancode/__init__.py
@@ -35,7 +35,6 @@ from os.path import getsize
 from os.path import getmtime
 from os.path import join
 from os.path import exists
-from types import *
 
 import click
 from click.types import BoolParamType
@@ -197,7 +196,7 @@ def _validate_option_dependencies(ctx, param, value,
         return
 
     def _is_set(_value, _param):
-        if _param.type in (BooleanType, BoolParamType):
+        if _param.type in (bool, BoolParamType):
             return _value
 
         if _param.multiple:

--- a/src/scancode/__init__.py
+++ b/src/scancode/__init__.py
@@ -35,7 +35,7 @@ from os.path import getsize
 from os.path import getmtime
 from os.path import join
 from os.path import exists
-from types import BooleanType
+from types import *
 
 import click
 from click.types import BoolParamType

--- a/tests/cluecode/data/finder/url/BeautifulSoup.py
+++ b/tests/cluecode/data/finder/url/BeautifulSoup.py
@@ -908,7 +908,7 @@ class SoupStrainer:
     def _matches(self, markup, matchAgainst):
         #print "Matching %s against %s" % (markup, matchAgainst)
         result = False
-        if matchAgainst == True and type(matchAgainst) == types.BooleanType:
+        if matchAgainst == True and type(matchAgainst) == bool:
             result = markup != None
         elif callable(matchAgainst):
             result = matchAgainst(markup)
@@ -950,7 +950,7 @@ def isList(l):
     """Convenience method that works with all 2.x versions of Python
     to determine whether or not something is listlike."""
     return hasattr(l, '__iter__') \
-           or (type(l) in (types.ListType, types.TupleType))
+           or (type(l) in (list, tuple))
 
 def isString(s):
     """Convenience method that works with all 2.x versions of Python
@@ -1755,7 +1755,7 @@ class UnicodeDammit:
         """Changes a MS smart quote character to an XML or HTML
         entity."""
         sub = self.MS_CHARS.get(orig)
-        if type(sub) == types.TupleType:
+        if type(sub) == tuple:
             if self.smartQuotesTo == 'xml':
                 sub = '&#x%s;' % sub[1]
             else:


### PR DESCRIPTION
The 'types' module contains a variety of constants to help you determine the type of an object. In Python 3, these constants have been eliminated;just use the primitive type name instead.

The old urllib module in Python 2 had a variety of functions, including urlopen() for fetching data; and splittype(), splithost(), and splituser() forsplitting a URL into its constituent parts. These functions have been reorganized more logically within the new urllib package.
The old urllib2 module in Python 2 has been folded into the urllib package in Python 3. All your urllib2 favorites–the build_opener() method, Request objects, and HTTPBasicAuthHandler and friends–are still available. 

Signed-off-by: Abhishek Kumar <abhishek.kasyap09@gmail.com>