### PR TITLE
Adding Path.py as dependencies for porting path #295

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ setup(
         # Hack to support pip 8 (for those poor sods forced to use ubuntu 16.04's system pip)
         # See https://github.com/nexB/scancode-toolkit/issues/1463
         'more_itertools <  6.0.0; python_version == "2.7"',
+        'path.py',
         # end hack
 
         # cluecode


### PR DESCRIPTION
As Path.py supports both Python 2 and 3. No need to tackle with bytes and unicode on linux on both version of Python.

Signed-off-by: Abhishek Kumar <abhishek.kasyap09@gmail.com>