### PR TITLE
Add classifier of Python 3.6 and make universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [metadata]
 license_file = NOTICE
 

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setup(
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Utilities',
     ],
     keywords=[


### PR DESCRIPTION
Update classifiers to Python 3.6 in setup.py and make scancode's wheel universal. For more details visit https://packaging.python.org/guides/distributing-packages-using-setuptools/#id74

Signed-off-by: Abhishek Kashyap <mymac@Abhisheks-MacBook-Air.local>