### PR TITLE
Add a separate boolean py2_with_linux

### DIFF
--- a/src/commoncode/system.py
+++ b/src/commoncode/system.py
@@ -109,6 +109,9 @@ py35 = py3 and _sys_v1 == 5
 py36 = py3 and _sys_v1 == 6
 py37 = py3 and _sys_v1 == 7
 
+#these are used together in many places
+py2_with_linux = py2_with_linux
+
 # Do not let Windows error pop up messages with default SetErrorMode
 # See http://msdn.microsoft.com/en-us/library/ms680621(VS100).aspx
 #

--- a/src/commoncode/system.py
+++ b/src/commoncode/system.py
@@ -110,7 +110,7 @@ py36 = py3 and _sys_v1 == 6
 py37 = py3 and _sys_v1 == 7
 
 #these are used together in many places
-py2_with_linux = py2_with_linux
+py2_with_linux = py2 and on_linux
 
 # Do not let Windows error pop up messages with default SetErrorMode
 # See http://msdn.microsoft.com/en-us/library/ms680621(VS100).aspx

--- a/src/scancode/resource.py
+++ b/src/scancode/resource.py
@@ -61,6 +61,10 @@ from commoncode.datautils import String
 from commoncode.filetype import is_file as filetype_is_file
 from commoncode.filetype import is_special
 
+from commoncode import ignore
+from commoncode.system import py2
+from commoncode.system import py2_with_linux
+
 from commoncode.fileutils import POSIX_PATH_SEP
 from commoncode.fileutils import WIN_PATH_SEP
 from commoncode.fileutils import as_posixpath
@@ -69,14 +73,15 @@ from commoncode.fileutils import delete
 from commoncode.fileutils import file_base_name
 from commoncode.fileutils import file_name
 from commoncode.fileutils import fsdecode
-from commoncode.fileutils import fsencode
 from commoncode.fileutils import parent_directory
 from commoncode.fileutils import splitext_name
 
-from commoncode import ignore
-from commoncode.system import on_linux
-from commoncode.system import py2
-from commoncode.system import py3
+if py2_with_linux:
+    from commoncode.fileutils import fsencode
+
+
+
+
 
 
 """
@@ -258,7 +263,7 @@ class Codebase(object):
 
         # setup location
         ########################################################################
-        if on_linux and py2:
+        if py2_with_linux:
             location = fsencode(location)
         else:
             location = fsdecode(location)
@@ -359,7 +364,7 @@ class Codebase(object):
         """
         if not self.cache_dir:
             return
-        resid = (b'%08x'if (py2 and on_linux) else '%08x') % rid
+        resid = (b'%08x' if (py2_with_linux) else '%08x') % rid
         cache_sub_dir, cache_file_name = resid[-2:], resid
         parent = join(self.cache_dir, cache_sub_dir)
         if create and not exists(parent):
@@ -696,7 +701,7 @@ class Codebase(object):
         # TODO: consider messagepack or protobuf for compact/faster processing?
         if py2:
             mode = 'wb'
-        if py3:
+        else:
             mode = 'w'
         with open(cache_location , mode) as cached:
             cached.write(json.dumps(resource.serialize(), check_circular=False))
@@ -927,7 +932,7 @@ def to_native_path(path):
     """
     if not path:
         return path
-    if on_linux and py2:
+    if py2_with_linux:
         return fsencode(path)
     else:
         return fsdecode(path)
@@ -1335,7 +1340,7 @@ def get_codebase_cache_dir(temp_dir):
 
     prefix = 'scancode-codebase-' + time2tstamp() + '-'
     cache_dir = get_temp_dir(base_dir=temp_dir, prefix=prefix)
-    if on_linux and py2:
+    if py2_with_linux:
         cache_dir = fsencode(cache_dir)
     else:
         cache_dir = fsdecode(cache_dir)

--- a/tests/commoncode/test_fileutils.py
+++ b/tests/commoncode/test_fileutils.py
@@ -43,6 +43,7 @@ from commoncode.system import on_macos_14_or_higher
 from commoncode.system import on_windows
 from commoncode.system import py2
 from commoncode.system import py3
+from commoncode.system import py2_with_linux
 from commoncode.testcase import FileBasedTesting
 from commoncode.testcase import make_non_executable
 from commoncode.testcase import make_non_readable
@@ -337,10 +338,10 @@ class TestFileUtilsWalk(FileBasedTesting):
         test_dir = self.extract_test_zip('fileutils/walk/unicode.zip')
         test_dir = join(test_dir, 'unicode')
 
-        if on_linux and py2:
+        if py2_with_linux:
             test_dir = compat.unicode(test_dir)
         result = list(x[-1] for x in fileutils.walk(test_dir))
-        if on_linux and py2:
+        if py2_with_linux:
             expected = [['2.csv'], ['gru\xcc\x88n.png']]
         else:
             expected = [[u'2.csv'], [u'gru\u0308n.png']]
@@ -378,7 +379,7 @@ class TestFileUtilsWalk(FileBasedTesting):
         test_dir = self.extract_test_tar_raw('fileutils/walk_non_utf8/non_unicode.tgz')
         test_dir = join(test_dir, 'non_unicode')
 
-        if not on_linux and py2:
+        if not py2_with_linux:
             test_dir = compat.unicode(test_dir)
         result = list(os.walk(test_dir))[0]
         _dirpath, _dirnames, filenames = result
@@ -472,7 +473,7 @@ class TestFileUtilsIter(FileBasedTesting):
             '/walk/unicode.zip'
         ]
         assert sorted(expected) == sorted(result)
-        if on_linux and py2:
+        if py2_with_linux:
             assert all(isinstance(p, bytes) for p in result)
         else:
             assert all(isinstance(p, compat.unicode) for p in result)
@@ -500,14 +501,14 @@ class TestFileUtilsIter(FileBasedTesting):
         test_dir = self.extract_test_zip('fileutils/walk/unicode.zip')
         test_dir = join(test_dir, 'unicode')
 
-        if on_linux and py2:
+        if py2_with_linux:
             EMPTY_STRING = ''
         else:
             test_dir = compat.unicode(test_dir)
             EMPTY_STRING = u''
 
         result = sorted([p.replace(test_dir, EMPTY_STRING) for p in fileutils.resource_iter(test_dir)])
-        if on_linux and py2:
+        if py2_with_linux:
             expected = [
                 '/2.csv',
                 '/a',
@@ -538,7 +539,7 @@ class TestFileUtilsIter(FileBasedTesting):
         test_dir = self.extract_test_tar_raw('fileutils/walk_non_utf8/non_unicode.tgz')
         test_dir = join(test_dir, 'non_unicode')
 
-        if not on_linux and py2:
+        if not py2_with_linux:
             test_dir = compat.unicode(test_dir)
         result = list(fileutils.resource_iter(test_dir, with_dirs=True))
         assert 18 == len(result)
@@ -548,7 +549,7 @@ class TestFileUtilsIter(FileBasedTesting):
         test_dir = self.extract_test_tar_raw('fileutils/walk_non_utf8/non_unicode.tgz')
         test_dir = join(test_dir, 'non_unicode')
 
-        if not on_linux and py2:
+        if not py2_with_linux:
             test_dir = compat.unicode(test_dir)
         result = list(fileutils.resource_iter(test_dir, with_dirs=False))
         assert 18 == len(result)

--- a/tests/commoncode/test_fileutils.py
+++ b/tests/commoncode/test_fileutils.py
@@ -493,7 +493,7 @@ class TestFileUtilsIter(FileBasedTesting):
             u'/walk/unicode.zip'
         ]
         assert sorted(expected) == sorted(result)
-        types = bytes if py2 and on_linux else compat.unicode
+        types = bytes if py2_with_linux else compat.unicode
         assert all(isinstance(p, types) for p in result)
 
     def test_resource_iter_can_walk_unicode_path_with_zip(self):


### PR DESCRIPTION
We are using `py2 and on_linux`  repeatedly in  many places. I propose to have separate boolean  
`py2_with_linux = py2 and on_linux`  defined in our src/commoncode/system.py .

I also added some minor fixes, I came across.

Please share your opinions