### PR TITLE
Add new rule for GPL historical note #1794

### DIFF
--- a/src/licensedcode/data/rules/gpl-1.0-plus_historical_note.RULE
+++ b/src/licensedcode/data/rules/gpl-1.0-plus_historical_note.RULE
@@ -1,0 +1,1 @@
+was originally licensed under the GPL until

--- a/src/licensedcode/data/rules/gpl-1.0-plus_historical_note.yml
+++ b/src/licensedcode/data/rules/gpl-1.0-plus_historical_note.yml
@@ -1,0 +1,4 @@
+is_negative: yes
+notes: |
+    Historical note about former GPL licensing.
+    See https://github.com/gettalong/kramdown/blob/179b81dcf057f8079fd9df5296ba858114d30f7a/README.md


### PR DESCRIPTION
This rule is from a scan of https://github.com/gettalong/kramdown/. Specifically, the README notes that it was originally GPL licensed. This blurb should not actually be matched.