### PR TITLE
Use new Python3 syntax for octal #295

### DIFF
--- a/src/commoncode/testcase.py
+++ b/src/commoncode/testcase.py
@@ -295,7 +295,7 @@ def extract_tar(location, target_dir, verbatim=False, *args, **kwargs):
             for tarinfo in tarinfos:
                 if tar_can_extract(tarinfo, verbatim):
                     if not verbatim:
-                        tarinfo.mode = 0700
+                        tarinfo.mode = 0o700
                     to_extract.append(tarinfo)
             tar.extractall(target_dir, members=to_extract)
         finally:
@@ -426,7 +426,7 @@ def make_non_readable(location):
         current_stat = stat.S_IMODE(os.lstat(location).st_mode)
         os.chmod(location, current_stat & ~stat.S_IREAD)
     else:
-        os.chmod(location, 0555)
+        os.chmod(location, 0o555)
 
 
 def make_non_writable(location):


### PR DESCRIPTION
Octal literals must now be specified with a leading "0o" or "0O" instead of "0" .
Reference: http://www.python.org/dev/peps/pep-3127/

Signed-off-by: Abhishek Kumar <abhishek.kasyap09@gmail.com>