### PR TITLE
Use compat module for unicode,string and int. #295

### DIFF
--- a/etc/scripts/synclic.py
+++ b/etc/scripts/synclic.py
@@ -45,6 +45,7 @@ import requests
 
 from commoncode import fetch
 from commoncode import fileutils
+from commoncode import compat
 
 import licensedcode
 from licensedcode.models import load_licenses
@@ -892,7 +893,7 @@ def merge_licenses(scancode_license, external_license, updatable_attributes,
 
             continue
 
-        if isinstance(scancode_value, basestring) and isinstance(external_value, basestring):
+        if (isinstance(scancode_value, compat.string_types) and isinstance(external_value, compat.string_types)):
             # keep the stripped and normalized spaces value
             # normalized spaces
             normalized_scancode_value = ' '.join(scancode_value.split())

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -36,6 +36,7 @@ from commoncode.text import toascii
 from commoncode.text import unixlinesep
 from cluecode import copyrights_hint
 from textcode import analysis
+from commoncode import compat
 
 
 # Tracing flags
@@ -59,7 +60,7 @@ if TRACE or TRACE_DEEP:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, (unicode, str)) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 """
 Detect and collect copyright statements.

--- a/src/cluecode/finder.py
+++ b/src/cluecode/finder.py
@@ -35,6 +35,7 @@ import url as urlpy
 
 from commoncode.text import toascii
 from cluecode import finder_data
+from commoncode import compat
 from textcode import analysis
 
 
@@ -58,7 +59,7 @@ if TRACE or TRACE_URL or TRACE_EMAIL:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, basestring) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 
 """
@@ -88,7 +89,6 @@ def find(location, patterns):
                     logger_debug('find: yielding match: key=%(key)r, '
                           'match=%(match)r,\n    line=%(line)r' % locals())
                 yield key, toascii(match), line, lineno
-
 
 def unique_filter(matches):
     """
@@ -249,7 +249,7 @@ def find_urls(location, unique=True):
         if TRACE_URL:
             logger_debug('find_urls: lineno:', lineno, '_line:', repr(_line),
                          'type(url):', type(url), 'url:', repr(url))
-        yield unicode(url), lineno
+        yield compat.unicode(url), lineno
 
 
 EMPTY_URLS = set(['https', 'http', 'ftp', 'www', ])
@@ -450,7 +450,7 @@ def get_ip(s):
         return False
 
     try:
-        ip = ipaddress.ip_address(unicode(s))
+        ip = ipaddress.ip_address(compat.unicode(s))
         return ip
     except ValueError:
         return False

--- a/src/cluecode/plugin_ignore_copyrights.py
+++ b/src/cluecode/plugin_ignore_copyrights.py
@@ -33,6 +33,7 @@ from plugincode.output_filter import OutputFilterPlugin
 from plugincode.output_filter import output_filter_impl
 from scancode import CommandLineOption
 from scancode import OUTPUT_FILTER_GROUP
+from commoncode import compat
 
 
 def logger_debug(*args):
@@ -50,7 +51,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        logger.debug(' '.join(isinstance(a, (unicode, str)) and a or repr(a) for a in args))
+        logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 
 @output_filter_impl

--- a/src/commoncode/command.py
+++ b/src/commoncode/command.py
@@ -37,6 +37,7 @@ import logging
 import signal
 import subprocess
 
+from commoncode import compat
 from commoncode.fileutils import fsdecode
 from commoncode.fileutils import fsencode
 from commoncode.fileutils import get_temp_dir
@@ -45,14 +46,6 @@ from commoncode.system import on_windows
 from commoncode.system import py2
 from commoncode import text
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
 
 """
 Minimal wrapper for executing external commands in sub-processes. The approach

--- a/src/commoncode/datautils.py
+++ b/src/commoncode/datautils.py
@@ -36,17 +36,6 @@ import typing
 Utilities and helpers for data classes.
 """
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str_orig = str
-    bytes = str  # NOQA
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
-
 
 HELP_METADATA = '__field_help'
 LABEL_METADATA = '__field_label'

--- a/src/commoncode/paths.py
+++ b/src/commoncode/paths.py
@@ -31,6 +31,7 @@ from os.path import commonprefix
 import posixpath
 import re
 
+from commoncode import compat
 from commoncode.text import as_unicode
 from commoncode.text import toascii
 from commoncode.fileutils import as_posixpath
@@ -61,7 +62,7 @@ def safe_path(path, posix=False):
     path with blackslash separators otherwise.
     """
     # if the path is UTF, try to use unicode instead
-    if not isinstance(path, unicode):
+    if not isinstance(path, compat.unicode):
         path = as_unicode(path)
 
     path = path.strip()
@@ -81,7 +82,7 @@ def safe_path(path, posix=False):
         return '_'
 
     # always return posix
-    sep = u'/' if isinstance(path, unicode) else b'/'
+    sep = u'/' if isinstance(path, compat.unicode) else b'/'
     path = sep.join(segments)
     return as_posixpath(path)
 
@@ -97,7 +98,7 @@ def path_handlers(path, posix=True):
     use_posix = posix or is_posix
     pathmod = use_posix and posixpath or ntpath
     path_sep = POSIX_PATH_SEP if use_posix else WIN_PATH_SEP
-    path_sep = isinstance(path, unicode) and unicode(path_sep) or path_sep
+    path_sep = isinstance(path, compat.unicode) and compat.unicode(path_sep) or path_sep
     return pathmod, path_sep
 
 
@@ -112,7 +113,7 @@ def resolve(path, posix=True):
     The `path` is treated as a POSIX path if `posix` is True (default) or as a
     Windows path with blackslash separators otherwise.
     """
-    is_unicode = isinstance(path, unicode)
+    is_unicode = isinstance(path, compat.unicode)
     dot = is_unicode and u'.' or b'.'
 
     if not path:

--- a/src/extractcode/archive.py
+++ b/src/extractcode/archive.py
@@ -51,6 +51,7 @@ from extractcode import sevenzip
 from extractcode import libarchive2
 from extractcode.uncompress import uncompress_gzip
 from extractcode.uncompress import uncompress_bzip2
+from commoncode import compat
 
 
 logger = logging.getLogger(__name__)
@@ -323,9 +324,9 @@ def extract_twice(location, target_dir, extractor1, extractor2):
         location = fileutils.fsencode(location)
         target_dir = fileutils.fsencode(target_dir)
     abs_location = os.path.abspath(os.path.expanduser(location))
-    abs_target_dir = unicode(os.path.abspath(os.path.expanduser(target_dir)))
+    abs_target_dir = compat.unicode(os.path.abspath(os.path.expanduser(target_dir)))
     # extract first the intermediate payload to a temp dir
-    temp_target = unicode(fileutils.get_temp_dir(prefix='scancode-extract-'))
+    temp_target = compat.unicode(fileutils.get_temp_dir(prefix='scancode-extract-'))
     warnings = extractor1(abs_location, temp_target)
     if TRACE:
         logger.debug('extract_twice: temp_target: %(temp_target)r' % locals())
@@ -356,9 +357,9 @@ def extract_with_fallback(location, target_dir, extractor1, extractor2):
     a secondary extractor will succeed.
     """
     abs_location = os.path.abspath(os.path.expanduser(location))
-    abs_target_dir = unicode(os.path.abspath(os.path.expanduser(target_dir)))
+    abs_target_dir = compat.unicode(os.path.abspath(os.path.expanduser(target_dir)))
     # attempt extract first to a temp dir
-    temp_target1 = unicode(fileutils.get_temp_dir(prefix='scancode-extract1-'))
+    temp_target1 = compat.unicode(fileutils.get_temp_dir(prefix='scancode-extract1-'))
     try:
         warnings = extractor1(abs_location, temp_target1)
         if TRACE:
@@ -366,7 +367,7 @@ def extract_with_fallback(location, target_dir, extractor1, extractor2):
         fileutils.copytree(temp_target1, abs_target_dir)
     except:
         try:
-            temp_target2 = unicode(fileutils.get_temp_dir(prefix='scancode-extract2-'))
+            temp_target2 = compat.unicode(fileutils.get_temp_dir(prefix='scancode-extract2-'))
             warnings = extractor2(abs_location, temp_target2)
             if TRACE:
                 logger.debug('extract_with_fallback: temp_target2: %(temp_target2)r' % locals())
@@ -387,8 +388,8 @@ def try_to_extract(location, target_dir, extractor):
     but do not care if this fails.
     """
     abs_location = os.path.abspath(os.path.expanduser(location))
-    abs_target_dir = unicode(os.path.abspath(os.path.expanduser(target_dir)))
-    temp_target = unicode(fileutils.get_temp_dir(prefix='scancode-extract1-'))
+    abs_target_dir = compat.unicode(os.path.abspath(os.path.expanduser(target_dir)))
+    temp_target = compat.unicode(fileutils.get_temp_dir(prefix='scancode-extract1-'))
     warnings = []
     try:
         warnings = extractor(abs_location, temp_target)

--- a/src/extractcode/libarchive2.py
+++ b/src/extractcode/libarchive2.py
@@ -40,6 +40,7 @@ from ctypes import POINTER
 from ctypes import create_string_buffer
 
 from commoncode import command
+from commoncode import compat
 from commoncode import fileutils
 from commoncode import paths
 
@@ -346,7 +347,7 @@ class Entry(object):
         path = func(self.entry_struct)
         if not path:
             path = func_w(self.entry_struct)
-        if isinstance(path, unicode):
+        if isinstance(path, compat.unicode):
             # FIXME: encoding MAY fail if the encoding is NOT UTF-8!
             # .... should we transliterate there?
             path = path.encode('utf-8')

--- a/src/formattedcode/output_csv.py
+++ b/src/formattedcode/output_csv.py
@@ -31,21 +31,13 @@ from collections import OrderedDict
 
 import unicodecsv
 
+from commoncode import compat
 from plugincode.output import output_impl
 from plugincode.output import OutputPlugin
 from scancode import CommandLineOption
 from scancode import FileOptionType
 from scancode import OUTPUT_GROUP
-
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
-    basestring = str  # NOQA
+from commoncode.compat import string_types
 
 
 # Tracing flags
@@ -65,7 +57,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode)
+        return logger.debug(' '.join(isinstance(a, compat.string_types)
                                      and a or repr(a) for a in args))
 
 
@@ -307,7 +299,7 @@ def flatten_package(_package, path, prefix='package__'):
                     if isinstance(component_val, list):
                         component_val = '\n'.join(component_val)
 
-                    if not isinstance(component_val, str):
+                    if not isinstance(component_val, string_types):
                         component_val = repr(component_val)
 
                     existing = pack.get(component_new_key) or []
@@ -325,7 +317,7 @@ def flatten_package(_package, path, prefix='package__'):
 
         pack[nk] = ''
 
-        if isinstance(val, basestring):
+        if isinstance(val, compat.string_types):
             pack[nk] = val
         else:
             # Use repr if not a string

--- a/src/formattedcode/output_html.py
+++ b/src/formattedcode/output_html.py
@@ -54,6 +54,7 @@ from plugincode.output import OutputPlugin
 from scancode import CommandLineOption
 from scancode import FileOptionType
 from scancode import OUTPUT_GROUP
+from commoncode import compat
 
 """
 Output plugins to write scan results using templates such as HTML.
@@ -136,7 +137,7 @@ def write_templated(output_file, results, version, template_loc):
     template = get_template(template_loc)
 
     for template_chunk in generate_output(results, version, template):
-        assert isinstance(template_chunk, unicode)
+        assert isinstance(template_chunk, compat.unicode)
         try:
             output_file.write(template_chunk)
         except Exception:

--- a/src/formattedcode/output_json.py
+++ b/src/formattedcode/output_json.py
@@ -35,6 +35,7 @@ from plugincode.output import OutputPlugin
 from scancode import CommandLineOption
 from scancode import FileOptionType
 from scancode import OUTPUT_GROUP
+from commoncode import compat
 
 """
 Output plugins to write scan results as JSON.
@@ -57,7 +58,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode)
+        return logger.debug(' '.join(isinstance(a, compat.string_types)
                                      and a or repr(a) for a in args))
 
 

--- a/src/formattedcode/output_spdx.py
+++ b/src/formattedcode/output_spdx.py
@@ -50,16 +50,6 @@ from scancode import CommandLineOption
 from scancode import FileOptionType
 from scancode import OUTPUT_GROUP
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str_orig = str
-    bytes = str  # NOQA
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
 
 # Tracing flags
 TRACE = False
@@ -78,7 +68,7 @@ if TRACE or TRACE_DEEP:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode)
+        return logger.debug(' '.join(isinstance(a, compat.string_types)
                                      and a or repr(a) for a in args))
 
 """

--- a/src/licensedcode/index.py
+++ b/src/licensedcode/index.py
@@ -45,6 +45,7 @@ except ImportError:
 
 from intbitset import intbitset
 
+from commoncode import compat
 from commoncode.dict_utils import sparsify
 from licensedcode import MAX_DIST
 from licensedcode import SMALL_RULE
@@ -97,7 +98,7 @@ if (TRACE or TRACE_MATCHES or TRACE_NEGATIVE
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, basestring) and a or repr(a)
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a)
                                      for a in args))
 
 

--- a/src/licensedcode/match.py
+++ b/src/licensedcode/match.py
@@ -36,6 +36,7 @@ from licensedcode import query
 from licensedcode.spans import Span
 from licensedcode.stopwords import STOPWORDS
 from licensedcode.tokenize import matched_query_text_tokenizer
+from commoncode import compat
 
 
 """
@@ -87,7 +88,7 @@ if (TRACE
     logger = logging.getLogger(__name__)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, basestring) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
     logging.basicConfig(stream=sys.stdout)
     logger.setLevel(logging.DEBUG)

--- a/src/licensedcode/match_aho.py
+++ b/src/licensedcode/match_aho.py
@@ -30,6 +30,7 @@ from itertools import groupby
 
 import ahocorasick
 
+from commoncode import compat
 from licensedcode import SMALL_RULE
 from licensedcode.match import LicenseMatch
 from licensedcode.spans import Span
@@ -50,7 +51,7 @@ if TRACE or TRACE_FRAG:
     logger = logging.getLogger(__name__)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, basestring) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
     logging.basicConfig(stream=sys.stdout)
     logger.setLevel(logging.DEBUG)

--- a/src/licensedcode/match_hash.py
+++ b/src/licensedcode/match_hash.py
@@ -29,6 +29,7 @@ from hashlib import md5
 
 from licensedcode.spans import Span
 from licensedcode.match import LicenseMatch
+from commoncode import compat
 
 """
 Matching strategy using hashes to match a whole text chunk at once.
@@ -44,7 +45,7 @@ if TRACE :
     logger = logging.getLogger(__name__)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, basestring) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
     # logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
     logging.basicConfig(stream=sys.stdout)

--- a/src/licensedcode/match_seq.py
+++ b/src/licensedcode/match_seq.py
@@ -31,6 +31,7 @@ import sys
 
 from licensedcode.match import LicenseMatch
 from licensedcode.spans import Span
+from commoncode import compat
 
 
 TRACE = False
@@ -47,7 +48,7 @@ if TRACE or TRACE2 or TRACE3:
     logger = logging.getLogger(__name__)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, basestring) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
     logging.basicConfig(stream=sys.stdout)
     logger.setLevel(logging.DEBUG)

--- a/src/licensedcode/match_set.py
+++ b/src/licensedcode/match_set.py
@@ -36,6 +36,8 @@ from intbitset import intbitset
 from commoncode.dict_utils import sparsify
 from licensedcode.tokenize import ngrams
 
+from commoncode import compat
+
 
 """
 Approximate matching strategies using token sets and multisets.
@@ -124,7 +126,7 @@ if (TRACE or TRACE_CANDIDATES or
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, basestring) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 
 def tids_sets_intersector(qset, iset):

--- a/src/licensedcode/match_spdx_lid.py
+++ b/src/licensedcode/match_spdx_lid.py
@@ -37,6 +37,7 @@ from license_expression import LicenseSymbol
 from license_expression import LicenseWithExceptionSymbol
 from license_expression import Licensing
 
+from commoncode import compat
 from licensedcode.match import LicenseMatch
 from licensedcode.models import SpdxRule
 from licensedcode.spans import Span
@@ -62,7 +63,7 @@ if TRACE or os.environ.get('SCANCODE_DEBUG_LICENSE'):
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, basestring) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 MATCH_SPDX_ID = '1-spdx-id'
 

--- a/src/licensedcode/plugin_license_text.py
+++ b/src/licensedcode/plugin_license_text.py
@@ -33,6 +33,7 @@ from plugincode.post_scan import PostScanPlugin
 from plugincode.post_scan import post_scan_impl
 from scancode import CommandLineOption
 from scancode import POST_SCAN_GROUP
+from commoncode import compat
 
 
 # Set to True to enable debug tracing
@@ -45,7 +46,7 @@ if TRACE:
     logger = logging.getLogger(__name__)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, basestring) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
     logging.basicConfig(stream=sys.stdout)
     logger.setLevel(logging.DEBUG)

--- a/src/licensedcode/query.py
+++ b/src/licensedcode/query.py
@@ -39,6 +39,7 @@ from commoncode.text import toascii
 from licensedcode.spans import Span
 from licensedcode.tokenize import query_lines
 from licensedcode.tokenize import query_tokenizer
+from commoncode import compat
 
 """
 Build license queries from scanned files to feed the detection pipeline.
@@ -104,7 +105,7 @@ if TRACE or TRACE_QR or TRACE_QR_BREAK or TRACE_SPDX:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, basestring) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 # for the cases of very long lines, we break in abritrary pseudo lines at 25
 # tokens to avoid getting huge query runs for texts on a single line (e.g.

--- a/src/licensedcode/spans.py
+++ b/src/licensedcode/spans.py
@@ -32,6 +32,7 @@ from __future__ import division
 from __future__ import print_function
 
 from collections import Set
+from commoncode import compat
 from itertools import count
 from itertools import groupby
 
@@ -107,7 +108,7 @@ class Span(Set):
 
         elif len_args == 1:
             # args0 is a single int or an iterable of ints
-            if isinstance(args[0], (int, long)):
+            if isinstance(args[0], compat.integer_types):
                 self._set = intbitset(args)
             else:
                 # some sequence or iterable
@@ -204,7 +205,7 @@ class Span(Set):
         if isinstance(other, Span):
             return self._set.issuperset(other._set)
 
-        if isinstance(other, (int, long)):
+        if isinstance(other, compat.integer_types):
             return self._set.__contains__(other)
 
         if isinstance(other, (set, frozenset)):

--- a/src/packagedcode/jar_manifest.py
+++ b/src/packagedcode/jar_manifest.py
@@ -37,17 +37,6 @@ from packagedcode.maven import parse_scm_connection
 from packagedcode.models import Package
 
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str_orig = str
-    bytes = str  # NOQA
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
-
 
 """
 A JAR/WAR/EAR and OSGi MANIFEST.MF parser and handler.

--- a/src/packagedcode/models.py
+++ b/src/packagedcode/models.py
@@ -35,6 +35,7 @@ from attr.validators import in_ as choices
 from packageurl import normalize_qualifiers
 from packageurl import PackageURL
 
+from commoncode import compat
 from commoncode.datautils import Boolean
 from commoncode.datautils import Date
 from commoncode.datautils import Integer
@@ -42,18 +43,6 @@ from commoncode.datautils import List
 from commoncode.datautils import Mapping
 from commoncode.datautils import String
 from commoncode.datautils import TriBoolean
-
-
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str_orig = str
-    bytes = str  # NOQA
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
 
 
 """
@@ -99,7 +88,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, (bytes, str)) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 
 

--- a/src/packagedcode/nuget.py
+++ b/src/packagedcode/nuget.py
@@ -31,15 +31,7 @@ import xmltodict
 
 from packagedcode import models
 from packagedcode.utils import build_description
-
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
+from commoncode import compat
 
 # TODO: add dependencies
 
@@ -64,7 +56,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, (str, unicode)) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 
 @attr.s()

--- a/src/packagedcode/win_pe.py
+++ b/src/packagedcode/win_pe.py
@@ -34,6 +34,7 @@ from commoncode import text
 from typecode import contenttype
 from contextlib import closing
 from collections import OrderedDict
+from commoncode import compat
 
 
 TRACE = False
@@ -163,7 +164,7 @@ def pe_info(location, include_extra_data=False):
 
             for k, v in strtab.entries.items():
                 # convert unicode to a safe ASCII representation
-                value = unicode(text.toascii(v).strip())
+                value = compat.unicode(text.toascii(v).strip())
                 if k in PE_INFO_KEYSET:
                     peinf[k] = value
                 else:

--- a/src/plugincode/location_provider.py
+++ b/src/plugincode/location_provider.py
@@ -36,6 +36,7 @@ from pluggy import PluginManager as PluggyPluginManager
 
 from plugincode import HookimplMarker
 from plugincode import HookspecMarker
+from commoncode import compat
 
 
 
@@ -56,7 +57,7 @@ logger = logging.getLogger(__name__)
 # logger.setLevel(logging.DEBUG)
 
 def logger_debug(*args):
-    return logger.debug(' '.join(isinstance(a, (unicode, str)) and a or repr(a) for a in args))
+    return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 
 project_name = __name__

--- a/src/plugincode/output.py
+++ b/src/plugincode/output.py
@@ -37,22 +37,13 @@ except ImportError:
         # Python 3
         pass
 
+from commoncode import compat
 from plugincode import CodebasePlugin
 from plugincode import PluginManager
 from plugincode import HookimplMarker
 from plugincode import HookspecMarker
 from scancode.resource import Resource
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str_orig = str
-    bytes = str  # NOQA
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
 
 # Tracing flags
 TRACE = False
@@ -72,7 +63,7 @@ if TRACE or TRACE_DEEP:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode)
+        return logger.debug(' '.join(isinstance(a, compat.string_types)
                                      and a or repr(a) for a in args))
 
 stage = 'output'

--- a/src/scancode/__init__.py
+++ b/src/scancode/__init__.py
@@ -41,16 +41,6 @@ from click.types import BoolParamType
 
 from commoncode import fileutils
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str_orig = str
-    bytes = str  # NOQA
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
 
 # Tracing flags
 TRACE = False
@@ -68,7 +58,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, (unicode, str))
+        return logger.debug(' '.join(isinstance(a, compat.string_types)
                                      and a or repr(a) for a in args))
 
 

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -56,6 +56,7 @@ click.disable_unicode_literals_warning = True
 # import early
 from scancode_config import __version__ as scancode_version
 
+from commoncode import compat
 from commoncode.fileutils import as_posixpath
 from commoncode.fileutils import PATH_TYPE
 from commoncode.fileutils import POSIX_PATH_SEP
@@ -100,18 +101,6 @@ from scancode.utils import path_progress_message
 from scancode.utils import progressmanager
 
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str_orig = str
-    bytes = str  # NOQA
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
-
-
 # Tracing flags
 TRACE = False
 TRACE_DEEP = False
@@ -129,7 +118,7 @@ if TRACE or TRACE_DEEP:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode)
+        return logger.debug(' '.join(isinstance(a, compat.string_types)
                                      and a or repr(a) for a in args))
 
 echo_stderr = partial(click.secho, err=True)
@@ -539,7 +528,7 @@ def run_scan(
 
     if not isinstance(input, (list, tuple)):
         # nothing else todo
-        assert isinstance(input, (bytes, unicode))
+        assert isinstance(input, compat.string_types)
 
     elif len(input) == 1:
         # we received a single input path, so we treat this as a single path
@@ -1513,7 +1502,7 @@ def get_pretty_params(ctx, generic_paths=False):
 
         # coerce to string for non-basic supported types
         if not (value in (True, False, None)
-            or isinstance(value, (str, unicode, bytes, tuple, list, dict, OrderedDict))):
+            or isinstance(value, (str, compat.string_types, bytes, tuple, list, dict, OrderedDict))):
             value = repr(value)
 
         # opts is a list of CLI options as in "--strip-root": the last opt is

--- a/src/scancode/extract_cli.py
+++ b/src/scancode/extract_cli.py
@@ -32,6 +32,7 @@ import os
 import click
 click.disable_unicode_literals_warning = True
 
+from commoncode import compat
 from commoncode import fileutils
 from commoncode import filetype
 from commoncode.text import toascii
@@ -41,14 +42,6 @@ from scancode.api import extract_archives
 from scancode import print_about
 from scancode import utils
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
 
 echo_stderr = partial(click.secho, err=True)
 
@@ -119,7 +112,7 @@ def extractcode(ctx, input, verbose, quiet, shallow, *args, **kwargs):  # NOQA
         if not item:
             return ''
         source = item.source
-        if not isinstance(source, unicode):
+        if not isinstance(source, compat.unicode):
             source = toascii(source, translit=True).decode('utf-8', 'replace')
         if verbose:
             if item.done:
@@ -127,7 +120,7 @@ def extractcode(ctx, input, verbose, quiet, shallow, *args, **kwargs):  # NOQA
             line = source and get_relative_path(path=source, len_base_path=len_base_path, base_is_dir=base_is_dir) or ''
         else:
             line = source and fileutils.file_name(source) or ''
-        if not isinstance(line, unicode):
+        if not isinstance(line, compat.unicode):
             line = toascii(line, translit=True).decode('utf-8', 'replace')
         return 'Extracting: %(line)s' % locals()
 
@@ -142,7 +135,7 @@ def extractcode(ctx, input, verbose, quiet, shallow, *args, **kwargs):  # NOQA
             has_errors = has_errors or bool(xev.errors)
             has_warnings = has_warnings or bool(xev.warnings)
             source = fileutils.as_posixpath(xev.source)
-            if not isinstance(source, unicode):
+            if not isinstance(source, compat.unicode):
                 source = toascii(source, translit=True).decode('utf-8', 'replace')
                 source = get_relative_path(path=source, len_base_path=len_base_path, base_is_dir=base_is_dir)
             for e in xev.errors:

--- a/src/scancode/plugin_ignore.py
+++ b/src/scancode/plugin_ignore.py
@@ -32,6 +32,7 @@ from plugincode.pre_scan import PreScanPlugin
 from plugincode.pre_scan import pre_scan_impl
 from scancode import CommandLineOption
 from scancode import PRE_SCAN_GROUP
+from commoncode import compat
 
 
 # Tracing flags
@@ -53,7 +54,7 @@ if TRACE:
 
     def logger_debug(*args):
         return logger.debug(
-            ' '.join(isinstance(a, unicode) and a or repr(a) for a in args))
+            ' '.join(isinstance(a, compat.unicode) and a or repr(a) for a in args))
 
 
 @pre_scan_impl

--- a/src/scancode/resource.py
+++ b/src/scancode/resource.py
@@ -53,6 +53,7 @@ except ImportError:
     import tempfile
     temp_dir = tempfile.mkdtemp(prefix='scancode-resource-cache')
 
+from commoncode import compat
 from commoncode.datautils import List
 from commoncode.datautils import Mapping
 from commoncode.datautils import String
@@ -75,16 +76,6 @@ from commoncode.fileutils import splitext_name
 from commoncode import ignore
 from commoncode.system import on_linux
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str_orig = str
-    bytes = str  # NOQA
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
 
 """
 This module provides Codebase and Resource objects as an abstraction for files
@@ -117,7 +108,7 @@ if TRACE or TRACE_DEEP:
 
     def logger_debug(*args):
         return logger.debug(
-            ' '.join(isinstance(a, unicode) and a or repr(a) for a in args))
+            ' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 
 class ResourceNotInCache(Exception):

--- a/src/scancode/utils.py
+++ b/src/scancode/utils.py
@@ -33,20 +33,11 @@ from click.utils import echo
 from click.termui import style
 from click._termui_impl import ProgressBar
 
+from commoncode import compat
 from commoncode.fileutils import file_name
 from commoncode.fileutils import splitext
 from commoncode.text import toascii
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str_orig = str
-    bytes = str  # NOQA
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
 
 """
 Command line UI utilities for help and and progress reporting.
@@ -232,7 +223,7 @@ def path_progress_message(item, verbose=False, prefix='Scanned: '):
         return ''
     location = item[0]
     errors = item[2]
-    location = unicode(toascii(location))
+    location = compat.unicode(toascii(location))
     progress_line = location
     if not verbose:
         max_file_name_len = file_name_max_len()

--- a/src/summarycode/classify.py
+++ b/src/summarycode/classify.py
@@ -29,6 +29,7 @@ from __future__ import unicode_literals
 
 from collections import OrderedDict
 
+from commoncode import compat
 from commoncode.datautils import Boolean
 from commoncode.fileset import get_matches
 from plugincode.pre_scan import PreScanPlugin
@@ -71,7 +72,7 @@ if TRACE:
 
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 
 @pre_scan_impl

--- a/src/summarycode/copyright_summary.py
+++ b/src/summarycode/copyright_summary.py
@@ -35,6 +35,7 @@ import fingerprints
 from text_unidecode import unidecode
 
 from cluecode.copyrights import CopyrightDetector
+from commoncode import compat
 from commoncode.text import toascii
 from summarycode.utils import sorted_counter
 from summarycode.utils import get_resource_summary
@@ -61,7 +62,7 @@ if TRACE or TRACE_CANO:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 # TODO: keep the original order of statements as much as possible
 

--- a/src/summarycode/facet.py
+++ b/src/summarycode/facet.py
@@ -31,6 +31,7 @@ import attr
 import click
 
 from commoncode.fileset import get_matches as get_fileset_matches
+from commoncode import compat
 from plugincode.pre_scan import PreScanPlugin
 from plugincode.pre_scan import pre_scan_impl
 from scancode import CommandLineOption
@@ -53,7 +54,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 """
 Assign a facet to a file.

--- a/src/summarycode/generated.py
+++ b/src/summarycode/generated.py
@@ -29,6 +29,7 @@ from __future__ import unicode_literals
 
 from itertools import islice
 
+from commoncode import compat
 from commoncode.datautils import Boolean
 from commoncode.text import toascii
 from plugincode.scan import ScanPlugin
@@ -58,7 +59,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 
 @scan_impl

--- a/src/summarycode/score.py
+++ b/src/summarycode/score.py
@@ -33,6 +33,7 @@ from itertools import chain
 import attr
 from license_expression import Licensing
 
+from commoncode import compat
 from commoncode.datautils import Mapping
 from licensedcode.cache import get_licenses_db
 from licensedcode import models
@@ -60,7 +61,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 """
 A plugin to compute a licensing clarity score as designed in ClearlyDefined

--- a/src/summarycode/summarizer.py
+++ b/src/summarycode/summarizer.py
@@ -32,6 +32,7 @@ from collections import OrderedDict
 
 import attr
 
+from commoncode import compat
 from plugincode.post_scan import PostScanPlugin
 from plugincode.post_scan import post_scan_impl
 from scancode import CommandLineOption
@@ -58,7 +59,7 @@ if TRACE or TRACE_LIGHT:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 """
 top_level:

--- a/src/textcode/analysis.py
+++ b/src/textcode/analysis.py
@@ -34,6 +34,7 @@ import unicodedata
 
 import chardet
 
+from commoncode import compat
 from commoncode.system import on_linux
 from textcode import pdf
 from textcode import markup
@@ -65,7 +66,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 
 def numbered_text_lines(location, demarkup=False, plain_text=False):
@@ -88,7 +89,7 @@ def numbered_text_lines(location, demarkup=False, plain_text=False):
     if not location:
         return iter([])
 
-    if not isinstance(location, basestring):
+    if not isinstance(location, compat.string_types):
         # not a path: wrap an iterator on location which should be a sequence
         # of lines
         if TRACE:
@@ -248,7 +249,7 @@ def as_unicode(line):
 
     TODO: Add file/magic detection, unicodedmanit/BS3/4
     """
-    if isinstance(line, unicode):
+    if isinstance(line, compat.unicode):
         return line
     try:
         s = line.decode('UTF-8')
@@ -268,7 +269,7 @@ def as_unicode(line):
             except UnicodeDecodeError:
                 try:
                     enc = chardet.detect(line)['encoding']
-                    s = unicode(line, enc)
+                    s = compat.unicode(line, enc)
                 except UnicodeDecodeError:
                     # fall-back to strings extraction if all else fails
                     s = strings.string_from_string(s)

--- a/src/typecode/contenttype.py
+++ b/src/typecode/contenttype.py
@@ -54,6 +54,8 @@ from typecode.pygments_lexers import guess_lexer
 from typecode import magic2
 from typecode import entropy
 from commoncode.datautils import String
+from commoncode import compat
+
 
 """
 Utilities to detect and report the type of a file or path based on its name,
@@ -77,7 +79,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, unicode) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 
 
@@ -96,13 +98,13 @@ PLAIN_TEXT_EXTENSIONS = ('.rst', '.rest', '.txt', '.md',
                         # are probably more.
                          '.log')
 if not on_linux:
-    PLAIN_TEXT_EXTENSIONS = tuple(unicode(e) for e in PLAIN_TEXT_EXTENSIONS)
+    PLAIN_TEXT_EXTENSIONS = tuple(compat.unicode(e) for e in PLAIN_TEXT_EXTENSIONS)
 
 C_EXTENSIONS = set(['.c', '.cc', '.cp', '.cpp', '.cxx', '.c++', '.h', '.hh',
                     '.s', '.asm', '.hpp', '.hxx', '.h++', '.i', '.ii', '.m'])
 
 if not on_linux:
-    C_EXTENSIONS = set(unicode(e) for e in C_EXTENSIONS)
+    C_EXTENSIONS = set(compat.unicode(e) for e in C_EXTENSIONS)
 
 ELF_EXE = 'executable'
 ELF_SHARED = 'shared object'

--- a/tests/cluecode/test_copyrights.py
+++ b/tests/cluecode/test_copyrights.py
@@ -31,13 +31,6 @@ from commoncode.testcase import FileBasedTesting
 from cluecode_test_utils import build_tests
 from cluecode_test_utils import load_copyright_tests
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
 
 
 import pytest

--- a/tests/commoncode/test_command.py
+++ b/tests/commoncode/test_command.py
@@ -32,6 +32,7 @@ from unittest.case import skipIf
 from commoncode.system import on_linux
 from commoncode.system import on_mac
 from commoncode.system import on_windows
+from commoncode import compat
 
 
 class TestCommand(FileBasedTesting):
@@ -48,7 +49,7 @@ class TestCommand(FileBasedTesting):
         # converting to Unicode could cause an "ordinal not in range..."
         # exception
         assert stdout == b'non ascii:  just passed it !'
-        unicode(stdout)
+        compat.unicode(stdout)
 
     @skipIf(not on_linux, 'Linux only')
     def test_update_path_environment_linux_from_bytes(self):

--- a/tests/commoncode/test_fileutils.py
+++ b/tests/commoncode/test_fileutils.py
@@ -43,6 +43,7 @@ from commoncode.testcase import FileBasedTesting
 from commoncode.testcase import make_non_executable
 from commoncode.testcase import make_non_readable
 from commoncode.testcase import make_non_writable
+from commoncode import compat
 
 
 class TestPermissions(FileBasedTesting):
@@ -301,11 +302,11 @@ class TestFileUtilsWalk(FileBasedTesting):
         test_dir = self.extract_test_zip('fileutils/walk/unicode.zip')
         test_dir = join(test_dir, 'unicode')
 
-        test_dir = unicode(test_dir)
+        test_dir = compat.unicode(test_dir)
         result = list(os.walk(test_dir))
         expected = [
-            (unicode(test_dir), ['a'], [u'2.csv']),
-            (unicode(test_dir) + sep + 'a', [], [u'gru\u0308n.png'])
+            (compat.unicode(test_dir), ['a'], [u'2.csv']),
+            (compat.unicode(test_dir) + sep + 'a', [], [u'gru\u0308n.png'])
         ]
         assert expected == result
 
@@ -326,7 +327,7 @@ class TestFileUtilsWalk(FileBasedTesting):
         test_dir = join(test_dir, 'unicode')
 
         if on_linux:
-            test_dir = unicode(test_dir)
+            test_dir = compat.unicode(test_dir)
         result = list(x[-1] for x in fileutils.walk(test_dir))
         if on_linux:
             expected = [['2.csv'], ['gru\xcc\x88n.png']]
@@ -365,7 +366,7 @@ class TestFileUtilsWalk(FileBasedTesting):
         test_dir = join(test_dir, 'non_unicode')
 
         if not on_linux:
-            test_dir = unicode(test_dir)
+            test_dir = compat.unicode(test_dir)
         result = list(os.walk(test_dir))[0]
         _dirpath, _dirnames, filenames = result
         assert 18 == len(filenames)
@@ -461,11 +462,11 @@ class TestFileUtilsIter(FileBasedTesting):
         if on_linux:
             assert all(isinstance(p, bytes) for p in result)
         else:
-            assert all(isinstance(p, unicode) for p in result)
+            assert all(isinstance(p, compat.unicode) for p in result)
 
     def test_resource_iter_return_unicode_on_unicode_input(self):
         test_dir = self.get_test_loc('fileutils/walk')
-        base = unicode(self.get_test_loc('fileutils'))
+        base = compat.unicode(self.get_test_loc('fileutils'))
         result = sorted([as_posixpath(f.replace(base, ''))
                          for f in fileutils.resource_iter(test_dir, with_dirs=True)])
         expected = [
@@ -479,7 +480,7 @@ class TestFileUtilsIter(FileBasedTesting):
             u'/walk/unicode.zip'
         ]
         assert sorted(expected) == sorted(result)
-        assert all(isinstance(p, unicode) for p in result)
+        assert all(isinstance(p, compat.unicode) for p in result)
 
     def test_resource_iter_can_walk_unicode_path_with_zip(self):
         test_dir = self.extract_test_zip('fileutils/walk/unicode.zip')
@@ -488,7 +489,7 @@ class TestFileUtilsIter(FileBasedTesting):
         if on_linux:
             EMPTY_STRING = ''
         else:
-            test_dir = unicode(test_dir)
+            test_dir = compat.unicode(test_dir)
             EMPTY_STRING = u''
 
         result = sorted([p.replace(test_dir, EMPTY_STRING) for p in fileutils.resource_iter(test_dir)])
@@ -517,7 +518,7 @@ class TestFileUtilsIter(FileBasedTesting):
         test_dir = join(test_dir, 'non_unicode')
 
         if not on_linux:
-            test_dir = unicode(test_dir)
+            test_dir = compat.unicode(test_dir)
         result = list(fileutils.resource_iter(test_dir, with_dirs=True))
         assert 18 == len(result)
 
@@ -526,7 +527,7 @@ class TestFileUtilsIter(FileBasedTesting):
         test_dir = join(test_dir, 'non_unicode')
 
         if not on_linux:
-            test_dir = unicode(test_dir)
+            test_dir = compat.unicode(test_dir)
         result = list(fileutils.resource_iter(test_dir, with_dirs=False))
         assert 18 == len(result)
 

--- a/tests/extractcode/test_archive.py
+++ b/tests/extractcode/test_archive.py
@@ -35,6 +35,7 @@ from unittest.case import skipIf
 
 import commoncode.date
 from commoncode.testcase import FileBasedTesting
+from commoncode import compat
 from commoncode import filetype
 from commoncode import fileutils
 from commoncode.system import on_linux
@@ -1907,7 +1908,7 @@ class TestRar(BaseArchiveTestCase):
     def test_extract_rar_with_non_ascii_path(self):
         test_file = self.get_test_loc('archive/rar/non_ascii_corrupted.rar')
         # The bug only occurs if the path was given as Unicode
-        test_file = unicode(test_file)
+        test_file = compat.unicode(test_file)
         test_dir = self.get_temp_dir()
         # raise an exception but still extracts some
         expected = Exception('Prefix found')
@@ -2404,7 +2405,7 @@ def to_posix(path):
     the windows explorer (except as a UNC or share name). It will be a valid path
     everywhere in Python. It will not be valid for windows command line operations.
     """
-    is_unicode = isinstance(path, unicode)
+    is_unicode = isinstance(path, compat.unicode)
     ntpath_sep = is_unicode and u'\\' or '\\'
     posixpath_sep = is_unicode and u'/' or '/'
     if is_posixpath(path):
@@ -2425,8 +2426,8 @@ class ExtractArchiveWithIllegalFilenamesTestCase(BaseArchiveTestCase):
         listed in the `test_file.excepted` file exist in the extracted target
         directory. Regen expected file if True.
         """
-        if not isinstance(test_file, unicode):
-            test_file = unicode(test_file)
+        if not isinstance(test_file, compat.unicode):
+            test_file = compat.unicode(test_file)
         test_file = self.get_test_loc(test_file)
         test_dir = self.get_temp_dir()
         warnings = test_function(test_file, test_dir)
@@ -2438,7 +2439,7 @@ class ExtractArchiveWithIllegalFilenamesTestCase(BaseArchiveTestCase):
 
         len_test_dir = len(test_dir)
         extracted = sorted(path[len_test_dir:] for path in fileutils.resource_iter(test_dir, with_dirs=False))
-        extracted = [unicode(p) for p in extracted]
+        extracted = [compat.unicode(p) for p in extracted]
         extracted = [to_posix(p) for p in extracted]
 
         if on_linux:

--- a/tests/packagedcode/test_jar_manifest.py
+++ b/tests/packagedcode/test_jar_manifest.py
@@ -31,6 +31,7 @@ from collections import OrderedDict
 import json
 import os.path
 
+from commoncode import compat
 from commoncode import text
 from commoncode import testcase
 from packagedcode.jar_manifest import parse_manifest
@@ -115,7 +116,7 @@ def create_test_function(test_manifest_loc, test_name, check_parse=True, regen=F
 
     # set a proper function name to display in reports and use in discovery
     # function names are best as bytes
-    if isinstance(test_name, unicode):
+    if isinstance(test_name, compat.string_types):
         test_name = test_name.encode('utf-8')
     test_manifest.__name__ = test_name
     return test_manifest

--- a/tests/packagedcode/test_maven.py
+++ b/tests/packagedcode/test_maven.py
@@ -34,6 +34,7 @@ import os.path
 import attr
 import pytest
 
+from commoncode import compat
 from commoncode import fileutils
 from commoncode import text
 from commoncode import testcase
@@ -497,7 +498,7 @@ def create_test_function(test_pom_loc, test_name, check_pom=True, regen=False):
 
     # set a proper function name to display in reports and use in discovery
     # function names are best as bytes
-    if isinstance(test_name, unicode):
+    if isinstance(test_name, compat.string_types):
         test_name = test_name.encode('utf-8')
     test_pom.__name__ = test_name
     return test_pom

--- a/tests/packagedcode/test_rubygems.py
+++ b/tests/packagedcode/test_rubygems.py
@@ -34,6 +34,7 @@ from unittest.case import expectedFailure
 
 import saneyaml
 
+from commoncode import compat
 from commoncode import text
 from commoncode.testcase import FileBasedTesting
 from packagedcode import rubygems
@@ -145,7 +146,7 @@ def create_test_function(test_loc, test_name, regen=False):
 
     # set a proper function name to display in reports and use in discovery
     # function names are best as bytes
-    if isinstance(test_name, unicode):
+    if isinstance(test_name, compat.string_types):
         test_name = test_name.encode('utf-8')
     check_rubygem.__name__ = test_name
     return check_rubygem

--- a/tests/summarycode/test_score.py
+++ b/tests/summarycode/test_score.py
@@ -30,6 +30,7 @@ import os
 import click
 click.disable_unicode_literals_warning = True
 
+from commoncode import compat
 from commoncode.testcase import FileDrivenTesting
 from commoncode.text import python_safe_name
 
@@ -70,7 +71,7 @@ def make_test_function(test_name, test_dir, expected_file, regen=False):
 
     test_name = 'test_license_clarity_score_%(test_name)s' % locals()
     test_name = python_safe_name(test_name)
-    if isinstance(test_name, unicode):
+    if isinstance(test_name, compat.unicode):
         test_name = test_name.encode('utf-8')
 
     closure_test_function.__name__ = test_name


### PR DESCRIPTION
Unicode string literals are simply converted into string literals, which are always Unicode in Python 3. 
This PR also remove unused Python 2/3 compat imports. Unicode raw strings (in which Python does not auto-escape backslashes) are converted to raw strings. In Python 3, raw strings are always Unicode.

Signed-off-by: Abhishek Kumar <abhishek.kasyap09@gmail.com>