### PR TITLE
Add Test Suite to CI on Python version 2.7 and 3.6 using Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,81 @@ trigger:
     include: ['*']
 
 jobs:
-  - job: TEST
-    displayName: Performing test 
-    steps:
-      - script: ./configure
-      - script: ./bin/py.test -vvs tests/commoncode
+- job: TestSuite1
+  displayName: Performing test On Linux and Mac
+  strategy:
+     matrix:
+      #linux
+      'ubuntu-16-py27':
+        imageName: 'ubuntu-16.04'
+        pythonVersion: '2.7'
+      'ubuntu-16-py36':
+        imageName: 'ubuntu-16.04'
+        pythonVersion: '3.6'
+
+      #High Sierra
+      'macOS-10.13-py27':                       
+        imageName: 'macos-10.13'
+        pythonVersion: '2.7'
+      'macOS-10.13-py37':                       
+        imageName: 'macos-10.13'
+        pythonVersion: '3.6'
+
+      #Mojave
+      'macOS-10.14-py27':                       
+        imageName: 'macos-10.14'
+        pythonVersion: '2.7'
+      'macOS-10.14-py37':                       
+        imageName: 'macos-10.14'
+        pythonVersion: '3.6'
+
+  pool:
+     vmImage: $(imageName)
+    
+     steps:
+    
+      - task: UsePythonVersion@0
+        inputs:
+        versionSpec: '$(pythonVersion)'
+        architecture: 'x64'
+      
+      - script: |
+         ./configure
+         ./bin/py.test -vvs tests/commoncode
+- job : TestSuite2
+  displayName: Performing test On Windows
+  strategy:
+     matrix:
+      #Windows
+      'Windows-py27':
+        imageName: 'vs2017-win2016'
+        pythonVersion: '2.7'
+      'Windows-py36':
+        imageName: 'vs2017-win2016'
+        pythonVersion: '3.6'
+      'Windows1-py27':
+        imageName: 'vs2015-win2012r2'
+        pythonVersion: '2.7'
+      'Windows1-py36':
+        imageName: 'vs2015-win2012r2'
+        pythonVersion: '3.6'
+      'Windows2-py27':
+        imageName: 'windows-2019'
+        pythonVersion: '2.7'
+      'Windows2-py36':
+        imageName: 'windows-2019'
+        pythonVersion: '3.6'
+  
+  pool:
+     vmImage: $(imageName)
+    
+     steps:
+    
+      - task: UsePythonVersion@0
+        inputs:
+        versionSpec: '$(pythonVersion)'
+        architecture: 'x64'
+      
+      - script: |
+         configure
+         ./bin/py.test -vvs tests/commoncode


### PR DESCRIPTION
Adding Pytest to Azure Pipeline to perform test on both Python 2.7 and Python 3.6 on macOS,window,Linux

Signed-off-by: Abhishek Kumar <abhishek.kasyap09@gmail.com>