### PR TITLE
Typecode libmagic system provided binaries plugin

### DIFF
--- a/plugins-builtin/typecode-libmagic-system_provided/setup.py
+++ b/plugins-builtin/typecode-libmagic-system_provided/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 desc = '''A ScanCode path provider plugin to provide a system package provided libmagic binary and database.'''
 
 setup(
-    name='typecode-libmagic',
+    name='typecode-libmagic-system-provided',
     version='5.22.1',
     license='bsd-simplified',
     description=desc,


### PR DESCRIPTION
This is the distro clubbed plugins which provide the path to the system package installed binaries.And the name of these does not overlap  with the original plugins.
Signed-off-by: aj4ayushjain <aj4ayushjain@gmail.com>