### PR TITLE
 Use 'str' or compat instead of 'basestring' on Python 3 #295

### DIFF
--- a/src/commoncode/fileutils.py
+++ b/src/commoncode/fileutils.py
@@ -26,14 +26,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-# Python 2 and 3 support
-try:
-    # Python 2
-    unicode
-    str = unicode  # NOQA
-except NameError:
-    # Python 3
-    unicode = str  # NOQA
+from commoncode import compat
 
 try:
     from os import fsencode
@@ -83,7 +76,7 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
 
     def logger_debug(*args):
-        return logger.debug(' '.join(isinstance(a, basestring) and a or repr(a) for a in args))
+        return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 # Paths can only be sanely handled as raw bytes on Linux
 PATH_TYPE = bytes if on_linux else unicode

--- a/src/commoncode/fileutils.py
+++ b/src/commoncode/fileutils.py
@@ -79,9 +79,7 @@ if TRACE:
         return logger.debug(' '.join(isinstance(a, compat.string_types) and a or repr(a) for a in args))
 
 # Paths can only be sanely handled as raw bytes on Linux
-PATH_TYPE = bytes if on_linux else unicode
-POSIX_PATH_SEP = b'/' if on_linux else '/'
-WIN_PATH_SEP = b'\\' if on_linux else '\\'
+
 
 if on_linux:
     PATH_TYPE = bytes 
@@ -89,20 +87,26 @@ if on_linux:
     WIN_PATH_SEP = b'\\'
     EMPTY_STRING = b''
     DOT = b'.'
+    if py2:
+        PATH_SEP = bytes(os.sep)
+        PATH_ENV_VAR = b'PATH'
+        PATH_ENV_SEP = bytes(os.pathsep)
+    else:
+        PATH_SEP = bytes(os.sep, encoding='utf-8')
+        PATH_ENV_VAR = 'PATH'
+        PATH_ENV_SEP = bytes(os.pathsep, encoding='utf-8')
+
 else:
     PATH_TYPE = unicode
     POSIX_PATH_SEP = '/'
     WIN_PATH_SEP = '\\'
     EMPTY_STRING = ''
     DOT = '.'
+    PATH_SEP = unicode(os.sep)
+    PATH_ENV_VAR = 'PATH'
+    PATH_ENV_SEP = unicode(os.pathsep)
 
 ALL_SEPS = POSIX_PATH_SEP + WIN_PATH_SEP
-EMPTY_STRING = b'' if on_linux else ''
-DOT = b'.' if on_linux else '.'
-if py2:
-   PATH_SEP = bytes(os.sep) if on_linux else unicode(os.sep)	
-else:
-   PATH_SEP = bytes(os.sep, encoding='utf-8') if on_linux else unicode(os.sep)
 
 """
 File, paths and directory utility functions.

--- a/src/typecode/entropy.py
+++ b/src/typecode/entropy.py
@@ -66,7 +66,7 @@ def gzip_entropy(s):
     compressed length to the original length. Because of overhead this
     does not gives great results on short strings.
     """
-    if not bytes:
+    if not s:
         return 0
 
     length = len(s)


### PR DESCRIPTION
Python 2 had two string types: Unicode and non-Unicode. But there was also another type: basestring.It was an abstract type, a superclass for both the str and unicode types. It couldn’t be called or instantiated directly, but you could pass it to the global isinstance() function to check whether an object was a Unicode or non-Unicode string. In Python 3, there is only one string type, so basestring has no reason to exist.

Signed-off-by: Abhishek Kumar abhishek.kasyap09@gmail.com