### PR TITLE
Improved Example

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ The following organizations or individuals have contributed to ScanCode:
 - Tushar Mittal @techytushar
 - Martin Petkov @MartinPetkov
 - Mrinal Paliwal @mriiinal
+- Shubham Kumar @sk9331657

--- a/src/scancode/help.py
+++ b/src/scancode/help.py
@@ -24,6 +24,11 @@ Print scan results to stdout as pretty formatted JSON.
 
     scancode -lc --package --ignore README --processes 4 --json-pp - samples/
 
+Scan a file for copyright and packages. Print scan results to file as pretty
+formatted JSON.
+
+    scancode --copyright --package  samples/zlib/zlib.h --json-pp - > scan.json
+
 Scan a directory while ignoring all files with .txt extension.
 Print scan results to stdout as pretty formatted JSON.
 It is recommended to use quotes around glob patterns to prevent pattern


### PR DESCRIPTION
- [:heavy_check_mark:]  Added Example for reading copyright in directory while ignoring header files and saving result in Json file in Pretty Printed Format .