### PR TITLE
Use 'maxsize' instead of 'maxint' on Python 3 #295

### DIFF
--- a/src/commoncode/testcase.py
+++ b/src/commoncode/testcase.py
@@ -50,7 +50,7 @@ from commoncode.system import on_windows
 test_run_temp_dir = None
 
 # set to 1 to see the slow tests
-timing_threshold = sys.maxint
+timing_threshold = sys.maxsize
 
 POSIX_PATH_SEP = b'/' if on_linux else '/'
 WIN_PATH_SEP = b'\\' if on_linux else '\\'


### PR DESCRIPTION
The sys.maxint constant was removed, since there is no longer a limit to the value of integers. However, sys.maxsize can be used as an integer larger than any practical list or string index. It conforms to the implementation’s “natural” integer size and is typically the same as sys.maxint in previous releases on the same platform (assuming the same build options).                                                                             
              Reference = http://docs.python.org/3.1/whatsnew/3.0.html#integers

Signed-off-by: Abhishek Kumar <abhishek.kasyap09@gmail.com>