### PR TITLE
setup.py: add two dependencies to make older systems happy; fixes #1463

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,11 @@ setup(
     ],
     python_requires='>=2.7,<3',    
     install_requires=[
+        # Hack to support pip 8 (for those poor sods forced to use ubuntu 16.04's system pip)
+        # See https://github.com/nexB/scancode-toolkit/issues/1463
+        'more_itertools <  6.0.0; python_version == "2.7"',
+        # end hack
+
         # cluecode
         # Some nltk version ranges are buggy
         'nltk >= 3.2, < 4.0',
@@ -140,6 +145,11 @@ setup(
         'extractcode-7z',
 
         # commoncode
+        # Hack to avoid broken backports.os on systems with old configparser
+        # See https://github.com/PiDelport/backports.os/issues/11
+        # and https://github.com/jaraco/configparser/issues/17
+        'configparser >= 0.6.0',
+        # end hack
         'backports.os == 0.1.1',
         'future == 0.16.0',
         'text-unidecode >= 1.0, < 2.0',


### PR DESCRIPTION
Python purists may scratch their heads over this commit, but it should make life easier for people trying to support ubuntu 16.04 and 18.04.

See https://github.com/nexB/scancode-toolkit/issues/1463