### PR TITLE
Remove references to funname and func_name #295

### DIFF
--- a/src/scancode/pool.py
+++ b/src/scancode/pool.py
@@ -41,7 +41,7 @@ from multiprocessing import pool
 
 def wrapped(func):
     # ensure that we do not double wrap
-    if func.func_name != 'wrap':
+    if func.__name__ != 'wrap':
 
         def wrap(self, timeout=None):
             return func(self, timeout=timeout or 1e10)

--- a/tests/cluecode/cluecode_test_utils.py
+++ b/tests/cluecode/cluecode_test_utils.py
@@ -265,7 +265,6 @@ def make_copyright_test_functions(test, test_data_dir=test_env.test_data_dir, re
         test_name = test_name.encode('utf-8')
 
     closure_test_function.__name__ = test_name
-    closure_test_function.funcname = test_name
 
     if test.expected_failures:
         closure_test_function = expectedFailure(closure_test_function)

--- a/tests/cluecode/test_copyrights_fosso.py
+++ b/tests/cluecode/test_copyrights_fosso.py
@@ -142,7 +142,6 @@ def build_copyright_test_methods_with_fossology_data():
             test_name = test_name.encode('utf-8')
 
         test_method.__name__ = test_name
-        test_method.funcname = test_name
 
         if test_name in expected_failures:
             test_method = pytest.mark.xfail(test_method)

--- a/tests/licensedcode/licensedcode_test_utils.py
+++ b/tests/licensedcode/licensedcode_test_utils.py
@@ -248,8 +248,7 @@ def make_test(license_test, regen=False):
             assert '\n'.join(results) == '\n'.join(failure_trace)
 
     closure_test_function.__name__ = test_name
-    closure_test_function.funcname = test_name
-
+    
     if expected_failure:
         closure_test_function = unittest.expectedFailure(closure_test_function)
 

--- a/tests/licensedcode/test_match_spdx_lid.py
+++ b/tests/licensedcode/test_match_spdx_lid.py
@@ -113,7 +113,6 @@ def build_spdx_line_tests(clazz, test_dir='spdx/lines', regen=False):
         test_name = str(test_name)
         test_method = get_query_spdx_lines_test_method(test_loc, expected_loc, regen)
         test_method.__name__ = test_name
-        test_method.funcname = test_name
         # attach that method to our test class
         setattr(clazz, test_name, test_method)
 

--- a/tests/packagedcode/test_jar_manifest.py
+++ b/tests/packagedcode/test_jar_manifest.py
@@ -118,7 +118,6 @@ def create_test_function(test_manifest_loc, test_name, check_parse=True, regen=F
     if isinstance(test_name, unicode):
         test_name = test_name.encode('utf-8')
     test_manifest.__name__ = test_name
-    test_manifest.funcname = test_name
     return test_manifest
 
 

--- a/tests/packagedcode/test_maven.py
+++ b/tests/packagedcode/test_maven.py
@@ -499,7 +499,6 @@ def create_test_function(test_pom_loc, test_name, check_pom=True, regen=False):
     if isinstance(test_name, unicode):
         test_name = test_name.encode('utf-8')
     test_pom.__name__ = test_name
-    test_pom.funcname = test_name
     return test_pom
 
 

--- a/tests/packagedcode/test_rubygems.py
+++ b/tests/packagedcode/test_rubygems.py
@@ -148,7 +148,6 @@ def create_test_function(test_loc, test_name, regen=False):
     if isinstance(test_name, unicode):
         test_name = test_name.encode('utf-8')
     check_rubygem.__name__ = test_name
-    check_rubygem.funcname = test_name
     return check_rubygem
 
 

--- a/tests/summarycode/test_score.py
+++ b/tests/summarycode/test_score.py
@@ -74,7 +74,6 @@ def make_test_function(test_name, test_dir, expected_file, regen=False):
         test_name = test_name.encode('utf-8')
 
     closure_test_function.__name__ = test_name
-    closure_test_function.funcname = test_name
 
     return closure_test_function, test_name
 


### PR DESCRIPTION
These are weird and either changed (func_name is now __name__) or
incorrect (funname was a typo and never really existed/was not used).

Signed-off-by: Abhishek Kumar abhishek.kasyap09@gmail.com


