### PR TITLE
Use proper str or unicode for path sep on Python 3 #295

### DIFF
--- a/src/commoncode/fileutils.py
+++ b/src/commoncode/fileutils.py
@@ -59,6 +59,7 @@ except ImportError:
 from commoncode import filetype
 from commoncode.filetype import is_rwx
 from commoncode.system import on_linux
+from commoncode.system import py2
 
 # this exception is not available on posix
 try:
@@ -91,8 +92,10 @@ WIN_PATH_SEP = b'\\' if on_linux else '\\'
 ALL_SEPS = POSIX_PATH_SEP + WIN_PATH_SEP
 EMPTY_STRING = b'' if on_linux else ''
 DOT = b'.' if on_linux else '.'
+if py2:
 PATH_SEP = bytes(os.sep) if on_linux else unicode(os.sep)
-
+else:
+PATH_SEP = bytes(os.sep, encoding='utf-8') if on_linux else unicode(os.sep)
 
 """
 File, paths and directory utility functions.

--- a/src/commoncode/testcase.py
+++ b/src/commoncode/testcase.py
@@ -50,7 +50,7 @@ from commoncode.system import on_windows
 test_run_temp_dir = None
 
 # set to 1 to see the slow tests
-timing_threshold = sys.maxint
+timing_threshold = sys.maxsize
 
 POSIX_PATH_SEP = b'/' if on_linux else '/'
 WIN_PATH_SEP = b'\\' if on_linux else '\\'

--- a/tests/cluecode/data/ics/chromium-net-tools-testserver/chromiumsync.py
+++ b/tests/cluecode/data/ics/chromium-net-tools-testserver/chromiumsync.py
@@ -6,4 +6,4 @@
     # to its nickname.
     self.clients = {}
     self.client_name_generator = ('+' * times + chr(c)
-        for times in xrange(0, sys.maxint) for c in xrange(ord('A'),ord('Z')))
+        for times in xrange(0, sys.maxsize) for c in xrange(ord('A'),ord('Z')))


### PR DESCRIPTION
Python2 and Python3 behave quite differently there.Eventually we will be able to use unicode throughout when working fully on Python3. But until then, we are left with using the os.fsencode and fs.decode backports and dealing only with bytes on Linux and unicode elsewhere.

Signed-off-by: Abhishek Kumar <abhishek.kasyap09@gmail.com>