### PR TITLE
Use 'zip' and 'map' instead of izip or imap #295

### DIFF
--- a/src/licensedcode/index.py
+++ b/src/licensedcode/index.py
@@ -32,7 +32,15 @@ from collections import Counter
 from collections import defaultdict
 import cPickle
 from functools import partial
-from itertools import izip
+
+# Python 2 and 3 support
+try:
+        # Python 2
+    import itertools.izip as zip
+except ImportError:
+        # Python 3
+        pass
+
 from operator import itemgetter
 import sys
 from time import time
@@ -297,7 +305,7 @@ class LicenseIndex(object):
         # assigned randomly here at first by unzipping: we get the frequencies
         # and tokens->id at once this way
         ########################################################################
-        tokens_by_tid, frequencies_by_tid = izip(*frequencies_by_token.items())
+        tokens_by_tid, frequencies_by_tid = zip(*frequencies_by_token.items())
         self.tokens_by_tid = tokens_by_tid
         self.len_tokens = len_tokens = len(tokens_by_tid)
         msg = 'Cannot support more than licensedcode.index.MAX_TOKENS: %d' % MAX_TOKENS

--- a/src/licensedcode/tokenize.py
+++ b/src/licensedcode/tokenize.py
@@ -28,7 +28,15 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from itertools import islice
-from itertools import izip
+
+# Python 2 and 3 support
+try:
+        # Python 2
+    import itertools.izip as zip
+except ImportError:
+        # Python 3
+        pass
+
 import re
 from zlib import crc32
 
@@ -168,7 +176,7 @@ def ngrams(iterable, ngram_length):
     >>> list(ngrams(tuple([1,2,3,4,5]), 2))
     [(1, 2), (2, 3), (3, 4), (4, 5)]
     """
-    return izip(*(islice(iterable, i, None) for i in range(ngram_length)))
+    return zip(*(islice(iterable, i, None) for i in range(ngram_length)))
 
 
 def select_ngrams(ngrams, with_pos=False):

--- a/src/plugincode/output.py
+++ b/src/plugincode/output.py
@@ -28,7 +28,14 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from functools import partial
-from itertools import imap
+
+# Python 2 and 3 support
+try:
+        # Python 2
+    import itertools.imap as map
+except ImportError:
+        # Python 3
+        pass
 
 from plugincode import CodebasePlugin
 from plugincode import PluginManager
@@ -104,7 +111,7 @@ class OutputPlugin(CodebasePlugin):
 
         strip_root = kwargs.get('strip_root', False)
         resources = codebase.walk_filtered(topdown=True, skip_root=strip_root)
-        return imap(serializer, resources)
+        return map(serializer, resources)
 
 
 output_plugins = PluginManager(

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -36,7 +36,15 @@ import scancode_config
 from collections import defaultdict
 from collections import OrderedDict
 from functools import partial
-from itertools import imap
+
+# Python 2 and 3 support
+try:
+        # Python 2
+    import itertools.imap as map
+except ImportError:
+        # Python 3
+        pass
+
 import os
 import sys
 from time import time
@@ -1120,7 +1128,7 @@ def scan_codebase(codebase, scanners, processes=1, timeout=DEFAULT_TIMEOUT,
             pool.close()
         else:
             # no multiprocessing with processes=0 or -1
-            scans = imap(runner, resources)
+            scans = map(runner, resources)
 
         if progress_manager:
             scans = progress_manager(scans)


### PR DESCRIPTION
Python 2.x introduced the itertools module, which defined variants of the global zip(), map(), and filter() functions that returned iterators instead of lists.In Python 3, those global functions return iterators, so those functions in the itertools module have been eliminated.Therefore we use them as 'map','zip'

Signed-off-by: Abhishek Kumar <abhishek.kasyap09@gmail.com>