### PR TITLE
Parse bower.json during Package scans

### DIFF
--- a/src/packagedcode/__init__.py
+++ b/src/packagedcode/__init__.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from packagedcode import models
+from packagedcode import bower
 from packagedcode import cargo
 from packagedcode import freebsd
 from packagedcode import haxe
@@ -57,7 +58,7 @@ PACKAGE_TYPES = [
     haxe.HaxePackage,
     cargo.RustCargoCrate,
     models.MeteorPackage,
-    models.BowerPackage,
+    bower.BowerPackage,
     freebsd.FreeBSDPackage,
     models.CpanModule,
     rubygems.RubyGem,

--- a/src/packagedcode/bower.py
+++ b/src/packagedcode/bower.py
@@ -27,21 +27,16 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from collections import OrderedDict
-from functools import partial
 import io
 import json
 import logging
-import re
 
 import attr
 from packageurl import PackageURL
-from six import string_types
 
 from commoncode import filetype
 from commoncode import fileutils
 from packagedcode import models
-from packagedcode.utils import combine_expressions
-from packagedcode.utils import parse_repo_url
 
 
 TRACE = False
@@ -155,3 +150,4 @@ def build_package(package_data):
         vcs_url=vcs_url,
         dependencies=dependencies
     )
+

--- a/src/packagedcode/bower.py
+++ b/src/packagedcode/bower.py
@@ -1,0 +1,164 @@
+
+# Copyright (c) 2019 nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/scancode-toolkit/
+# The ScanCode software is licensed under the Apache License version 2.0.
+# Data generated with ScanCode require an acknowledgment.
+# ScanCode is a trademark of nexB Inc.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with ScanCode or any ScanCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No package_data created from
+#  ScanCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  ScanCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/scancode-toolkit/ for support and download.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from collections import OrderedDict
+from functools import partial
+import io
+import json
+import logging
+import re
+
+import attr
+from packageurl import PackageURL
+from six import string_types
+
+from commoncode import filetype
+from commoncode import fileutils
+from packagedcode import models
+from packagedcode.utils import combine_expressions
+from packagedcode.utils import parse_repo_url
+
+
+TRACE = False
+
+logger = logging.getLogger(__name__)
+
+if TRACE:
+    import sys
+    logging.basicConfig(stream=sys.stdout)
+    logger.setLevel(logging.DEBUG)
+
+
+@attr.s()
+class BowerPackage(models.Package):
+    metafiles = ('bower.json', '.bower.json')
+    default_type = 'bower'
+
+    @classmethod
+    def recognize(cls, location):
+        return parse(location)
+
+
+def is_bower_json(location):
+    return (filetype.is_file(location)
+            and (fileutils.file_name(location).lower() == 'bower.json'
+            or fileutils.file_name(location).lower() == '.bower.json'))
+
+
+def parse(location):
+    """
+    Return a Package object from a package.json file or None.
+    """
+    if not is_bower_json(location):
+        return
+
+    with io.open(location, encoding='utf-8') as loc:
+        package_data = json.load(loc, object_pairs_hook=OrderedDict)
+
+    return build_package(package_data)
+
+
+def get_vcs_repo(content):
+    """
+    Return the repo type and url.
+    """
+    repo = content.get('repository', {})
+    if repo:
+        return repo.get('type'), repo.get('url')
+    return None, None
+
+
+def build_packages_from_jsonfile(package_data, uri=None, purl=None):
+    """
+    Yield Package built from Bower json package_data
+    """
+    licenses_content = package_data.get('license')
+    declared_licenses = set([])
+    if licenses_content:
+        if isinstance(licenses_content, list):
+            for lic in licenses_content:
+                declared_licenses.add(lic)
+        else:
+            declared_licenses.add(licenses_content)
+
+    keywords_content = package_data.get('keywords', [])
+    name = package_data.get('name')
+
+    devdependencies = package_data.get('devDependencies')
+    dev_dependencies = []
+    if devdependencies:
+        for key, value in devdependencies.items():
+            dev_dependencies.append(
+                models.DependentPackage(purl=key, requirement=value, scope='devdependency')
+            )
+
+    dependencies = package_data.get('dependencies')
+    dependencies_build = []
+    if dependencies:
+        for key, value in dependencies.items():
+            dependencies_build.append(
+                models.DependentPackage(purl=key, requirement=value, scope='runtime')
+            )
+
+    if name:
+        vcs_tool, vcs_repo = get_vcs_repo(package_data)
+        if vcs_tool and vcs_repo:
+            # Form the vsc_url by
+            # https://spdx.org/spdx-specification-21-web-version#h.49x2ik5
+            vcs_repo = vcs_tool + '+' + vcs_repo
+        common_data = dict(
+            type='bower',
+            name=name,
+            description=package_data.get('description'),
+            version=package_data.get('version'),
+            vcs_url=vcs_repo,
+            keywords=keywords_content,
+            homepage_url=package_data.get('homepage'),
+        )
+
+        if declared_licenses:
+            common_data['declared_license'] = '\n'.join(declared_licenses)
+
+        author_content = package_data.get('authors', [])
+        if author_content:
+            parties = common_data.get('parties')
+            if not parties:
+                common_data['parties'] = []
+            for author in author_content:
+                common_data['parties'].append(models.Party(name=author, role='author',))
+
+        dependencies = []
+        if dependencies_build:
+            dependencies.extend(dependencies_build)
+        if dev_dependencies:
+            dependencies.extend(dev_dependencies)
+        if len(dependencies) > 0:
+            common_data['dependencies'] = dependencies
+        package = BowerPackage(**common_data)
+        package.set_purl(purl)
+        yield package

--- a/src/packagedcode/bower.py
+++ b/src/packagedcode/bower.py
@@ -93,6 +93,7 @@ def build_package(package_data):
 
     description = package_data.get('description')
     version = package_data.get('version')
+    license = package_data.get('license')
     keywords = package_data.get('keywords', [])
 
     authors = package_data.get('authors', [])
@@ -147,6 +148,7 @@ def build_package(package_data):
         name=name,
         description=description,
         version=version,
+        declared_license=license,
         keywords=keywords,
         parties=parties,
         homepage_url=homepage_url,

--- a/tests/packagedcode/data/bower/author-objects/bower.json
+++ b/tests/packagedcode/data/bower/author-objects/bower.json
@@ -1,0 +1,46 @@
+{
+  "name": "blue-leaf",
+  "description": "Physics-like animations for pretty particles",
+  "main": [
+    "js/motion.js",
+    "sass/motion.scss"
+  ],
+  "dependencies": {
+    "get-size": "~1.2.2",
+    "eventEmitter": "~4.2.11"
+  },
+  "devDependencies": {
+    "qunit": "~1.16.0"
+  },
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "motion",
+    "physics",
+    "particles"
+  ],
+  "authors": [
+    "Betty Beta <bbeta@example.com>",
+    {
+      "name": "John Doe",
+      "email": "john@doe.com",
+      "homepage": "http://johndoe.com"
+    }
+  ],
+  "license": [
+    "MIT",
+    "Apache 2.0",
+    "BSD-3-Clause"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "private": true
+}

--- a/tests/packagedcode/data/bower/author-objects/expected.json
+++ b/tests/packagedcode/data/bower/author-objects/expected.json
@@ -1,0 +1,83 @@
+{
+  "type": "bower",
+  "namespace": null,
+  "name": "John Doe",
+  "version": null,
+  "qualifiers": null,
+  "subpath": null,
+  "primary_language": null,
+  "description": "Physics-like animations for pretty particles",
+  "release_date": null,
+  "parties": [
+    {
+      "type": null,
+      "role": "author",
+      "name": "Betty Beta <bbeta@example.com>",
+      "email": null,
+      "url": null
+    },
+    {
+      "type": null,
+      "role": "author",
+      "name": "John Doe",
+      "email": "john@doe.com",
+      "url": "http://johndoe.com"
+    }
+  ],
+  "keywords": [
+    "motion",
+    "physics",
+    "particles"
+  ],
+  "homepage_url": null,
+  "download_url": null,
+  "size": null,
+  "sha1": null,
+  "md5": null,
+  "sha256": null,
+  "sha512": null,
+  "bug_tracking_url": null,
+  "code_view_url": null,
+  "vcs_url": null,
+  "copyright": null,
+  "license_expression": "mit AND apache-2.0 AND bsd-new",
+  "declared_license": [
+    "MIT",
+    "Apache 2.0",
+    "BSD-3-Clause"
+  ],
+  "notice_text": null,
+  "manifest_path": null,
+  "dependencies": [
+    {
+      "purl": "pkg:bower/get-size",
+      "requirement": "~1.2.2",
+      "scope": "dependencies",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_resolved": false
+    },
+    {
+      "purl": "pkg:bower/eventEmitter",
+      "requirement": "~4.2.11",
+      "scope": "dependencies",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_resolved": false
+    },
+    {
+      "purl": "pkg:bower/qunit",
+      "requirement": "~1.16.0",
+      "scope": "devDependencies",
+      "is_runtime": false,
+      "is_optional": true,
+      "is_resolved": false
+    }
+  ],
+  "contains_source_code": null,
+  "source_packages": [],
+  "purl": "pkg:bower/John%20Doe",
+  "repository_homepage_url": null,
+  "repository_download_url": null,
+  "api_data_url": null
+}

--- a/tests/packagedcode/data/bower/basic/bower.json
+++ b/tests/packagedcode/data/bower/basic/bower.json
@@ -1,0 +1,37 @@
+{
+  "name": "blue-leaf",
+  "description": "Physics-like animations for pretty particles",
+  "main": [
+    "js/motion.js",
+    "sass/motion.scss"
+  ],
+  "dependencies": {
+    "get-size": "~1.2.2",
+    "eventEmitter": "~4.2.11"
+  },
+  "devDependencies": {
+    "qunit": "~1.16.0"
+  },
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "motion",
+    "physics",
+    "particles"
+  ],
+  "authors": [
+    "Betty Beta <bbeta@example.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "private": true
+}

--- a/tests/packagedcode/data/bower/basic/expected.json
+++ b/tests/packagedcode/data/bower/basic/expected.json
@@ -1,0 +1,74 @@
+{
+  "type": "bower",
+  "namespace": null,
+  "name": "blue-leaf",
+  "version": null,
+  "qualifiers": null,
+  "subpath": null,
+  "primary_language": null,
+  "description": "Physics-like animations for pretty particles",
+  "release_date": null,
+  "parties": [
+    {
+      "type": null,
+      "role": "author",
+      "name": "Betty Beta <bbeta@example.com>",
+      "email": null,
+      "url": null
+    }
+  ],
+  "keywords": [
+    "motion",
+    "physics",
+    "particles"
+  ],
+  "homepage_url": null,
+  "download_url": null,
+  "size": null,
+  "sha1": null,
+  "md5": null,
+  "sha256": null,
+  "sha512": null,
+  "bug_tracking_url": null,
+  "code_view_url": null,
+  "vcs_url": null,
+  "copyright": null,
+  "license_expression": "mit",
+  "declared_license": [
+    "MIT"
+  ],
+  "notice_text": null,
+  "manifest_path": null,
+  "dependencies": [
+    {
+      "purl": "pkg:bower/get-size",
+      "requirement": "~1.2.2",
+      "scope": "dependencies",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_resolved": false
+    },
+    {
+      "purl": "pkg:bower/eventEmitter",
+      "requirement": "~4.2.11",
+      "scope": "dependencies",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_resolved": false
+    },
+    {
+      "purl": "pkg:bower/qunit",
+      "requirement": "~1.16.0",
+      "scope": "devDependencies",
+      "is_runtime": false,
+      "is_optional": true,
+      "is_resolved": false
+    }
+  ],
+  "contains_source_code": null,
+  "source_packages": [],
+  "purl": "pkg:bower/blue-leaf",
+  "repository_homepage_url": null,
+  "repository_download_url": null,
+  "api_data_url": null
+}

--- a/tests/packagedcode/data/bower/list-of-licenses/bower.json
+++ b/tests/packagedcode/data/bower/list-of-licenses/bower.json
@@ -1,0 +1,41 @@
+{
+  "name": "blue-leaf",
+  "description": "Physics-like animations for pretty particles",
+  "main": [
+    "js/motion.js",
+    "sass/motion.scss"
+  ],
+  "dependencies": {
+    "get-size": "~1.2.2",
+    "eventEmitter": "~4.2.11"
+  },
+  "devDependencies": {
+    "qunit": "~1.16.0"
+  },
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "motion",
+    "physics",
+    "particles"
+  ],
+  "authors": [
+    "Betty Beta <bbeta@example.com>"
+  ],
+  "license": [
+    "MIT",
+    "Apache 2.0",
+    "BSD-3-Clause"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "private": true
+}

--- a/tests/packagedcode/data/bower/list-of-licenses/expected.json
+++ b/tests/packagedcode/data/bower/list-of-licenses/expected.json
@@ -1,0 +1,76 @@
+{
+  "type": "bower",
+  "namespace": null,
+  "name": "blue-leaf",
+  "version": null,
+  "qualifiers": null,
+  "subpath": null,
+  "primary_language": null,
+  "description": "Physics-like animations for pretty particles",
+  "release_date": null,
+  "parties": [
+    {
+      "type": null,
+      "role": "author",
+      "name": "Betty Beta <bbeta@example.com>",
+      "email": null,
+      "url": null
+    }
+  ],
+  "keywords": [
+    "motion",
+    "physics",
+    "particles"
+  ],
+  "homepage_url": null,
+  "download_url": null,
+  "size": null,
+  "sha1": null,
+  "md5": null,
+  "sha256": null,
+  "sha512": null,
+  "bug_tracking_url": null,
+  "code_view_url": null,
+  "vcs_url": null,
+  "copyright": null,
+  "license_expression": "mit AND apache-2.0 AND bsd-new",
+  "declared_license": [
+    "MIT",
+    "Apache 2.0",
+    "BSD-3-Clause"
+  ],
+  "notice_text": null,
+  "manifest_path": null,
+  "dependencies": [
+    {
+      "purl": "pkg:bower/get-size",
+      "requirement": "~1.2.2",
+      "scope": "dependencies",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_resolved": false
+    },
+    {
+      "purl": "pkg:bower/eventEmitter",
+      "requirement": "~4.2.11",
+      "scope": "dependencies",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_resolved": false
+    },
+    {
+      "purl": "pkg:bower/qunit",
+      "requirement": "~1.16.0",
+      "scope": "devDependencies",
+      "is_runtime": false,
+      "is_optional": true,
+      "is_resolved": false
+    }
+  ],
+  "contains_source_code": null,
+  "source_packages": [],
+  "purl": "pkg:bower/blue-leaf",
+  "repository_homepage_url": null,
+  "repository_download_url": null,
+  "api_data_url": null
+}

--- a/tests/packagedcode/test_bower.py
+++ b/tests/packagedcode/test_bower.py
@@ -42,8 +42,14 @@ class TestBower(PackageTester):
         expected_loc = self.get_test_loc('bower/basic/expected.json')
         self.check_package(package, expected_loc, regen=False)
 
-    def test_parse_bower_json_basic_list_of_licenses(self):
+    def test_parse_bower_json_list_of_licenses(self):
         test_file = self.get_test_loc('bower/list-of-licenses/bower.json')
         package = bower.parse(test_file)
         expected_loc = self.get_test_loc('bower/list-of-licenses/expected.json')
+        self.check_package(package, expected_loc, regen=False)
+
+    def test_parse_bower_json_author_objects(self):
+        test_file = self.get_test_loc('bower/author-objects/bower.json')
+        package = bower.parse(test_file)
+        expected_loc = self.get_test_loc('bower/author-objects/expected.json')
         self.check_package(package, expected_loc, regen=False)

--- a/tests/packagedcode/test_bower.py
+++ b/tests/packagedcode/test_bower.py
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2019 nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/scancode-toolkit/
+# The ScanCode software is licensed under the Apache License version 2.0.
+# Data generated with ScanCode require an acknowledgment.
+# ScanCode is a trademark of nexB Inc.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with ScanCode or any ScanCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  ScanCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  ScanCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/scancode-toolkit/ for support and download.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os.path
+
+from packagedcode import bower
+
+from packages_test_utils import PackageTester
+
+
+class TestBower(PackageTester):
+    test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
+
+    def test_parse_bower_json_basic(self):
+        test_file = self.get_test_loc('bower/basic/bower.json')
+        package = bower.parse(test_file)
+        expected_loc = self.get_test_loc('bower/basic/expected.json')
+        self.check_package(package, expected_loc, regen=False)

--- a/tests/packagedcode/test_bower.py
+++ b/tests/packagedcode/test_bower.py
@@ -41,3 +41,9 @@ class TestBower(PackageTester):
         package = bower.parse(test_file)
         expected_loc = self.get_test_loc('bower/basic/expected.json')
         self.check_package(package, expected_loc, regen=False)
+
+    def test_parse_bower_json_basic_list_of_licenses(self):
+        test_file = self.get_test_loc('bower/list-of-licenses/bower.json')
+        package = bower.parse(test_file)
+        expected_loc = self.get_test_loc('bower/list-of-licenses/expected.json')
+        self.check_package(package, expected_loc, regen=False)


### PR DESCRIPTION
This is a new parser for bower.json files for Package scans based on the bower.json spec (https://github.com/bower/spec/blob/master/json.md) 

I've added some basic tests to ensure that the different type variation in the `license` and `authors` fiends are handled.

This handles #1491 and #1505 