### PR TITLE
Yield multiple packages #1771

### DIFF
--- a/src/packagedcode/about.py
+++ b/src/packagedcode/about.py
@@ -55,7 +55,7 @@ class AboutPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/bower.py
+++ b/src/packagedcode/bower.py
@@ -59,7 +59,7 @@ class BowerPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/build.py
+++ b/src/packagedcode/build.py
@@ -69,7 +69,7 @@ class BaseBuildManifestPackage(models.Package):
         # declared_license = None
         # there is are dependencies we could use
         # dependencies = []
-        return cls(
+        yield cls(
             name=name,
             version=version)
 

--- a/src/packagedcode/cargo.py
+++ b/src/packagedcode/cargo.py
@@ -63,7 +63,7 @@ class RustCargoCrate(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/chef.py
+++ b/src/packagedcode/chef.py
@@ -70,7 +70,7 @@ class ChefPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/conda.py
+++ b/src/packagedcode/conda.py
@@ -74,7 +74,7 @@ class CondaPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/cran.py
+++ b/src/packagedcode/cran.py
@@ -59,7 +59,7 @@ class CranPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/freebsd.py
+++ b/src/packagedcode/freebsd.py
@@ -61,7 +61,7 @@ class FreeBSDPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/haxe.py
+++ b/src/packagedcode/haxe.py
@@ -79,7 +79,7 @@ class HaxePackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/jar_manifest.py
+++ b/src/packagedcode/jar_manifest.py
@@ -60,7 +60,7 @@ class JavaArchive(Package):
     @classmethod
     def recognize(cls, location):
         if is_manifest(location):
-            return parse_manifest(location)
+            yield parse_manifest(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/maven.py
+++ b/src/packagedcode/maven.py
@@ -80,7 +80,7 @@ class MavenPomPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/models.py
+++ b/src/packagedcode/models.py
@@ -479,7 +479,7 @@ class Package(BasePackage):
     @classmethod
     def recognize(cls, location):
         """
-        Return a Package object or None given a file location pointing to a
+        Yield a Package object or None given a file location pointing to a
         package archive, manifest or similar.
 
         Sub-classes should override to implement their own package recognition.

--- a/src/packagedcode/models.py
+++ b/src/packagedcode/models.py
@@ -479,7 +479,7 @@ class Package(BasePackage):
     @classmethod
     def recognize(cls, location):
         """
-        Yield a Package object or None given a file location pointing to a
+        Yield one or more Package objects given a file location pointing to a
         package archive, manifest or similar.
 
         Sub-classes should override to implement their own package recognition.

--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -81,7 +81,7 @@ class NpmPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/nuget.py
+++ b/src/packagedcode/nuget.py
@@ -74,7 +74,7 @@ class NugetPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/phpcomposer.py
+++ b/src/packagedcode/phpcomposer.py
@@ -80,7 +80,7 @@ class PHPComposerPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     @classmethod
     def get_package_root(cls, manifest_resource, codebase):

--- a/src/packagedcode/pypi.py
+++ b/src/packagedcode/pypi.py
@@ -93,7 +93,7 @@ class PythonPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
     def compute_normalized_license(self):
         return compute_normalized_license(self.declared_license)

--- a/src/packagedcode/recognize.py
+++ b/src/packagedcode/recognize.py
@@ -66,8 +66,8 @@ Recognize package manifests in files.
 
 def recognize_packages(location):
     """
-    Return a list of Package object if one/several was recognized for this
-    `location` or None. Raises Exceptions on errors.
+    Return a list of Package object if any packages were recognized for this
+    `location`, or None if there were no Packages found. Raises Exceptions on errors.
     """
 
     if not filetype.is_file(location):

--- a/src/packagedcode/recognize.py
+++ b/src/packagedcode/recognize.py
@@ -66,8 +66,8 @@ Recognize package manifests in files.
 
 def recognize_packages(location):
     """
-    Return a Package object if one was recognized for this `location` or None.
-    Raises Exceptions on errors.
+    Return a list of Package object if one/several was recognized for this
+    `location` or None. Raises Exceptions on errors.
     """
 
     if not filetype.is_file(location):
@@ -86,6 +86,7 @@ def recognize_packages(location):
                      'pygtype:', T.filetype_pygment,
                      'fname:', filename, 'ext:', extension)
 
+    recognized_packages = []
     for package_type in PACKAGE_TYPES:
         # Note: default to True if there is nothing to match against
         metafiles = package_type.metafiles
@@ -99,7 +100,8 @@ def recognize_packages(location):
                     # compute and set a normalized license expression
                     recognized.license_expression = recognized.compute_normalized_license()
                     if TRACE:logger_debug('recognize_packages: recognized.license_expression:', recognized.license_expression)
-                yield recognized
+                recognized_packages.append(recognized)
+            return recognized_packages
 
         type_matched = False
         if package_type.filetypes:
@@ -127,11 +129,12 @@ def recognize_packages(location):
                     if recognized and not recognized.license_expression:
                         recognized.license_expression = recognized.compute_normalized_license()
                     if TRACE: logger_debug('recognize_packages: recognized', recognized)
-                    yield recognized
+                    recognized_packages.append(recognized)
             except NotImplementedError:
                 # build a plain package if recognize is not yet implemented
                 recognized = package_type()
                 if TRACE: logger_debug('recognize_packages: recognized', recognized)
-                yield recognized
+                recognized_packages.append(recognized)
+            return recognized_packages
 
         if TRACE: logger_debug('recognize_packages: no match for type:', package_type)

--- a/src/packagedcode/recognize.py
+++ b/src/packagedcode/recognize.py
@@ -64,7 +64,7 @@ Recognize package manifests in files.
 """
 
 
-def recognize_package(location):
+def recognize_packages(location):
     """
     Return a Package object if one was recognized for this `location` or None.
     Raises Exceptions on errors.
@@ -82,7 +82,7 @@ def recognize_package(location):
     extension = extension.lower()
 
     if TRACE:
-        logger_debug('recognize_package: ftype:', ftype, 'mtype:', mtype,
+        logger_debug('recognize_packages: ftype:', ftype, 'mtype:', mtype,
                      'pygtype:', T.filetype_pygment,
                      'fname:', filename, 'ext:', extension)
 
@@ -93,13 +93,13 @@ def recognize_package(location):
             metafiles = (fsencode(m) for m in metafiles)
 
         if any(fnmatch.fnmatchcase(filename, metaf) for metaf in metafiles):
-            recognized = package_type.recognize(location)
-            if TRACE:logger_debug('recognize_package: metafile matching: recognized:', recognized)
-            if recognized and not recognized.license_expression:
-                # compute and set a normalized license expression
-                recognized.license_expression = recognized.compute_normalized_license()
-                if TRACE:logger_debug('recognize_package: recognized.license_expression:', recognized.license_expression)
-            return recognized
+            for recognized in package_type.recognize(location):
+                if TRACE:logger_debug('recognize_packages: metafile matching: recognized:', recognized)
+                if recognized and not recognized.license_expression:
+                    # compute and set a normalized license expression
+                    recognized.license_expression = recognized.compute_normalized_license()
+                    if TRACE:logger_debug('recognize_packages: recognized.license_expression:', recognized.license_expression)
+                yield recognized
 
         type_matched = False
         if package_type.filetypes:
@@ -120,17 +120,18 @@ def recognize_package(location):
                                     for ext_pat in extensions)
 
         if type_matched and mime_matched and extension_matched:
-            if TRACE: logger_debug('recognize_package: all matching')
+            if TRACE: logger_debug('recognize_packages: all matching')
             try:
-                recognized = package_type.recognize(location)
-                # compute and set a normalized license expression
-                if recognized and not recognized.license_expression:
-                    recognized.license_expression = recognized.compute_normalized_license()
+                for recognized in package_type.recognize(location):
+                    # compute and set a normalized license expression
+                    if recognized and not recognized.license_expression:
+                        recognized.license_expression = recognized.compute_normalized_license()
+                    if TRACE: logger_debug('recognize_packages: recognized', recognized)
+                    yield recognized
             except NotImplementedError:
                 # build a plain package if recognize is not yet implemented
                 recognized = package_type()
+                if TRACE: logger_debug('recognize_packages: recognized', recognized)
+                yield recognized
 
-            if TRACE: logger_debug('recognize_package: recognized', recognized)
-            return recognized
-
-        if TRACE: logger_debug('recognize_package: no match for type:', package_type)
+        if TRACE: logger_debug('recognize_packages: no match for type:', package_type)

--- a/src/packagedcode/rpm.py
+++ b/src/packagedcode/rpm.py
@@ -148,7 +148,7 @@ class RpmPackage(models.Package):
 
     @classmethod
     def recognize(cls, location):
-        return parse(location)
+        yield parse(location)
 
 
 def parse(location):

--- a/src/packagedcode/rubygems.py
+++ b/src/packagedcode/rubygems.py
@@ -107,28 +107,26 @@ class RubyGem(models.Package):
 
         # an unextracted .gen archive
         if location.endswith('.gem'):
-            return get_gem_package(location)
+            yield get_gem_package(location)
 
         # an extractcode-extracted .gen archive
         if location.endswith('metadata.gz-extract'):
             with open(location, 'rb') as met:
                 metadata = met.read()
             metadata = saneyaml.load(metadata)
-            return build_rubygem_package(metadata)
+            yield build_rubygem_package(metadata)
 
         if location.endswith('.gemspec'):
-            # TODO implement me
-            return
+            # TODO: implement me
+            pass
 
         if location.endswith('Gemfile'):
-            # TODO implement me
-            return
+            # TODO: implement me
+            pass
 
         if location.endswith('Gemfile.lock'):
-            # TODO implement me
-            return
-
-        return
+            # TODO: implement me
+            pass
 
     def repository_homepage_url(self, baseurl=default_web_baseurl):
         return rubygems_homepage_url(self.name, self.version, repo=baseurl)

--- a/src/scancode/api.py
+++ b/src/scancode/api.py
@@ -280,7 +280,9 @@ def get_package_info(location, **kwargs):
     """
     from packagedcode.recognize import recognize_packages
     try:
-        return dict(packages=[manifest.to_dict() for manifest in recognize_packages(location)])
+        recognized_packages = recognize_packages(location)
+        if recognized_packages:
+            return dict(packages=[package.to_dict() for package in recognized_packages])
     except Exception as e:
         if TRACE:
             logger.error('get_package_info: {}: Exception: {}'.format(location, e))

--- a/src/scancode/api.py
+++ b/src/scancode/api.py
@@ -278,12 +278,9 @@ def get_package_info(location, **kwargs):
     Note that all exceptions are caught if there are any errors while parsing a
     package manifest.
     """
-    from packagedcode.recognize import recognize_package
+    from packagedcode.recognize import recognize_packages
     try:
-        manifest = recognize_package(location)
-        if manifest:
-            # TODO: what if we have more than one package in a manifest?
-            return dict(packages=[manifest.to_dict()])
+        return dict(packages=[manifest.to_dict() for manifest in recognize_packages(location)])
     except Exception as e:
         if TRACE:
             logger.error('get_package_info: {}: Exception: {}'.format(location, e))

--- a/tests/packagedcode/test_maven.py
+++ b/tests/packagedcode/test_maven.py
@@ -240,7 +240,9 @@ class TestMavenMisc(BaseMavenCase):
         test_dir = self.get_test_loc('maven_misc/package_root')
         codebase = Codebase(test_dir, resource_attributes=PackageScanner.resource_attributes)
         manifest_resource = [r for r in codebase.walk() if r.name == 'pom.xml'][0]
-        package = maven.MavenPomPackage.recognize(manifest_resource.location)
+        packages = list(maven.MavenPomPackage.recognize(manifest_resource.location))
+        assert len(packages) > 0
+        package = packages[0]
         manifest_resource.packages.append(package.to_dict())
         manifest_resource.save(codebase)
         proot = maven.MavenPomPackage.get_package_root(manifest_resource, codebase)

--- a/tests/packagedcode/test_maven.py
+++ b/tests/packagedcode/test_maven.py
@@ -240,10 +240,9 @@ class TestMavenMisc(BaseMavenCase):
         test_dir = self.get_test_loc('maven_misc/package_root')
         codebase = Codebase(test_dir, resource_attributes=PackageScanner.resource_attributes)
         manifest_resource = [r for r in codebase.walk() if r.name == 'pom.xml'][0]
-        packages = list(maven.MavenPomPackage.recognize(manifest_resource.location))
-        assert len(packages) > 0
-        package = packages[0]
-        manifest_resource.packages.append(package.to_dict())
+        packages = maven.MavenPomPackage.recognize(manifest_resource.location)
+        assert packages
+        manifest_resource.packages.append(packages[0].to_dict())
         manifest_resource.save(codebase)
         proot = maven.MavenPomPackage.get_package_root(manifest_resource, codebase)
         assert 'activiti-image-generator-7-201802-EA-sources.jar-extract' == proot.name

--- a/tests/packagedcode/test_maven.py
+++ b/tests/packagedcode/test_maven.py
@@ -240,7 +240,7 @@ class TestMavenMisc(BaseMavenCase):
         test_dir = self.get_test_loc('maven_misc/package_root')
         codebase = Codebase(test_dir, resource_attributes=PackageScanner.resource_attributes)
         manifest_resource = [r for r in codebase.walk() if r.name == 'pom.xml'][0]
-        packages = maven.MavenPomPackage.recognize(manifest_resource.location)
+        packages = list(maven.MavenPomPackage.recognize(manifest_resource.location))
         assert packages
         manifest_resource.packages.append(packages[0].to_dict())
         manifest_resource.save(codebase)

--- a/tests/packagedcode/test_recognize.py
+++ b/tests/packagedcode/test_recognize.py
@@ -45,65 +45,59 @@ class TestRecognize(FileBasedTesting):
 
     def test_recognize_packages_deb(self):
         test_file = self.get_test_loc('archives/adduser_3.112ubuntu1_all.deb')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, packagedcode.models.DebianPackage)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], packagedcode.models.DebianPackage)
 
     def test_recognize_packages_rpm(self):
         test_file = self.get_test_loc('archives/alfandega-2.2-2.rh80.src.rpm')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, rpm.RpmPackage)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], rpm.RpmPackage)
 
     def test_recognize_packages_cab(self):
         test_file = self.get_test_loc('archives/basic.cab')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, packagedcode.models.CabPackage)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], packagedcode.models.CabPackage)
 
     def test_recognize_packages_rar(self):
         test_file = self.get_test_loc('archives/basic.rar')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) == 0
+        packages = recognize_packages(test_file)
+        assert not packages
 
     def test_recognize_packages_zip(self):
         test_file = self.get_test_loc('archives/myarch-2.3.0.7z')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) == 0
+        packages = recognize_packages(test_file)
+        assert not packages
 
     def test_recognize_packages_gem(self):
         test_file = self.get_test_loc('archives/mysmallidea-address_standardization-0.4.1.gem')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, packagedcode.rubygems.RubyGem)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], packagedcode.rubygems.RubyGem)
 
     def test_recognize_packages_jar(self):
         test_file = self.get_test_loc('archives/simple.jar')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, packagedcode.models.JavaJar)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], packagedcode.models.JavaJar)
 
     def test_recognize_packages_iso(self):
         test_file = self.get_test_loc('archives/small.iso')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, packagedcode.models.IsoImagePackage)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], packagedcode.models.IsoImagePackage)
 
     def test_recognize_packages_does_not_recognize_plain_tarball(self):
         test_file = self.get_test_loc('archives/tarred_bzipped.tar.bz2')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) == 0
+        packages = recognize_packages(test_file)
+        assert not packages
 
     def test_recognize_cpan_manifest_as_plain_package(self):
         test_file = self.get_test_loc('cpan/MANIFEST')
         try:
-            list(recognize_packages(test_file))
+            recognize_packages(test_file)
             self.fail('Exception not raised')
         except NotImplementedError:
             pass
@@ -111,48 +105,41 @@ class TestRecognize(FileBasedTesting):
     def test_recognize_maven_dot_pom(self):
         test_file = self.get_test_loc('m2/aspectj/aspectjrt/1.5.3/aspectjrt-1.5.3.pom')
         packages = recognize_packages(test_file)
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, maven.MavenPomPackage)
+        assert packages
+        assert isinstance(packages[0], maven.MavenPomPackage)
 
     def test_recognize_maven_pom_xml(self):
         test_file = self.get_test_loc('maven2/pom.xml')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, maven.MavenPomPackage)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], maven.MavenPomPackage)
 
     def test_recognize_npm(self):
         test_file = self.get_test_loc('recon/package.json')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, npm.NpmPackage)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], npm.NpmPackage)
 
     def test_recognize_cargo(self):
         test_file = self.get_test_loc('recon/Cargo.toml')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, cargo.RustCargoCrate)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], cargo.RustCargoCrate)
 
     def test_recognize_composer(self):
         test_file = self.get_test_loc('recon/composer.json')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, phpcomposer.PHPComposerPackage)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], phpcomposer.PHPComposerPackage)
 
     def test_recognize_freebsd(self):
         test_file = self.get_test_loc('freebsd/multi_license/+COMPACT_MANIFEST')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, freebsd.FreeBSDPackage)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], freebsd.FreeBSDPackage)
 
     def test_recognize_nuget(self):
         test_file = self.get_test_loc('recon/bootstrap.nuspec')
-        packages = list(recognize_packages(test_file))
-        assert len(packages) > 0
-        package = packages[0]
-        assert isinstance(package, nuget.NugetPackage)
+        packages = recognize_packages(test_file)
+        assert packages
+        assert isinstance(packages[0], nuget.NugetPackage)

--- a/tests/packagedcode/test_recognize.py
+++ b/tests/packagedcode/test_recognize.py
@@ -110,7 +110,7 @@ class TestRecognize(FileBasedTesting):
 
     def test_recognize_maven_dot_pom(self):
         test_file = self.get_test_loc('m2/aspectj/aspectjrt/1.5.3/aspectjrt-1.5.3.pom')
-        packages = list(recognize_packages(test_file))
+        packages = recognize_packages(test_file)
         assert len(packages) > 0
         package = packages[0]
         assert isinstance(package, maven.MavenPomPackage)

--- a/tests/packagedcode/test_recognize.py
+++ b/tests/packagedcode/test_recognize.py
@@ -103,7 +103,7 @@ class TestRecognize(FileBasedTesting):
     def test_recognize_cpan_manifest_as_plain_package(self):
         test_file = self.get_test_loc('cpan/MANIFEST')
         try:
-            recognize_packages(test_file)
+            list(recognize_packages(test_file))
             self.fail('Exception not raised')
         except NotImplementedError:
             pass

--- a/tests/packagedcode/test_recognize.py
+++ b/tests/packagedcode/test_recognize.py
@@ -36,97 +36,123 @@ from packagedcode import npm
 from packagedcode import cargo
 from packagedcode import phpcomposer
 from packagedcode import rpm
-from packagedcode.recognize import recognize_package
+from packagedcode.recognize import recognize_packages
 from packagedcode import nuget
 
 
 class TestRecognize(FileBasedTesting):
     test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
-    def test_recognize_package_deb(self):
+    def test_recognize_packages_deb(self):
         test_file = self.get_test_loc('archives/adduser_3.112ubuntu1_all.deb')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, packagedcode.models.DebianPackage)
 
-    def test_recognize_package_rpm(self):
+    def test_recognize_packages_rpm(self):
         test_file = self.get_test_loc('archives/alfandega-2.2-2.rh80.src.rpm')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, rpm.RpmPackage)
 
-    def test_recognize_package_cab(self):
+    def test_recognize_packages_cab(self):
         test_file = self.get_test_loc('archives/basic.cab')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, packagedcode.models.CabPackage)
 
-    def test_recognize_package_rar(self):
+    def test_recognize_packages_rar(self):
         test_file = self.get_test_loc('archives/basic.rar')
-        package = recognize_package(test_file)
-        assert None == package
+        packages = list(recognize_packages(test_file))
+        assert len(packages) == 0
 
-    def test_recognize_package_zip(self):
+    def test_recognize_packages_zip(self):
         test_file = self.get_test_loc('archives/myarch-2.3.0.7z')
-        package = recognize_package(test_file)
-        assert None == package
+        packages = list(recognize_packages(test_file))
+        assert len(packages) == 0
 
-    def test_recognize_package_gem(self):
+    def test_recognize_packages_gem(self):
         test_file = self.get_test_loc('archives/mysmallidea-address_standardization-0.4.1.gem')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, packagedcode.rubygems.RubyGem)
 
-    def test_recognize_package_jar(self):
+    def test_recognize_packages_jar(self):
         test_file = self.get_test_loc('archives/simple.jar')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, packagedcode.models.JavaJar)
 
-    def test_recognize_package_iso(self):
+    def test_recognize_packages_iso(self):
         test_file = self.get_test_loc('archives/small.iso')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, packagedcode.models.IsoImagePackage)
 
-    def test_recognize_package_does_not_recognize_plain_tarball(self):
+    def test_recognize_packages_does_not_recognize_plain_tarball(self):
         test_file = self.get_test_loc('archives/tarred_bzipped.tar.bz2')
-        package = recognize_package(test_file)
-        assert None == package
+        packages = list(recognize_packages(test_file))
+        assert len(packages) == 0
 
     def test_recognize_cpan_manifest_as_plain_package(self):
         test_file = self.get_test_loc('cpan/MANIFEST')
         try:
-            recognize_package(test_file)
+            recognize_packages(test_file)
             self.fail('Exception not raised')
         except NotImplementedError:
             pass
 
     def test_recognize_maven_dot_pom(self):
         test_file = self.get_test_loc('m2/aspectj/aspectjrt/1.5.3/aspectjrt-1.5.3.pom')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, maven.MavenPomPackage)
 
     def test_recognize_maven_pom_xml(self):
         test_file = self.get_test_loc('maven2/pom.xml')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, maven.MavenPomPackage)
 
     def test_recognize_npm(self):
         test_file = self.get_test_loc('recon/package.json')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, npm.NpmPackage)
 
     def test_recognize_cargo(self):
         test_file = self.get_test_loc('recon/Cargo.toml')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, cargo.RustCargoCrate)
 
     def test_recognize_composer(self):
         test_file = self.get_test_loc('recon/composer.json')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, phpcomposer.PHPComposerPackage)
 
     def test_recognize_freebsd(self):
         test_file = self.get_test_loc('freebsd/multi_license/+COMPACT_MANIFEST')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, freebsd.FreeBSDPackage)
 
     def test_recognize_nuget(self):
         test_file = self.get_test_loc('recon/bootstrap.nuspec')
-        package = recognize_package(test_file)
+        packages = list(recognize_packages(test_file))
+        assert len(packages) > 0
+        package = packages[0]
         assert isinstance(package, nuget.NugetPackage)


### PR DESCRIPTION
This PR allows the `Package` class' `recognize` method to return multiple Package objects for a single manifest, if more than one Package was detected. 