### PR TITLE
Added Specific Instructions for --license-text

### DIFF
--- a/src/licensedcode/plugin_license.py
+++ b/src/licensedcode/plugin_license.py
@@ -84,7 +84,7 @@ class LicenseScanner(ScanPlugin):
         CommandLineOption(('--license-text',),
             is_flag=True,
             required_options=['license'],
-            help='Include the detected licenses matched text.',
+            help='Include the detected licenses matched text for json output only.',
             help_group=SCAN_OPTIONS_GROUP),
 
         CommandLineOption(('--license-url-template',),


### PR DESCRIPTION
I merely changed one line from 
'**Include the detected licenses matched text.' to 'Include the detected licenses matched text for json output only.**'

In accordance to the issue https://github.com/nexB/scancode-toolkit/issues/1330