### PR TITLE
Added the Zurich license proprietary rule

### DIFF
--- a/src/licensedcode/data/rules/zi-labone-proprietary.RULE
+++ b/src/licensedcode/data/rules/zi-labone-proprietary.RULE
@@ -1,0 +1,69 @@
+SOFTWARE LICENSE AGREEMENT
+
+This is a legal agreement ("Agreement") between you, the end user
+("User"), and Zurich Instruments ("ZI"), Zurich, Switzerland. By
+installing this software ("Software") you are agreeing to be bound by
+the terms of this agreement. If you do not agree to the terms of this
+agreement, immediately stop with the installation of this software on
+your computer.
+
+1. LICENSE GRANT. Zurich Instruments grants you a non-exclusive
+license to install and use the executable code of this Software. The
+intended use of this Software is in combination with an HF2, UHF or MF
+Series Instrument from Zurich Instruments. The use of this Software
+together with a different instrumentation is not covered by this
+grant. This Agreement will also govern any software upgrades provided
+by Zurich Instruments that replace and/or supplement the original
+Software, unless such upgrades are accompanied by a separate license,
+in which case the terms of that license will govern. The Software is
+licensed, not sold.
+
+2. RESTRICTIONS. The User shall not modify, alter, distribute, rent,
+lease, reverse-engineer, reverse-compile, license or sublicense, or
+re-sale the Software or any portions of it.
+
+3. TERMINATION. The license is effective until terminated. You may
+terminate it at any other time by deleting (de-installing) the
+Software and the related documentation from your computer. It will
+also terminate upon conditions set forth elsewhere in this Agreement
+or if you fail to comply with any term or condition of this Agreement.
+You agree upon such termination to delete the Software together with
+the related documentation.
+
+4. PROPRIETARY RIGHTS. This Product is owned by Zurich Instruments and
+is protected by Switzerland Laws and International Treaty provisions.
+Therefore, you must treat the software like any other copyrighted
+material (e.g. a book or musical recording) EXCEPT that you may make
+copies and install the software on any computer belonging to the same
+company, institution, or governement agency ("multiple-user license
+grant").
+
+5. LIMITED WARRANTY. The Software is provided by Zurich Instruments
+"as is". ZI warrants that the Software will perform substantially in
+accordance with the accompanying written documentation. These
+warranties do not guarantee that the Software will perform error-free
+or uninterrupted, or that all errors in the Software and documentation
+will be corrected. These warranties are exclusive and take the place
+of all other express or implied warranties or conditions including
+warranties or conditions of merchantability, satisfactory quality, and
+fitness for a particular purpose. ZI will provide updates
+(functionality extension and bug fixes) to the Software licensed
+hereunder in accordance with the internal release schedule. Neither
+party shall be liable for any indirect, incidental, special, punitive,
+or consequential damages, or any loss of profits, revenue, data, or
+data use deriving from the installation and use of this Software. This
+also holds if Zurich Instruments has been advised of the possibility
+of such damages.
+
+6. GENERAL. If any provision of this Agreement is declared void or
+unenforceable by any judicial authority, this shall not nullify the
+remaining provisions of the Agreement which shall remain in full force
+and effect.
+
+Copyright © Zurich Instruments AG
+Technoparkstrasse 1
+8005 Zurich
+Switzerland
+
+phone: +41-44-5150410
+web: www.zhinst.com

--- a/src/licensedcode/data/rules/zi-labone-proprietary.yml
+++ b/src/licensedcode/data/rules/zi-labone-proprietary.yml
@@ -1,0 +1,3 @@
+license_expression: proprietary-license
+is_license_notice: yes
+notes:  https://gitweb.gentoo.org/repo/gentoo.git/tree/licenses/zi-labone


### PR DESCRIPTION
This is the rule addition for the undetected license(Zurich Instruments) for the series of licenses in #296 
Signed-off-by: aj4ayushjain <aj4ayushjain@gmail.com>