### PR TITLE
Avoid explicitly specifying str type as Unicode #295

### DIFF
--- a/src/cluecode/finder_data.py
+++ b/src/cluecode/finder_data.py
@@ -31,7 +31,7 @@ def set_from_text(text):
     return set(u.lower().strip('/') for u in text.split())
 
 
-JUNK_EMAILS = set_from_text(u'''
+JUNK_HOSTS_AND_DOMAINS = set_from_text('''
     test@test.com
     exmaple.com
     example.com
@@ -42,7 +42,7 @@ JUNK_EMAILS = set_from_text(u'''
 ''')
 
 
-JUNK_HOSTS_AND_DOMAINS = set_from_text(u'''
+JUNK_HOSTS_AND_DOMAINS = set_from_text('''
     exmaple.com
     example.com
     example.net
@@ -57,11 +57,11 @@ JUNK_HOSTS_AND_DOMAINS = set_from_text(u'''
     localhost
 ''')
 
-JUNK_IPS = set_from_text(u'''
+JUNK_IPS = set_from_text('''
     1.2.3.4
 ''')
 
-JUNK_URLS = set_from_text(u'''
+JUNK_URLS = set_from_text('''
     http://www.adobe.com/2006/mxml
     http://www.w3.org/1999/XSL/Transform
     http://docs.oasis-open.org/ns/xri/xrd-1.0

--- a/src/cluecode/plugin_ignore_copyrights.py
+++ b/src/cluecode/plugin_ignore_copyrights.py
@@ -50,7 +50,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        logger.debug(' '.join(isinstance(a, (unicode, str)) and a or repr(a) for a in args))
+        logger.debug(' '.join(isinstance(a, str) and a or repr(a) for a in args))
 
 
 @output_filter_impl


### PR DESCRIPTION
In Python 3.x implicit **str** type is **Unicode**.
Signing off : Shivam Chauhan <chauhanshivam999@gmail.com>