### PR TITLE
Add missing imports #1718 #1735

### DIFF
--- a/src/packagedcode/plugin_package.py
+++ b/src/packagedcode/plugin_package.py
@@ -28,6 +28,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import attr
+import os.path
 
 import click
 click.disable_unicode_literals_warning = True
@@ -37,6 +38,7 @@ from plugincode.scan import scan_impl
 from scancode import CommandLineOption
 from scancode import DOC_GROUP
 from scancode import SCAN_GROUP
+from commoncode.fileutils import parent_directory
 
 from packagedcode import PACKAGE_TYPES
 


### PR DESCRIPTION
As mentioned in the issue #1718 , manifest_path was showing null after the scan.
It was because the `os.path` and `parent_directory` that are being used to get the `manifest_path` were imported. 