### PR TITLE
Use byte path only on Linux and Python 2 #295

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,9 +166,9 @@ jobs:
           python_versions: ['3.6']
           test_suites:
               commoncode: |
-                bin/py.test -vvs tests/commoncode/test_codec.py
-                bin/py.test -vvs tests/commoncode/test_fileutils.py
-                bin/py.test -vvs tests/commoncode/test_functional.py
+                bin/py.test -vvs tests/commoncode/test_codec.py \
+                    tests/commoncode/test_fileutils.py \
+                    tests/commoncode/test_functional.py
 
     - template: etc/ci/azure-mac.yml
       parameters:
@@ -177,9 +177,9 @@ jobs:
           python_versions: ['3.6']
           test_suites:
               commoncode: |
-                bin/py.test -vvs tests/commoncode/test_codec.py
-                bin/py.test -vvs tests/commoncode/test_fileutils.py
-                bin/py.test -vvs tests/commoncode/test_functional.py
+                bin/py.test -vvs tests/commoncode/test_codec.py \
+                    tests/commoncode/test_fileutils.py \
+                    tests/commoncode/test_functional.py
 
     - template: etc/ci/azure-mac.yml
       parameters:
@@ -188,9 +188,9 @@ jobs:
           python_versions: ['3.6']
           test_suites:
               commoncode: |
-                bin/py.test -vvs tests/commoncode/test_codec.py
-                bin/py.test -vvs tests/commoncode/test_fileutils.py
-                bin/py.test -vvs tests/commoncode/test_functional.py
+                bin/py.test -vvs tests/commoncode/test_codec.py \
+                    tests/commoncode/test_fileutils.py \
+                    tests/commoncode/test_functional.py
 
     - template: etc/ci/azure-win.yml
       parameters:
@@ -200,9 +200,7 @@ jobs:
           python_architecture: x86
           test_suites:
               commoncode: |
-                Scripts\py.test -vvs tests\commoncode\test_codec.py
-                Scripts\py.test -vvs tests\commoncode\test_fileutils.py
-                Scripts\py.test -vvs tests\commoncode\test_functional.py
+                Scripts\py.test -vvs tests\commoncode\test_codec.py tests\commoncode\test_fileutils.py tests\commoncode\test_functional.py
 
 
 ################################################################################
@@ -232,9 +230,9 @@ jobs:
           install_python: sudo apt-get install -y python3.6 python3.6-venv python3.6-dev
           test_suite_label: commoncode
           test_suite: |
-              bin/py.test -vvs tests/commoncode/test_codec.py
-              bin/py.test -vvs tests/commoncode/test_fileutils.py
-              bin/py.test -vvs tests/commoncode/test_functional.py
+                bin/py.test -vvs tests/commoncode/test_codec.py \
+                    tests/commoncode/test_fileutils.py \
+                    tests/commoncode/test_functional.py
 
 #    - template: etc/ci/azure-container-rpm.yml
 #      parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,6 +167,7 @@ jobs:
           test_suites:
               commoncode: |
                 bin/py.test -vvs tests/commoncode/test_codec.py
+                bin/py.test -vvs tests/commoncode/test_fileutils.py
                 bin/py.test -vvs tests/commoncode/test_functional.py
 
     - template: etc/ci/azure-mac.yml
@@ -177,6 +178,7 @@ jobs:
           test_suites:
               commoncode: |
                 bin/py.test -vvs tests/commoncode/test_codec.py
+                bin/py.test -vvs tests/commoncode/test_fileutils.py
                 bin/py.test -vvs tests/commoncode/test_functional.py
 
     - template: etc/ci/azure-mac.yml
@@ -187,6 +189,7 @@ jobs:
           test_suites:
               commoncode: |
                 bin/py.test -vvs tests/commoncode/test_codec.py
+                bin/py.test -vvs tests/commoncode/test_fileutils.py
                 bin/py.test -vvs tests/commoncode/test_functional.py
 
     - template: etc/ci/azure-win.yml
@@ -198,6 +201,7 @@ jobs:
           test_suites:
               commoncode: |
                 Scripts\py.test -vvs tests\commoncode\test_codec.py
+                Scripts\py.test -vvs tests\commoncode\test_fileutils.py
                 Scripts\py.test -vvs tests\commoncode\test_functional.py
 
 
@@ -229,6 +233,7 @@ jobs:
           test_suite_label: commoncode
           test_suite: |
               bin/py.test -vvs tests/commoncode/test_codec.py
+              bin/py.test -vvs tests/commoncode/test_fileutils.py
               bin/py.test -vvs tests/commoncode/test_functional.py
 
 #    - template: etc/ci/azure-container-rpm.yml

--- a/src/commoncode/fileutils.py
+++ b/src/commoncode/fileutils.py
@@ -97,14 +97,14 @@ if on_linux:
         PATH_ENV_SEP = bytes(os.pathsep, encoding='utf-8')
 
 else:
-    PATH_TYPE = unicode
+    PATH_TYPE = str
     POSIX_PATH_SEP = '/'
     WIN_PATH_SEP = '\\'
     EMPTY_STRING = ''
     DOT = '.'
-    PATH_SEP = unicode(os.sep)
+    PATH_SEP = str(os.sep)
     PATH_ENV_VAR = 'PATH'
-    PATH_ENV_SEP = unicode(os.pathsep)
+    PATH_ENV_SEP = str(os.pathsep)
 
 ALL_SEPS = POSIX_PATH_SEP + WIN_PATH_SEP
 

--- a/src/commoncode/fileutils.py
+++ b/src/commoncode/fileutils.py
@@ -172,7 +172,7 @@ def get_temp_dir(base_dir=scancode_temp_dir, prefix=''):
         if not base_dir:
             base_dir = tempfile.gettempdir()
         else:
-            if on_linux:
+            if on_linux and py2:
                 base_dir = fsencode(base_dir)
 
     if not os.path.exists(base_dir):
@@ -181,7 +181,7 @@ def get_temp_dir(base_dir=scancode_temp_dir, prefix=''):
     if not has_base:
         prefix = 'scancode-tk-'
 
-    if on_linux:
+    if on_linux and py2:
         prefix = fsencode(prefix)
 
     return tempfile.mkdtemp(prefix=prefix, dir=base_dir)

--- a/src/commoncode/testcase.py
+++ b/src/commoncode/testcase.py
@@ -46,6 +46,7 @@ from commoncode import filetype
 from commoncode.system import on_linux
 from commoncode.system import on_posix
 from commoncode.system import on_windows
+from commoncode.system import py2
 
 
 # a base test dir specific to a given test run
@@ -55,10 +56,10 @@ test_run_temp_dir = None
 # set to 1 to see the slow tests
 timing_threshold = sys.maxsize
 
-POSIX_PATH_SEP = b'/' if on_linux else '/'
-WIN_PATH_SEP = b'\\' if on_linux else '\\'
-EMPTY_STRING = b'' if on_linux else ''
-DOT = b'.' if on_linux else '.'
+POSIX_PATH_SEP = b'/' if on_linux and py2 else '/'
+WIN_PATH_SEP = b'\\' if on_linux and py2 else '\\'
+EMPTY_STRING = b'' if on_linux and py2 else ''
+DOT = b'.' if on_linux and py2 else '.'
 
 if on_windows:
     OS_PATH_SEP = WIN_PATH_SEP
@@ -70,7 +71,7 @@ def to_os_native_path(path):
     """
     Normalize a path to use the native OS path separator.
     """
-    if on_linux:
+    if on_linux and py2:
         path = fsencode(path)
     path = path.replace(POSIX_PATH_SEP, OS_PATH_SEP)
     path = path.replace(WIN_PATH_SEP, OS_PATH_SEP)
@@ -83,7 +84,7 @@ def get_test_loc(test_path, test_data_dir, debug=False, exists=True):
     Given a `test_path` relative to the `test_data_dir` directory, return the
     location to a test file or directory for this path. No copy is done.
     """
-    if on_linux:
+    if on_linux and py2:
         test_path = fsencode(test_path)
         test_data_dir = fsencode(test_data_dir)
 
@@ -124,7 +125,7 @@ class FileDrivenTesting(object):
         test location if `copy` is True.
         """
         test_data_dir = self.test_data_dir
-        if on_linux:
+        if on_linux and py2:
             test_path = fsencode(test_path)
             test_data_dir = fsencode(test_data_dir)
 
@@ -159,7 +160,7 @@ class FileDrivenTesting(object):
         if extension is None:
             extension = '.txt'
 
-        if on_linux:
+        if on_linux and py2:
             extension = fsencode(extension)
             dir_name = fsencode(dir_name)
             file_name = fsencode(file_name)
@@ -187,7 +188,7 @@ class FileDrivenTesting(object):
             # now we add a space in the path for testing path with spaces
             test_run_temp_dir = fileutils.get_temp_dir(
                 base_dir=test_tmp_root_dir, prefix='scancode-tk-tests -')
-        if on_linux:
+        if on_linux and py2:
             test_run_temp_dir = fsencode(test_run_temp_dir)
 
         test_run_temp_subdir = fileutils.get_temp_dir(
@@ -205,7 +206,7 @@ class FileDrivenTesting(object):
         Remove some version control directories and some temp editor files.
         """
         vcses = ('CVS', '.svn', '.git', '.hg')
-        if on_linux:
+        if on_linux and py2:
             vcses = tuple(fsencode(p) for p in vcses)
             test_dir = fsencode(test_dir)
 
@@ -219,7 +220,7 @@ class FileDrivenTesting(object):
                     shutil.rmtree(path.join(root, vcs_dir), False)
 
             # editors temp file leftovers
-            tilde = b'~' if on_linux else '~'
+            tilde = b'~' if on_linux and py2 else '~'
             map(os.remove, [path.join(root, file_loc)
                             for file_loc in files if file_loc.endswith(tilde)])
 
@@ -231,13 +232,13 @@ class FileDrivenTesting(object):
         If `verbatim` is True preserve the permissions.
         """
         assert test_path and test_path != ''
-        if on_linux:
+        if on_linux and py2:
             test_path = fsencode(test_path)
         test_path = to_os_native_path(test_path)
         target_path = path.basename(test_path)
         target_dir = self.get_temp_dir(target_path)
         original_archive = self.get_test_loc(test_path)
-        if on_linux:
+        if on_linux and py2:
             target_dir = fsencode(target_dir)
             original_archive = fsencode(original_archive)
         extract_func(original_archive, target_dir,
@@ -265,7 +266,7 @@ def _extract_tar_raw(test_path, target_dir, to_bytes, *args, **kwargs):
     Raw simplified extract for certain really weird paths and file
     names.
     """
-    if to_bytes:
+    if to_bytes and py2:
         # use bytes for paths on ALL OSes (though this may fail on macOS)
         target_dir = fsencode(target_dir)
         test_path = fsencode(test_path)
@@ -313,7 +314,7 @@ def extract_zip(location, target_dir, *args, **kwargs):
     if not path.isfile(location) and zipfile.is_zipfile(location):
         raise Exception('Incorrect zip file %(location)r' % locals())
 
-    if on_linux:
+    if on_linux and py2:
         location = fsencode(location)
         target_dir = fsencode(target_dir)
 
@@ -340,7 +341,7 @@ def extract_zip_raw(location, target_dir, *args, **kwargs):
     if not path.isfile(location) and zipfile.is_zipfile(location):
         raise Exception('Incorrect zip file %(location)r' % locals())
 
-    if on_linux:
+    if on_linux and py2:
         location = fsencode(location)
         target_dir = fsencode(target_dir)
 

--- a/tests/commoncode/test_fileutils.py
+++ b/tests/commoncode/test_fileutils.py
@@ -30,6 +30,7 @@ from os.path import join
 from os.path import sep
 from unittest.case import skipIf
 
+from commoncode import compat
 from commoncode import filetype
 from commoncode import fileutils
 from commoncode.fileutils import as_posixpath
@@ -40,11 +41,12 @@ from commoncode.system import on_posix
 from commoncode.system import on_mac
 from commoncode.system import on_macos_14_or_higher
 from commoncode.system import on_windows
+from commoncode.system import py2
 from commoncode.testcase import FileBasedTesting
 from commoncode.testcase import make_non_executable
 from commoncode.testcase import make_non_readable
 from commoncode.testcase import make_non_writable
-from commoncode import compat
+
 
 import pytest
 pytestmark = pytest.mark.scanpy3 #NOQA
@@ -371,7 +373,7 @@ class TestFileUtilsWalk(FileBasedTesting):
         test_dir = self.extract_test_tar_raw('fileutils/walk_non_utf8/non_unicode.tgz')
         test_dir = join(test_dir, 'non_unicode')
 
-        if not on_linux:
+        if not on_linux and py2:
             test_dir = compat.unicode(test_dir)
         result = list(os.walk(test_dir))[0]
         _dirpath, _dirnames, filenames = result

--- a/tests/commoncode/test_fileutils.py
+++ b/tests/commoncode/test_fileutils.py
@@ -46,6 +46,9 @@ from commoncode.testcase import make_non_readable
 from commoncode.testcase import make_non_writable
 from commoncode import compat
 
+import pytest
+pytestmark = pytest.mark.scanpy3 #NOQA
+
 
 class TestPermissions(FileBasedTesting):
     """
@@ -152,7 +155,7 @@ class TestPermissions(FileBasedTesting):
         src_file = self.get_temp_file()
         dest = self.get_temp_dir()
         with open(src_file, 'wb') as f:
-            f.write('')
+            f.write(b'')
         try:
             make_non_readable(src_file)
             if on_posix:


### PR DESCRIPTION
We now use bytes in commoncode.fileutils only if  on Linux and Python 2 and unicode everywhere else.

Signed-off-by: Abhishek Kumar <abhishek.kasyap09@gmail.com>
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>