### PR TITLE
Remove RCS from list of VCS names to ignore #1748

### DIFF
--- a/src/commoncode/ignore.py
+++ b/src/commoncode/ignore.py
@@ -202,7 +202,6 @@ ignores_VCS = {
 
     'CVS': 'Default ignore: CVS artifact',
     '.cvsignore': 'Default ignore: CVS config artifact',
-    '*/RCS': 'Default ignore: CVS artifact',
     '*/SCCS': 'Default ignore: CVS artifact',
 
     '*/_MTN': 'Default ignore: Monotone artifact',


### PR DESCRIPTION
This just removes `RCS` from the list of VCS-related directory names in `commoncode/ignore.py`

Let me know if anything else should be removed also