### PR TITLE
Converted Paths to String Literals.

### DIFF
--- a/configure
+++ b/configure
@@ -23,5 +23,5 @@ CONFIGURE_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 python2.7 "$CONFIGURE_ROOT_DIR/etc/configure.py" $CFG_CMD_LINE_ARGS
 if [ -f "$CONFIGURE_ROOT_DIR/bin/activate" ]; then
-    source $CONFIGURE_ROOT_DIR/bin/activate
+    source "$CONFIGURE_ROOT_DIR/bin/activate"
 fi

--- a/etc/configure.py
+++ b/etc/configure.py
@@ -251,7 +251,7 @@ def run_scripts(configs, root_dir, configured_python, quiet=False):
         print("* Configuring ...")
     # Run Python scripts for each configurations
     for py_script in get_conf_files(configs, root_dir, python_scripts):
-        cmd = [configured_python, '"' + os.path.join(root_dir, py_script) + '"']
+        cmd = ['"' + configured_python + '"', '"' + os.path.join(root_dir, py_script) + '"']
         call(cmd, root_dir)
 
     # Run sh_script scripts for each configurations


### PR DESCRIPTION
- Closes #1511 

- Converted the whole path to String Literal to avoid Problems with spaces.
https://github.com/nexB/scancode-toolkit/blob/794d7acf78480823084def703b5d61ade12efdf2/configure#L26
- Added quotes around `configured_python` for the same reason.
https://github.com/nexB/scancode-toolkit/blob/794d7acf78480823084def703b5d61ade12efdf2/etc/configure.py#L254

This successfully completes all the configurations.  
  
Signed-off-by: Vibhu Agarwal <vibhu4agarwal@gmail.com>