### PR TITLE
ABOUT File Parser

### DIFF
--- a/src/packagedcode/__init__.py
+++ b/src/packagedcode/__init__.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from packagedcode import models
+from packagedcode import about
 from packagedcode import bower
 from packagedcode import cargo
 from packagedcode import freebsd
@@ -53,6 +54,7 @@ PACKAGE_TYPES = [
     models.JBossSar,
     models.Axis2Mar,
 
+    about.AboutPackage,
     npm.NpmPackage,
     phpcomposer.PHPComposerPackage,
     haxe.HaxePackage,

--- a/src/packagedcode/about.py
+++ b/src/packagedcode/about.py
@@ -79,7 +79,7 @@ def parse(location):
 
 def build_package(package_data):
     """
-    Return a Package built from Bower json `package_data`.
+    Return a Package built from `package_data` obtained by an ABOUT file.
     """
     name = package_data.get('name')
     # FIXME: having no name may not be a problem See #1514
@@ -87,7 +87,7 @@ def build_package(package_data):
         return
 
     version = package_data.get('version')
-    homepage_url = package_data.get('home_url')
+    homepage_url = package_data.get('home_url') or package_data.get('homepage_url')
     download_url = package_data.get('download_url')
     declared_license = package_data.get('license_expression')
 

--- a/src/packagedcode/about.py
+++ b/src/packagedcode/about.py
@@ -56,6 +56,16 @@ class AboutPackage(models.Package):
     def recognize(cls, location):
         return parse(location)
 
+    @classmethod
+    def get_package_root(cls, manifest_resource, codebase):
+        about_resource = cls.extra_data.get('about_resource')
+        if about_resource:
+            manifest_resource_parent = manifest_resource.parent(codebase)
+            for child in manifest_resource_parent.children(codebase):
+                if child.name == about_resource:
+                    return child
+        return manifest_resource
+
 
 def is_about_file(location):
     return (filetype.is_file(location)
@@ -95,7 +105,7 @@ def build_package(package_data):
         owner = repr(owner)
     parties = [models.Party(type=models.party_person, name=owner, role='owner')]
 
-    return AboutPackage(
+    package = AboutPackage(
         type='about',
         name=name,
         version=version,
@@ -105,3 +115,9 @@ def build_package(package_data):
         homepage_url=homepage_url,
         download_url=download_url,
     )
+
+    about_resource = package_data.get('about_resource')
+    if about_resource:
+        package.extra_data['about_resource'] = about_resource
+
+    return package

--- a/src/packagedcode/about.py
+++ b/src/packagedcode/about.py
@@ -31,12 +31,10 @@ import io
 import logging
 
 import attr
-from packageurl import PackageURL
 from six import string_types
 
 from commoncode import filetype
 from packagedcode import models
-from packagedcode.utils import combine_expressions
 import saneyaml
 
 
@@ -90,14 +88,19 @@ def build_package(package_data):
     homepage_url = package_data.get('home_url') or package_data.get('homepage_url')
     download_url = package_data.get('download_url')
     declared_license = package_data.get('license_expression')
+    copyright = package_data.get('copyright')
 
     owner = package_data.get('owner')
-    parties = [models.Party(name=repr(owner), role='owner')]
+    if not isinstance(owner, string_types):
+        owner = repr(owner)
+    parties = [models.Party(type=models.party_person, name=owner, role='owner')]
 
     return AboutPackage(
+        type='about',
         name=name,
         version=version,
         declared_license=declared_license,
+        copyright=copyright,
         parties=parties,
         homepage_url=homepage_url,
         download_url=download_url,

--- a/src/packagedcode/about.py
+++ b/src/packagedcode/about.py
@@ -51,6 +51,7 @@ if TRACE:
 @attr.s()
 class AboutPackage(models.Package):
     metafiles = ('*.ABOUT',)
+    default_type = 'about'
 
     @classmethod
     def recognize(cls, location):
@@ -58,7 +59,9 @@ class AboutPackage(models.Package):
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):
-        about_resource = cls.extra_data.get('about_resource')
+        with io.open(manifest_resource.location, encoding='utf-8') as loc:
+            package_data = saneyaml.load(loc.read())
+        about_resource = package_data.get('about_resource')
         if about_resource:
             manifest_resource_parent = manifest_resource.parent(codebase)
             for child in manifest_resource_parent.children(codebase):
@@ -105,7 +108,7 @@ def build_package(package_data):
         owner = repr(owner)
     parties = [models.Party(type=models.party_person, name=owner, role='owner')]
 
-    package = AboutPackage(
+    return AboutPackage(
         type='about',
         name=name,
         version=version,
@@ -115,9 +118,3 @@ def build_package(package_data):
         homepage_url=homepage_url,
         download_url=download_url,
     )
-
-    about_resource = package_data.get('about_resource')
-    if about_resource:
-        package.extra_data['about_resource'] = about_resource
-
-    return package

--- a/src/packagedcode/about.py
+++ b/src/packagedcode/about.py
@@ -1,0 +1,104 @@
+#
+# Copyright (c) 2019 nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/scancode-toolkit/
+# The ScanCode software is licensed under the Apache License version 2.0.
+# Data generated with ScanCode require an acknowledgment.
+# ScanCode is a trademark of nexB Inc.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with ScanCode or any ScanCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  ScanCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  ScanCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/scancode-toolkit/ for support and download.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from collections import OrderedDict
+import io
+import logging
+
+import attr
+from packageurl import PackageURL
+from six import string_types
+
+from commoncode import filetype
+from packagedcode import models
+from packagedcode.utils import combine_expressions
+import saneyaml
+
+
+TRACE = False
+
+logger = logging.getLogger(__name__)
+
+if TRACE:
+    import sys
+    logging.basicConfig(stream=sys.stdout)
+    logger.setLevel(logging.DEBUG)
+
+
+@attr.s()
+class AboutPackage(models.Package):
+    metafiles = ('*.ABOUT',)
+
+    @classmethod
+    def recognize(cls, location):
+        return parse(location)
+
+
+def is_about_file(location):
+    return (filetype.is_file(location)
+            and location.lower().endswith(('.about',)))
+
+
+def parse(location):
+    """
+    Return a Package object from an ABOUT file or None.
+    """
+    if not is_about_file(location):
+        return
+
+    with io.open(location, encoding='utf-8') as loc:
+        package_data = saneyaml.load(loc.read())
+
+    return build_package(package_data)
+
+
+def build_package(package_data):
+    """
+    Return a Package built from Bower json `package_data`.
+    """
+    name = package_data.get('name')
+    # FIXME: having no name may not be a problem See #1514
+    if not name:
+        return
+
+    version = package_data.get('version')
+    homepage_url = package_data.get('home_url')
+    download_url = package_data.get('download_url')
+    declared_license = package_data.get('license_expression')
+
+    owner = package_data.get('owner')
+    parties = [models.Party(name=repr(owner), role='owner')]
+
+    return AboutPackage(
+        name=name,
+        version=version,
+        declared_license=declared_license,
+        parties=parties,
+        homepage_url=homepage_url,
+        download_url=download_url,
+    )

--- a/src/packagedcode/models.py
+++ b/src/packagedcode/models.py
@@ -209,9 +209,6 @@ class BasePackage(BaseModel):
     # TODO: add description of the Package type for info
     # type_description = None
 
-    # Optional. Parsed package data can saved here for use at a later point
-    extra_data = OrderedDict()
-
     type = String(
         repr=True,
         label='package type',

--- a/src/packagedcode/models.py
+++ b/src/packagedcode/models.py
@@ -209,6 +209,9 @@ class BasePackage(BaseModel):
     # TODO: add description of the Package type for info
     # type_description = None
 
+    # Optional. Parsed package data can saved here for use at a later point
+    extra_data = OrderedDict()
+
     type = String(
         repr=True,
         label='package type',

--- a/src/packagedcode/plugin_package.py
+++ b/src/packagedcode/plugin_package.py
@@ -120,11 +120,6 @@ class PackageScanner(ScanPlugin):
                 # 3. set the manifest_path if needed.
                 # 4. save.
 
-                # NOTE: do not do this if the new_package_root is not an ancestor
-                # FIXME: this may not hold at all times?
-                ancestors = resource.ancestors(codebase)
-                if new_package_root not in ancestors:
-                    continue
                 # here we have a relocated Resource and we compute the manifest path
                 # relative to the new package root
                 new_package_root_path = new_package_root.path and new_package_root.path.strip('/')
@@ -137,4 +132,3 @@ class PackageScanner(ScanPlugin):
                 codebase.save_resource(new_package_root)
                 resource.packages = []
                 codebase.save_resource(resource)
-

--- a/tests/packagedcode/data/about/apipkg.ABOUT
+++ b/tests/packagedcode/data/about/apipkg.ABOUT
@@ -1,0 +1,10 @@
+about_resource: apipkg-1.4-py2.py3-none-any.whl
+download_url: https://pypi.python.org/packages/94/72/fd4f2e46ce7b0d388191c819ef691c8195fab09602bbf1a2f92aa5351444/apipkg-1.4-py2.py3-none-any.whl#md5=5644eb6aff3f19e13430251a820e987f
+version: 1.4
+
+name: apipkg
+home_url: https://bitbucket.org/hpk42/apipkg
+owner: Holger Krekel
+license_expression: mit
+license_file: apipkg.LICENSE
+copyright: Copyright (c) 2009 holger krekel

--- a/tests/packagedcode/data/about/apipkg.ABOUT-expected
+++ b/tests/packagedcode/data/about/apipkg.ABOUT-expected
@@ -1,0 +1,43 @@
+{
+  "type": "about",
+  "namespace": null,
+  "name": "apipkg",
+  "version": "1.4",
+  "qualifiers": null,
+  "subpath": null,
+  "primary_language": null,
+  "description": null,
+  "release_date": null,
+  "parties": [
+    {
+      "type": "person",
+      "role": "owner",
+      "name": "Holger Krekel",
+      "email": null,
+      "url": null
+    }
+  ],
+  "keywords": [],
+  "homepage_url": "https://bitbucket.org/hpk42/apipkg",
+  "download_url": "https://pypi.python.org/packages/94/72/fd4f2e46ce7b0d388191c819ef691c8195fab09602bbf1a2f92aa5351444/apipkg-1.4-py2.py3-none-any.whl#md5=5644eb6aff3f19e13430251a820e987f",
+  "size": null,
+  "sha1": null,
+  "md5": null,
+  "sha256": null,
+  "sha512": null,
+  "bug_tracking_url": null,
+  "code_view_url": null,
+  "vcs_url": null,
+  "copyright": "Copyright (c) 2009 holger krekel",
+  "license_expression": "mit",
+  "declared_license": "mit",
+  "notice_text": null,
+  "manifest_path": null,
+  "dependencies": [],
+  "contains_source_code": null,
+  "source_packages": [],
+  "purl": "pkg:about/apipkg@1.4",
+  "repository_homepage_url": null,
+  "repository_download_url": null,
+  "api_data_url": null
+}

--- a/tests/packagedcode/data/about/appdirs.ABOUT
+++ b/tests/packagedcode/data/about/appdirs.ABOUT
@@ -1,0 +1,17 @@
+about_resource: appdirs-1.4.3-py2.py3-none-any.whl
+name: appdirs
+version: 1.4.3
+
+download_url: https://pypi.python.org/packages/56/eb/810e700ed1349edde4cbdc1b2a21e28cdf115f9faf263f6bbf8447c1abf3/appdirs-1.4.3-py2.py3-none-any.whl#md5=9ed4b51c9611775c3078b3831072e153
+
+homepage_url: https://pypi.python.org/pypi/appdirs
+owner: ActiveState  
+
+vcs_url: https://github.com/ActiveState/appdirs.git
+
+copyright: Copyright (c) 2010 ActiveState Software Inc.
+
+license_expression: mit
+license_file: appdirs.LICENSE
+    
+    

--- a/tests/packagedcode/data/about/appdirs.ABOUT-expected
+++ b/tests/packagedcode/data/about/appdirs.ABOUT-expected
@@ -1,0 +1,43 @@
+{
+  "type": "about",
+  "namespace": null,
+  "name": "appdirs",
+  "version": "1.4.3",
+  "qualifiers": null,
+  "subpath": null,
+  "primary_language": null,
+  "description": null,
+  "release_date": null,
+  "parties": [
+    {
+      "type": "person",
+      "role": "owner",
+      "name": "ActiveState",
+      "email": null,
+      "url": null
+    }
+  ],
+  "keywords": [],
+  "homepage_url": "https://pypi.python.org/pypi/appdirs",
+  "download_url": "https://pypi.python.org/packages/56/eb/810e700ed1349edde4cbdc1b2a21e28cdf115f9faf263f6bbf8447c1abf3/appdirs-1.4.3-py2.py3-none-any.whl#md5=9ed4b51c9611775c3078b3831072e153",
+  "size": null,
+  "sha1": null,
+  "md5": null,
+  "sha256": null,
+  "sha512": null,
+  "bug_tracking_url": null,
+  "code_view_url": null,
+  "vcs_url": null,
+  "copyright": "Copyright (c) 2010 ActiveState Software Inc.",
+  "license_expression": "mit",
+  "declared_license": "mit",
+  "notice_text": null,
+  "manifest_path": null,
+  "dependencies": [],
+  "contains_source_code": null,
+  "source_packages": [],
+  "purl": "pkg:about/appdirs@1.4.3",
+  "repository_homepage_url": null,
+  "repository_download_url": null,
+  "api_data_url": null
+}

--- a/tests/packagedcode/test_about.py
+++ b/tests/packagedcode/test_about.py
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2019 nexB Inc. and others. All rights reserved.
+# http://nexb.com and https://github.com/nexB/scancode-toolkit/
+# The ScanCode software is licensed under the Apache License version 2.0.
+# Data generated with ScanCode require an acknowledgment.
+# ScanCode is a trademark of nexB Inc.
+#
+# You may not use this software except in compliance with the License.
+# You may obtain a copy of the License at: http://apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# When you publish or redistribute any data created with ScanCode or any ScanCode
+# derivative work, you must accompany this data with the following acknowledgment:
+#
+#  Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+#  ScanCode should be considered or used as legal advice. Consult an Attorney
+#  for any legal advice.
+#  ScanCode is a free software code scanning tool from nexB Inc. and others.
+#  Visit https://github.com/nexB/scancode-toolkit/ for support and download.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os.path
+
+from packagedcode import about
+
+from packages_test_utils import PackageTester
+
+
+class TestAbout(PackageTester):
+    test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
+
+    def test_parse_about_file_home_url(self):
+        test_file = self.get_test_loc('about/apipkg.ABOUT')
+        package = about.parse(test_file)
+        expected_loc = self.get_test_loc('about/apipkg.ABOUT-expected')
+        self.check_package(package, expected_loc, regen=False)
+
+    def test_parse_about_file_homepage_url(self):
+        test_file = self.get_test_loc('about/appdirs.ABOUT')
+        package = about.parse(test_file)
+        expected_loc = self.get_test_loc('about/appdirs.ABOUT-expected')
+        self.check_package(package, expected_loc, regen=False)


### PR DESCRIPTION
This is a new parser that allows ScanCode to generate Package data for ABOUT files. The parser will attempt to roll up the Package data to the Resource referenced in the `about_resource` field of the ABOUT file, assuming that the Resource is in the codebase being scanned. Otherwise, the Package data will be attached to the ABOUT file. 

I have also removed a check in `src/packagedcode/plugin_package.py` that prevents Package data from being appended to a Resource that is not an ancestor of a manifest Resource.