### PR TITLE
Use ordered dict to save Pypi license and classifiers #1492

### DIFF
--- a/src/packagedcode/bower.py
+++ b/src/packagedcode/bower.py
@@ -65,7 +65,7 @@ class BowerPackage(models.Package):
 
 def is_bower_json(location):
     return (filetype.is_file(location)
-            and location.lower().endswith('bower.json', '.bower.json'))
+            and location.lower().endswith(('bower.json', '.bower.json')))
 
 
 def parse(location):

--- a/src/packagedcode/pypi.py
+++ b/src/packagedcode/pypi.py
@@ -25,6 +25,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+from collections import OrderedDict
 import json
 import logging
 import os
@@ -89,11 +90,20 @@ def compute_normalized_license(declared_license):
 
     detected_licenses = []
 
-    for declared in declared_license:
-        if isinstance(declared, string_types):
-            detected_license = models.compute_normalized_license(declared)
+    for value in declared_license.values():
+        if not value:
+            continue
+        # The value could be a string or a list
+        if isinstance(value, string_types):
+            detected_license = models.compute_normalized_license(value)
             if detected_license:
                 detected_licenses.append(detected_license)
+        else:
+            for declared in value:
+                detected_license = models.compute_normalized_license(declared)
+                if detected_license:
+                    detected_licenses.append(detected_license)
+            
     if detected_licenses:
         return combine_expressions(detected_licenses)
 
@@ -263,15 +273,15 @@ def parse_setup_py(location):
             type=models.party_person,
             name=author, role='author'))
 
+    declared_license = OrderedDict()
+    license_setuptext = get_setup_attribute(setup_text, 'license')
+    declared_license['license'] = license_setuptext
+
     classifiers = get_classifiers(setup_text)
     license_classifiers = [c for c in classifiers if c.startswith('License')]
+    declared_license['classifiers'] = license_classifiers
+    
     other_classifiers = [c for c in classifiers if not c.startswith('License')]
-
-    declared_license = []
-    license_setuptext =  get_setup_attribute(setup_text, 'license')
-    if license_setuptext:
-        declared_license.append(license_setuptext)
-    declared_license.extend(license_classifiers)
 
     package = PythonPackage(
         name=get_setup_attribute(setup_text, 'name'),

--- a/tests/packagedcode/data/pypi/setup.py/arpy_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/arpy_setup.py-expected.json
@@ -22,7 +22,10 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": null,
-  "declared_license": [],
+  "declared_license": {
+    "license": null,
+    "classifiers": []
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/boolean2_py_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/boolean2_py_setup.py-expected.json
@@ -41,10 +41,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "(bsd-new AND unknown) AND bsd-new",
-  "declared_license": [
-    "revised BSD license",
-    "License :: OSI Approved :: BSD License"
-  ],
+  "declared_license": {
+    "license": "revised BSD license",
+    "classifiers": [
+      "License :: OSI Approved :: BSD License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/container_check_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/container_check_setup.py-expected.json
@@ -40,10 +40,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "unknown AND apache-2.0",
-  "declared_license": [
-    "Apache Software License",
-    "License :: OSI Approved :: Apache Software License"
-  ],
+  "declared_license": {
+    "license": "Apache Software License",
+    "classifiers": [
+      "License :: OSI Approved :: Apache Software License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/fb303_py_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/fb303_py_setup.py-expected.json
@@ -30,9 +30,10 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "apache-2.0",
-  "declared_license": [
-    "Apache License 2.0"
-  ],
+  "declared_license": {
+    "license": "Apache License 2.0",
+    "classifiers": []
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/gyp_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/gyp_setup.py-expected.json
@@ -30,7 +30,10 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": null,
-  "declared_license": [],
+  "declared_license": {
+    "license": null,
+    "classifiers": []
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/interlap_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/interlap_setup.py-expected.json
@@ -41,10 +41,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "mit",
-  "declared_license": [
-    "MIT",
-    "License :: OSI Approved :: MIT License"
-  ],
+  "declared_license": {
+    "license": "MIT",
+    "classifiers": [
+      "License :: OSI Approved :: MIT License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/mb_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/mb_setup.py-expected.json
@@ -30,9 +30,10 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "gpl-2.0",
-  "declared_license": [
-    "GPLv2"
-  ],
+  "declared_license": {
+    "license": "GPLv2",
+    "classifiers": []
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/ntfs_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/ntfs_setup.py-expected.json
@@ -37,10 +37,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "unknown AND bsd-new",
-  "declared_license": [
-    "BSD",
-    "License :: OSI Approved :: BSD License"
-  ],
+  "declared_license": {
+    "license": "BSD",
+    "classifiers": [
+      "License :: OSI Approved :: BSD License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/nvchecker_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/nvchecker_setup.py-expected.json
@@ -47,10 +47,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "mit",
-  "declared_license": [
-    "MIT",
-    "License :: OSI Approved :: MIT License"
-  ],
+  "declared_license": {
+    "license": "MIT",
+    "classifiers": [
+      "License :: OSI Approved :: MIT License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/oi_agents_common_code_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/oi_agents_common_code_setup.py-expected.json
@@ -39,10 +39,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "gpl-3.0 AND (free-unknown AND gpl-3.0)",
-  "declared_license": [
-    "GPLv3",
-    "License :: OSI Approved :: GPLv3 License"
-  ],
+  "declared_license": {
+    "license": "GPLv3",
+    "classifiers": [
+      "License :: OSI Approved :: GPLv3 License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/packageurl_python_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/packageurl_python_setup.py-expected.json
@@ -41,10 +41,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "mit",
-  "declared_license": [
-    "MIT",
-    "License :: OSI Approved :: MIT License"
-  ],
+  "declared_license": {
+    "license": "MIT",
+    "classifiers": [
+      "License :: OSI Approved :: MIT License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/pipdeptree_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/pipdeptree_setup.py-expected.json
@@ -40,10 +40,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "mit",
-  "declared_license": [
-    "MIT License",
-    "License :: OSI Approved :: MIT License"
-  ],
+  "declared_license": {
+    "license": "MIT License",
+    "classifiers": [
+      "License :: OSI Approved :: MIT License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/pluggy_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/pluggy_setup.py-expected.json
@@ -40,10 +40,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "mit",
-  "declared_license": [
-    "MIT license",
-    "License :: OSI Approved :: MIT License"
-  ],
+  "declared_license": {
+    "license": "MIT license",
+    "classifiers": [
+      "License :: OSI Approved :: MIT License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/pydep_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/pydep_setup.py-expected.json
@@ -30,7 +30,10 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": null,
-  "declared_license": [],
+  "declared_license": {
+    "license": null,
+    "classifiers": []
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/pyrpm_2_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/pyrpm_2_setup.py-expected.json
@@ -42,10 +42,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "unknown AND bsd-new",
-  "declared_license": [
-    "BSD\",      classifiers=[          'Development Status :: 4 - Beta",
-    "License :: OSI Approved :: BSD License"
-  ],
+  "declared_license": {
+    "license": "BSD\",      classifiers=[          'Development Status :: 4 - Beta",
+    "classifiers": [
+      "License :: OSI Approved :: BSD License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/python_publicsuffix_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/python_publicsuffix_setup.py-expected.json
@@ -35,10 +35,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "mit",
-  "declared_license": [
-    "MIT",
-    "License :: OSI Approved :: MIT License"
-  ],
+  "declared_license": {
+    "license": "MIT",
+    "classifiers": [
+      "License :: OSI Approved :: MIT License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/repology_py_libversion_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/repology_py_libversion_setup.py-expected.json
@@ -40,10 +40,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "mit",
-  "declared_license": [
-    "MIT",
-    "License :: OSI Approved :: MIT License"
-  ],
+  "declared_license": {
+    "license": "MIT",
+    "classifiers": [
+      "License :: OSI Approved :: MIT License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/saneyaml_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/saneyaml_setup.py-expected.json
@@ -41,10 +41,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "apache-2.0",
-  "declared_license": [
-    "Apache-2.0",
-    "License :: OSI Approved :: Apache Software License"
-  ],
+  "declared_license": {
+    "license": "Apache-2.0",
+    "classifiers": [
+      "License :: OSI Approved :: Apache Software License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/setup.py-expected.json
@@ -36,11 +36,13 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "((apache-2.0 AND cc0-1.0) AND unknown) AND apache-2.0 AND (free-unknown AND unknown)",
-  "declared_license": [
-    "Apache-2.0 with ScanCode acknowledgment and CC0-1.0 and others",
-    "License :: OSI Approved :: Apache Software License",
-    "License :: OSI Approved :: CC0"
-  ],
+  "declared_license": {
+    "license": "Apache-2.0 with ScanCode acknowledgment and CC0-1.0 and others",
+    "classifiers": [
+      "License :: OSI Approved :: Apache Software License",
+      "License :: OSI Approved :: CC0"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/setuppycheck_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/setuppycheck_setup.py-expected.json
@@ -30,9 +30,10 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "mit",
-  "declared_license": [
-    "MIT"
-  ],
+  "declared_license": {
+    "license": "MIT",
+    "classifiers": []
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/url_py_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/url_py_setup.py-expected.json
@@ -35,10 +35,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "mit",
-  "declared_license": [
-    "MIT",
-    "License :: OSI Approved :: MIT License"
-  ],
+  "declared_license": {
+    "license": "MIT",
+    "classifiers": [
+      "License :: OSI Approved :: MIT License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/venv_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/venv_setup.py-expected.json
@@ -40,10 +40,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "mit",
-  "declared_license": [
-    "MIT",
-    "License :: OSI Approved :: MIT License"
-  ],
+  "declared_license": {
+    "license": "MIT",
+    "classifiers": [
+      "License :: OSI Approved :: MIT License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],

--- a/tests/packagedcode/data/pypi/setup.py/xmltodict_setup.py-expected.json
+++ b/tests/packagedcode/data/pypi/setup.py/xmltodict_setup.py-expected.json
@@ -38,9 +38,12 @@
   "vcs_url": null,
   "copyright": null,
   "license_expression": "mit",
-  "declared_license": [
-    "License :: OSI Approved :: MIT License"
-  ],
+  "declared_license": {
+    "license": null,
+    "classifiers": [
+      "License :: OSI Approved :: MIT License"
+    ]
+  },
   "notice_text": null,
   "manifest_path": null,
   "dependencies": [],


### PR DESCRIPTION
Use this dictionary format to store the declared_license
{
 'license': '...........',
 'classifiers: [......]
}

Also fix a build error for bower
Signed-off-by: Li <li@nexb.com>