### PR TITLE
Add an option to include the original matched license text

### DIFF
--- a/src/licensedcode/plugin_license.py
+++ b/src/licensedcode/plugin_license.py
@@ -87,6 +87,12 @@ class LicenseScanner(ScanPlugin):
             help='Include the detected licenses matched text.',
             help_group=SCAN_OPTIONS_GROUP),
 
+        CommandLineOption(('--origin-license-text',),
+            is_flag=True,
+            required_options=['license'],
+            help='Include the detected licenses matched text without highlighting.',
+            help_group=SCAN_OPTIONS_GROUP),
+
         CommandLineOption(('--license-url-template',),
             default=DEJACODE_LICENSE_URL, show_default=True,
             required_options=['license'],
@@ -121,9 +127,11 @@ class LicenseScanner(ScanPlugin):
 
     def get_scanner(self, license_score=0, license_text=False,
                     license_url_template=DEJACODE_LICENSE_URL,
-                    license_diag=False, **kwargs):
+                    license_diag=False, origin_license_text=False,
+                    **kwargs):
 
         from scancode.api import get_licenses
         return partial(get_licenses, min_score=license_score,
                        include_text=license_text, diag=license_diag,
-                       license_url_template=license_url_template)
+                       license_url_template=license_url_template,
+                       include_origin_text=origin_license_text)

--- a/src/scancode/api.py
+++ b/src/scancode/api.py
@@ -154,7 +154,8 @@ SPDX_LICENSE_URL = 'https://spdx.org/licenses/{}'
 
 def get_licenses(location, min_score=0, include_text=False,
                  license_url_template=DEJACODE_LICENSE_URL,
-                 deadline=sys.maxsize, **kwargs):
+                 deadline=sys.maxsize, include_origin_text=False,
+                 **kwargs):
     """
     Return a mapping or detected_licenses for licenses detected in the file at
     `location`
@@ -170,6 +171,8 @@ def get_licenses(location, min_score=0, include_text=False,
 
     if `include_text` is True, matched text is included in the returned
     `licenses` data.
+    if `include_origin_text` is True, matched text is included in the returned
+    `licenses` data without highlighting.
     """
     from licensedcode.cache import get_index
     from licensedcode.cache import get_licenses_db
@@ -185,6 +188,12 @@ def get_licenses(location, min_score=0, include_text=False,
         if include_text:
             # TODO: handle whole lines with the case of very long lines
             matched_text = match.matched_text(whole_lines=False)
+        if include_origin_text:
+            highlight_not_matched = highlight_matched = u'%s'
+            origin_matched_text = match.matched_text(
+                highlight_matched=highlight_matched,
+                highlight_not_matched=highlight_not_matched,
+                whole_lines=False)
 
         detected_expressions.append(match.rule.license_expression)
 
@@ -231,6 +240,8 @@ def get_licenses(location, min_score=0, include_text=False,
             # FIXME: for sanity this should always be included?????
             if include_text:
                 result['matched_text'] = matched_text
+            if include_origin_text:
+                result['origin_matched_text'] = origin_matched_text
 
     return OrderedDict([
         ('licenses', detected_licenses),

--- a/tests/licensedcode/test_match.py
+++ b/tests/licensedcode/test_match.py
@@ -915,6 +915,18 @@ class TestCollectLicenseMatchTexts(FileBasedTesting):
         matched_text = u''.join(get_full_matched_text(match, query_string=querys, idx=idx, _usecache=False))
         assert expected == matched_text
 
+        expected_origin_text = u"""Copyright 2003 (C) James. All Rights Reserved.
+            THIS IS FROM THE CODEHAUS AND CONTRIBUTORS
+            IN NO EVENT SHALL THE best CODEHAUS OR ITS CONTRIBUTORS BE LIABLE
+            EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. """
+        origin_matched_text = u''.join(get_full_matched_text(
+            match,
+            query_string=querys,
+            idx=idx,
+            highlight_not_matched=u'%s',
+        ))
+        assert expected_origin_text == origin_matched_text
+
     def test_get_full_matched_text(self):
         rule_text = u'''
             Copyright {{some copyright}}


### PR DESCRIPTION
Add an option to include the original matched license text so that there is no need to remove the highlighting marks from the scanning result if the user wants to get the original matched license text.