### PR TITLE
Update Consolidation Plugin Following Package Model Update

### DIFF
--- a/src/packagedcode/models.py
+++ b/src/packagedcode/models.py
@@ -500,7 +500,7 @@ class Package(BasePackage):
         of a "xyz.pom" file found inside a JAR META-INF/ directory, the root is
         the JAR itself which may not be the direct parent
 
-        Each package type should subclass as needed. This deafult to return the
+        Each package type should subclass as needed. This default to return the
         same path.
         """
         return manifest_resource

--- a/tests/scancode/data/plugin_consolidate/component-package-build-expected.json
+++ b/tests/scancode/data/plugin_consolidate/component-package-build-expected.json
@@ -87,18 +87,22 @@
       "repository_download_url": "https://registry.npmjs.org/test-package/-/test-package-0.0.1.tgz",
       "api_data_url": "https://registry.npmjs.org/test-package/0.0.1",
       "identifier": "pkg_npm_test_package_0_0_1_1",
-      "consolidated_license_expression": "apache-2.0",
+      "consolidated_license_expression": "apache-2.0 AND gpl-1.0-plus AND unknown",
       "consolidated_holders": [
-        "The Apache Software"
+        "IBM Corp.",
+        "The Apache Software",
+        "The Apache Software Foundation"
       ],
-      "consolidated_copyright": "Copyright (c) The Apache Software",
+      "consolidated_copyright": "Copyright (c) IBM Corp., The Apache Software, The Apache Software Foundation",
       "core_license_expression": "apache-2.0",
       "core_holders": [],
-      "other_license_expression": "apache-2.0",
+      "other_license_expression": "apache-2.0 AND gpl-1.0-plus AND unknown",
       "other_holders": [
-        "The Apache Software"
+        "IBM Corp.",
+        "The Apache Software",
+        "The Apache Software Foundation"
       ],
-      "files_count": 1
+      "files_count": 3
     }
   ],
   "files": [
@@ -156,7 +160,9 @@
       "holders": [],
       "authors": [],
       "packages": [],
-      "consolidated_to": [],
+      "consolidated_to": [
+        "build_1"
+      ],
       "files_count": 1,
       "dirs_count": 0,
       "size_count": 261,
@@ -600,7 +606,9 @@
       "holders": [],
       "authors": [],
       "packages": [],
-      "consolidated_to": [],
+      "consolidated_to": [
+        "pkg_npm_test_package_0_0_1_1"
+      ],
       "files_count": 3,
       "dirs_count": 0,
       "size_count": 275,
@@ -794,7 +802,9 @@
       ],
       "authors": [],
       "packages": [],
-      "consolidated_to": [],
+      "consolidated_to": [
+        "pkg_npm_test_package_0_0_1_1"
+      ],
       "files_count": 0,
       "dirs_count": 0,
       "size_count": 0,
@@ -904,7 +914,9 @@
       ],
       "authors": [],
       "packages": [],
-      "consolidated_to": [],
+      "consolidated_to": [
+        "pkg_npm_test_package_0_0_1_1"
+      ],
       "files_count": 0,
       "dirs_count": 0,
       "size_count": 0,

--- a/tests/scancode/data/plugin_consolidate/component-package-expected.json
+++ b/tests/scancode/data/plugin_consolidate/component-package-expected.json
@@ -108,18 +108,22 @@
       "repository_download_url": "https://registry.npmjs.org/test-package/-/test-package-0.0.1.tgz",
       "api_data_url": "https://registry.npmjs.org/test-package/0.0.1",
       "identifier": "pkg_npm_test_package_0_0_1_1",
-      "consolidated_license_expression": "apache-2.0",
+      "consolidated_license_expression": "apache-2.0 AND gpl-1.0-plus AND unknown",
       "consolidated_holders": [
-        "The Apache Software"
+        "IBM Corp.",
+        "The Apache Software",
+        "The Apache Software Foundation"
       ],
-      "consolidated_copyright": "Copyright (c) The Apache Software",
+      "consolidated_copyright": "Copyright (c) IBM Corp., The Apache Software, The Apache Software Foundation",
       "core_license_expression": "apache-2.0",
       "core_holders": [],
-      "other_license_expression": "apache-2.0",
+      "other_license_expression": "apache-2.0 AND gpl-1.0-plus AND unknown",
       "other_holders": [
-        "The Apache Software"
+        "IBM Corp.",
+        "The Apache Software",
+        "The Apache Software Foundation"
       ],
-      "files_count": 1
+      "files_count": 3
     }
   ],
   "files": [
@@ -147,7 +151,9 @@
       "holders": [],
       "authors": [],
       "packages": [],
-      "consolidated_to": [],
+      "consolidated_to": [
+        "the_apache_software_foundation_1"
+      ],
       "files_count": 7,
       "dirs_count": 2,
       "size_count": 477,
@@ -523,7 +529,9 @@
       "holders": [],
       "authors": [],
       "packages": [],
-      "consolidated_to": [],
+      "consolidated_to": [
+        "pkg_npm_test_package_0_0_1_1"
+      ],
       "files_count": 3,
       "dirs_count": 0,
       "size_count": 275,
@@ -717,7 +725,9 @@
       ],
       "authors": [],
       "packages": [],
-      "consolidated_to": [],
+      "consolidated_to": [
+        "pkg_npm_test_package_0_0_1_1"
+      ],
       "files_count": 0,
       "dirs_count": 0,
       "size_count": 0,
@@ -827,7 +837,9 @@
       ],
       "authors": [],
       "packages": [],
-      "consolidated_to": [],
+      "consolidated_to": [
+        "pkg_npm_test_package_0_0_1_1"
+      ],
       "files_count": 0,
       "dirs_count": 0,
       "size_count": 0,

--- a/tests/scancode/data/plugin_consolidate/package-files-not-counted-in-license-holders-expected.json
+++ b/tests/scancode/data/plugin_consolidate/package-files-not-counted-in-license-holders-expected.json
@@ -34,7 +34,7 @@
       ],
       "other_license_expression": null,
       "other_holders": [],
-      "files_count": 5
+      "files_count": 2
     }
   ],
   "consolidated_packages": [
@@ -77,16 +77,18 @@
       "identifier": "pkg_npm_test_package_0_0_1_1",
       "consolidated_license_expression": "apache-2.0",
       "consolidated_holders": [
-        "The Apache Software"
+        "The Apache Software",
+        "The Apache Software Foundation"
       ],
-      "consolidated_copyright": "Copyright (c) The Apache Software",
+      "consolidated_copyright": "Copyright (c) The Apache Software, The Apache Software Foundation",
       "core_license_expression": "apache-2.0",
       "core_holders": [],
       "other_license_expression": "apache-2.0",
       "other_holders": [
-        "The Apache Software"
+        "The Apache Software",
+        "The Apache Software Foundation"
       ],
-      "files_count": 1
+      "files_count": 4
     }
   ],
   "files": [
@@ -147,7 +149,7 @@
       "authors": [],
       "packages": [],
       "consolidated_to": [
-        "the_apache_software_foundation_1"
+        "pkg_npm_test_package_0_0_1_1"
       ],
       "files_count": 4,
       "dirs_count": 0,
@@ -343,7 +345,7 @@
       "authors": [],
       "packages": [],
       "consolidated_to": [
-        "the_apache_software_foundation_1"
+        "pkg_npm_test_package_0_0_1_1"
       ],
       "files_count": 0,
       "dirs_count": 0,
@@ -422,7 +424,7 @@
       "authors": [],
       "packages": [],
       "consolidated_to": [
-        "the_apache_software_foundation_1"
+        "pkg_npm_test_package_0_0_1_1"
       ],
       "files_count": 0,
       "dirs_count": 0,
@@ -501,7 +503,7 @@
       "authors": [],
       "packages": [],
       "consolidated_to": [
-        "the_apache_software_foundation_1"
+        "pkg_npm_test_package_0_0_1_1"
       ],
       "files_count": 0,
       "dirs_count": 0,

--- a/tests/scancode/data/plugin_consolidate/package-fileset-expected.json
+++ b/tests/scancode/data/plugin_consolidate/package-fileset-expected.json
@@ -19,24 +19,7 @@
       }
     }
   ],
-  "consolidated_components": [
-    {
-      "type": "license-holders",
-      "identifier": "the_apache_software_foundation_1",
-      "consolidated_license_expression": "apache-2.0",
-      "consolidated_holders": [
-        "The Apache Software Foundation"
-      ],
-      "consolidated_copyright": "Copyright (c) The Apache Software Foundation",
-      "core_license_expression": "apache-2.0",
-      "core_holders": [
-        "The Apache Software Foundation"
-      ],
-      "other_license_expression": null,
-      "other_holders": [],
-      "files_count": 3
-    }
-  ],
+  "consolidated_components": [],
   "consolidated_packages": [
     {
       "type": "npm",
@@ -76,13 +59,17 @@
       "api_data_url": "https://registry.npmjs.org/test-package/0.0.1",
       "identifier": "pkg_npm_test_package_0_0_1_1",
       "consolidated_license_expression": "apache-2.0",
-      "consolidated_holders": [],
-      "consolidated_copyright": "Copyright (c) ",
+      "consolidated_holders": [
+        "The Apache Software Foundation"
+      ],
+      "consolidated_copyright": "Copyright (c) The Apache Software Foundation",
       "core_license_expression": "apache-2.0",
       "core_holders": [],
       "other_license_expression": "apache-2.0",
-      "other_holders": [],
-      "files_count": 1
+      "other_holders": [
+        "The Apache Software Foundation"
+      ],
+      "files_count": 4
     }
   ],
   "files": [
@@ -111,7 +98,7 @@
       "authors": [],
       "packages": [],
       "consolidated_to": [
-        "the_apache_software_foundation_1"
+        "pkg_npm_test_package_0_0_1_1"
       ],
       "files_count": 4,
       "dirs_count": 0,
@@ -295,7 +282,7 @@
       "authors": [],
       "packages": [],
       "consolidated_to": [
-        "the_apache_software_foundation_1"
+        "pkg_npm_test_package_0_0_1_1"
       ],
       "files_count": 0,
       "dirs_count": 0,
@@ -374,7 +361,7 @@
       "authors": [],
       "packages": [],
       "consolidated_to": [
-        "the_apache_software_foundation_1"
+        "pkg_npm_test_package_0_0_1_1"
       ],
       "files_count": 0,
       "dirs_count": 0,
@@ -453,7 +440,7 @@
       "authors": [],
       "packages": [],
       "consolidated_to": [
-        "the_apache_software_foundation_1"
+        "pkg_npm_test_package_0_0_1_1"
       ],
       "files_count": 0,
       "dirs_count": 0,

--- a/tests/scancode/data/plugin_consolidate/package-manifest-expected.json
+++ b/tests/scancode/data/plugin_consolidate/package-manifest-expected.json
@@ -93,7 +93,9 @@
       "holders": [],
       "authors": [],
       "packages": [],
-      "consolidated_to": [],
+      "consolidated_to": [
+        "pkg_npm_test_package_0_0_1_1"
+      ],
       "files_count": 1,
       "dirs_count": 0,
       "size_count": 78,


### PR DESCRIPTION
This PR updates the Consolidation plugin to work with the new Package model. An extra step to get the package root has been added. Consolidation logic was also fixed, where we were not properly ignoring Package file count from the total file count when determining license-holder majorities. 