### PR TITLE
Improve Rubygems declared license storage #1480

### DIFF
--- a/src/packagedcode/maven.py
+++ b/src/packagedcode/maven.py
@@ -47,6 +47,7 @@ from commoncode import filetype
 from commoncode import fileutils
 from packagedcode import models
 from packagedcode.models import Package
+from packagedcode.utils import combine_expressions
 from packagedcode.utils import normalize_vcs_url
 from packagedcode.utils import VCS_URLS
 from textcode import analysis
@@ -202,27 +203,16 @@ def compute_normalized_license(declared_license):
                 detections = via_name, via_url, via_comments
                 detections = [l for l in detections if l]
                 if detections:
-                    if len(detections) == 1:
-                        combined_expression = detections[0]
-                    else:
-                        expressions = [
-                            licensing.parse(le, simple=True) for le in detections]
-                        combined_expression = str(licensing.AND(*expressions))
-                    detected_licenses.append(combined_expression)
-
+                    combined_expression =  combine_expressions(detections)
+                    if combined_expression:
+                        detected_licenses.append(combined_expression)
         elif via_url:
             detected_licenses.append(via_url)
         elif via_comments:
             detected_licenses.append(via_comments)
 
-    if len(detected_licenses) == 1:
-        return detected_licenses[0]
-
     if detected_licenses:
-        # Combine if pom contains more than one licenses declarations.
-        expressions = [licensing.parse(le, simple=True) for le in detected_licenses]
-        combined_expression = licensing.AND(*expressions)
-        return str(combined_expression)
+        return combine_expressions(detected_licenses)
 
 
 def build_url(group_id, artifact_id, version, filename, baseurl='http://repo1.maven.org/maven2'):

--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -34,13 +34,13 @@ import logging
 import re
 
 import attr
-from license_expression import Licensing
 from packageurl import PackageURL
 from six import string_types
 
 from commoncode import filetype
 from commoncode import fileutils
 from packagedcode import models
+from packagedcode.utils import combine_expressions
 from packagedcode.utils import parse_repo_url
 
 
@@ -145,25 +145,6 @@ def compute_normalized_license(declared_license):
 
     if detected_licenses:
         return combine_expressions(detected_licenses)
-
-
-def combine_expressions(expressions, licensing=Licensing()):
-    """
-    Return a combined license expression string with AND, given a list of
-    license expressions.
-
-    For example:
-    >>> a = 'mit'
-    >>> b = 'gpl'
-    >>> combine_expressions([a, b])
-    'mit AND gpl'
-    """
-    if not expressions:
-        return
-    if len(expressions) == 1:
-        return expressions[0]
-    expressions = [licensing.parse(le, simple=True) for le in expressions]
-    return str(licensing.AND(*expressions))
 
 
 def npm_homepage_url(namespace, name, registry='https://www.npmjs.com/package'):

--- a/src/packagedcode/rubygems.py
+++ b/src/packagedcode/rubygems.py
@@ -291,9 +291,7 @@ def build_rubygem_package(gem_data, download_url=None, package_url=None):
     descriptions = [d for d in (short_desc, long_desc) if d and d.strip()]
     description = '\n'.join(descriptions)
 
-    # Since the gem spec doc is not clear https://guides.rubygems.org
-    # /specification-reference/#licenseo, we will treat a list of licenses and a
-    # conjunction for now (e.g. AND)
+
     declared_licenses = []
     licenses = gem_data.get('licenses') or []
     for lic in licenses:
@@ -306,6 +304,7 @@ def build_rubygem_package(gem_data, download_url=None, package_url=None):
 
     declared_license = '\n'.join(declared_licenses) or None
 
+
     package = RubyGem(
         name=name,
         description=description,
@@ -313,6 +312,13 @@ def build_rubygem_package(gem_data, download_url=None, package_url=None):
         download_url=download_url,
         declared_license=declared_license,
     )
+
+    # Since the gem spec doc is not clear https://guides.rubygems.org
+    # /specification-reference/#licenseo, we will treat a list of licenses and a
+    # conjunction for now (e.g. AND)
+    license = gem_data.get('license')
+    licenses = gem_data.get('licenses')
+    package = licenses_mapper(license, licenses, package)
 
     # we can have one singular or a plural list of authors
     authors = gem_data.get('authors') or []
@@ -382,6 +388,22 @@ def build_rubygem_package(gem_data, download_url=None, package_url=None):
     if not package.homepage_url:
         package.homepage_url = package.repository_homepage_url()
 
+    return package
+
+
+def licenses_mapper(license, licenses, package):
+    """
+    Update package licensing and return package based on the `license` and
+    `licenses` values found in a package.
+    """
+    declared_licenses = []
+    if license:
+        declared_licenses.append(str(license).strip())
+    if licenses:
+        for lic in licenses:
+            if lic and lic.strip():
+                declared_licenses.append(lic.strip())
+    package.declared_license = declared_licenses
     return package
 
 

--- a/src/packagedcode/rubygems.py
+++ b/src/packagedcode/rubygems.py
@@ -40,6 +40,7 @@ from commoncode import fileutils
 from extractcode import archive
 from extractcode.uncompress import get_gz_compressed_file_content
 from packagedcode import models
+from packagedcode.utils import combine_expressions
 
 
 # TODO: check:
@@ -99,25 +100,7 @@ class RubyGem(models.Package):
         return manifest_resource
 
     def compute_normalized_license(self):
-        # TODO: there is a mapping of well known licenses to reuse too
-
-        if not self.declared_license or not self.declared_license.strip():
-            return
-
-        # scancode convention is to put one license per line when there are
-        # multiple licenses as a list in the manifest.
-        lines = [l for l in self.declared_license.splitlines(False) if l and l.strip()]
-        if not lines:
-            return
-
-        # we default to and AND as the Gem spec is rather vague on what it means
-        # to have a list of licenses. Note that we do not use the
-        # license_expression library for this, as each license may not be
-        # parsable at all: instead we do this at the string level
-        if len(lines) > 1:
-            lines = ['({})'.format(l) for l in lines]
-        licenses = ' AND '.join(lines)
-        return models.compute_normalized_license(licenses)
+        return compute_normalized_license(self.declared_license)
 
     @classmethod
     def recognize(cls, location):
@@ -165,6 +148,30 @@ class RubyGem(models.Package):
     @classmethod
     def extra_root_dirs(cls):
         return ['data.tar.gz-extract']
+
+
+
+def compute_normalized_license(declared_license):
+    """
+    Return a normalized license expression string detected from a list of
+    declared license items.
+    """
+    if not declared_license:
+        return
+
+    detected_licenses = []
+
+    for declared in declared_license:
+        #TODO:  scancode convention is to put one license per line when there are
+        # multiple licenses as a list in the manifest.
+        # lines = [l for l in self.declared_license.splitlines(False) if l and l.strip()]
+        if declared:
+            detected_license = models.compute_normalized_license(declared)
+            if detected_license:
+                detected_licenses.append(detected_license)
+
+    if detected_licenses:
+        return combine_expressions(detected_licenses)
 
 
 def rubygems_homepage_url(name, version, repo='https://rubygems.org/gems'):

--- a/src/packagedcode/rubygems.py
+++ b/src/packagedcode/rubygems.py
@@ -162,12 +162,9 @@ def compute_normalized_license(declared_license):
     detected_licenses = []
 
     for declared in declared_license:
-        #TODO:  scancode convention is to put one license per line when there are
-        # multiple licenses as a list in the manifest.
-        if declared:
-            detected_license = models.compute_normalized_license(declared)
-            if detected_license:
-                detected_licenses.append(detected_license)
+        detected_license = models.compute_normalized_license(declared)
+        if detected_license:
+            detected_licenses.append(detected_license)
 
     if detected_licenses:
         return combine_expressions(detected_licenses)

--- a/src/packagedcode/utils.py
+++ b/src/packagedcode/utils.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from license_expression import Licensing
 from six import string_types
 
 
@@ -146,3 +147,22 @@ def build_description(summary, description):
             description = '\n'.join([summary , description])
 
     return description
+
+def combine_expressions(expressions, licensing=Licensing()):
+    """
+    Return a combined license expression string with AND, given a list of
+    license expressions.
+
+    For example:
+    >>> a = 'mit'
+    >>> b = 'gpl'
+    >>> combine_expressions([a, b])
+    'mit AND gpl'
+    """
+    if not expressions:
+        return
+    if len(expressions) == 1:
+        return expressions[0]
+    expressions = [licensing.parse(le, simple=True) for le in expressions]
+    return str(licensing.AND(*expressions))
+

--- a/tests/packagedcode/data/rubygems/gem/a_okay-0.1.0.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/a_okay-0.1.0.gem.json
@@ -31,7 +31,7 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": null, 
+    "declared_license": [], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [], 

--- a/tests/packagedcode/data/rubygems/gem/action_tracker-1.0.2.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/action_tracker-1.0.2.gem.json
@@ -37,7 +37,7 @@
     "code_view_url": null, 
     "vcs_url": null, 
     "copyright": null, 
-    "license_expression": null, 
+    "license_expression": "mit", 
     "declared_license": [
       "MIT"
     ], 

--- a/tests/packagedcode/data/rubygems/gem/action_tracker-1.0.2.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/action_tracker-1.0.2.gem.json
@@ -38,7 +38,9 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": "MIT", 
+    "declared_license": [
+      "MIT"
+    ], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [

--- a/tests/packagedcode/data/rubygems/gem/archive-tar-minitar-0.5.2.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/archive-tar-minitar-0.5.2.gem.json
@@ -31,7 +31,7 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": null, 
+    "declared_license": [], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [], 

--- a/tests/packagedcode/data/rubygems/gem/blankslate-3.1.3.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/blankslate-3.1.3.gem.json
@@ -45,7 +45,7 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": null, 
+    "declared_license": [], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [

--- a/tests/packagedcode/data/rubygems/gem/m2r-2.1.0.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/m2r-2.1.0.gem.json
@@ -51,7 +51,7 @@
     "code_view_url": null, 
     "vcs_url": null, 
     "copyright": null, 
-    "license_expression": null, 
+    "license_expression": "mit", 
     "declared_license": [
       "MIT"
     ], 

--- a/tests/packagedcode/data/rubygems/gem/m2r-2.1.0.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/m2r-2.1.0.gem.json
@@ -52,7 +52,9 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": "MIT", 
+    "declared_license": [
+      "MIT"
+    ], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [

--- a/tests/packagedcode/data/rubygems/gem/mysmallidea-address_standardization-0.4.1.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/mysmallidea-address_standardization-0.4.1.gem.json
@@ -31,7 +31,7 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": null, 
+    "declared_license": [], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [

--- a/tests/packagedcode/data/rubygems/gem/mysmallidea-mad_mimi_mailer-0.0.9.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/mysmallidea-mad_mimi_mailer-0.0.9.gem.json
@@ -31,7 +31,7 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": null, 
+    "declared_license": [], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [], 

--- a/tests/packagedcode/data/rubygems/gem/new/dependabot-omnibus-0.87.15.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/new/dependabot-omnibus-0.87.15.gem.json
@@ -31,7 +31,9 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": "Nonstandard", 
+    "declared_license": [
+      "Nonstandard"
+    ], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [

--- a/tests/packagedcode/data/rubygems/gem/new/dependabot-omnibus-0.87.15.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/new/dependabot-omnibus-0.87.15.gem.json
@@ -30,7 +30,7 @@
     "code_view_url": null, 
     "vcs_url": null, 
     "copyright": null, 
-    "license_expression": null, 
+    "license_expression": "unknown", 
     "declared_license": [
       "Nonstandard"
     ], 

--- a/tests/packagedcode/data/rubygems/gem/new/hiredis-0.6.3-java.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/new/hiredis-0.6.3-java.gem.json
@@ -30,7 +30,7 @@
     "code_view_url": null, 
     "vcs_url": null, 
     "copyright": null, 
-    "license_expression": null, 
+    "license_expression": "bsd-new", 
     "declared_license": [
       "BSD-3-Clause"
     ], 

--- a/tests/packagedcode/data/rubygems/gem/new/hiredis-0.6.3-java.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/new/hiredis-0.6.3-java.gem.json
@@ -31,7 +31,9 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": "BSD-3-Clause", 
+    "declared_license": [
+      "BSD-3-Clause"
+    ], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [

--- a/tests/packagedcode/data/rubygems/gem/new/int_time-0.0.2.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/new/int_time-0.0.2.gem.json
@@ -30,7 +30,7 @@
     "code_view_url": null, 
     "vcs_url": null, 
     "copyright": null, 
-    "license_expression": null, 
+    "license_expression": "mit", 
     "declared_license": [
       "MIT"
     ], 

--- a/tests/packagedcode/data/rubygems/gem/new/int_time-0.0.2.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/new/int_time-0.0.2.gem.json
@@ -31,7 +31,9 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": "MIT", 
+    "declared_license": [
+      "MIT"
+    ], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [], 

--- a/tests/packagedcode/data/rubygems/gem/new/jaro_winkler-1.5.1-java.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/new/jaro_winkler-1.5.1-java.gem.json
@@ -30,7 +30,7 @@
     "code_view_url": null, 
     "vcs_url": null, 
     "copyright": null, 
-    "license_expression": null, 
+    "license_expression": "mit", 
     "declared_license": [
       "MIT"
     ], 

--- a/tests/packagedcode/data/rubygems/gem/new/jaro_winkler-1.5.1-java.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/new/jaro_winkler-1.5.1-java.gem.json
@@ -31,7 +31,9 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": "MIT", 
+    "declared_license": [
+      "MIT"
+    ], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [

--- a/tests/packagedcode/data/rubygems/gem/new/rubocop-0.62.0.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/new/rubocop-0.62.0.gem.json
@@ -45,7 +45,9 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": "MIT", 
+    "declared_license": [
+      "MIT"
+    ], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [

--- a/tests/packagedcode/data/rubygems/gem/new/rubocop-0.62.0.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/new/rubocop-0.62.0.gem.json
@@ -44,7 +44,7 @@
     "code_view_url": "https://github.com/rubocop-hq/rubocop/", 
     "vcs_url": null, 
     "copyright": null, 
-    "license_expression": null, 
+    "license_expression": "mit", 
     "declared_license": [
       "MIT"
     ], 

--- a/tests/packagedcode/data/rubygems/gem/ng-rails-csrf-0.1.0.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/ng-rails-csrf-0.1.0.gem.json
@@ -31,7 +31,7 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": null, 
+    "declared_license": [], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [], 

--- a/tests/packagedcode/data/rubygems/gem/small-0.2.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/small-0.2.gem.json
@@ -31,7 +31,7 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": null, 
+    "declared_license": [], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [], 

--- a/tests/packagedcode/data/rubygems/gem/small_wonder-0.1.10.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/small_wonder-0.1.10.gem.json
@@ -31,7 +31,7 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": null, 
+    "declared_license": [], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [

--- a/tests/packagedcode/data/rubygems/gem/sprockets-vendor_gems-0.1.3.gem.json
+++ b/tests/packagedcode/data/rubygems/gem/sprockets-vendor_gems-0.1.3.gem.json
@@ -31,7 +31,7 @@
     "vcs_url": null, 
     "copyright": null, 
     "license_expression": null, 
-    "declared_license": null, 
+    "declared_license": [], 
     "notice_text": null, 
     "manifest_path": null, 
     "dependencies": [

--- a/tests/packagedcode/test_rubygems.py
+++ b/tests/packagedcode/test_rubygems.py
@@ -122,7 +122,9 @@ def create_test_function(test_loc, test_name, regen=False):
     def check_rubygem(self):
         loc = self.get_test_loc(test_loc)
         expected_json_loc = loc + '.json'
-        package = [rubygems.get_gem_package(location=loc).to_dict()]
+        package = rubygems.get_gem_package(location=loc)
+        package.license_expression = package.compute_normalized_license()
+        package = [package.to_dict()]
         if regen:
             with open(expected_json_loc, 'wb') as ex:
                 json.dump(package, ex, indent=2)


### PR DESCRIPTION
See #1480 
Store the declared license as a list of strings and compute a license expression from these.