### PR TITLE
Add /dev and /sys to ignores #1010

### DIFF
--- a/src/commoncode/ignore.py
+++ b/src/commoncode/ignore.py
@@ -111,7 +111,9 @@ ignores_Windows = {
 
 ignores_Linux = {
     '.directory': 'Default ignore: KDE artifact',
-    '.Trash-*': 'Default ignore: Linux/Gome/KDE artifact',
+    '.Trash-*': 'Default ignore: Linux/Gnome/KDE artifact',
+    '/dev/*': 'Default ignore: Linux device files',
+    '/sys/*': 'Default ignore: Linux device files',
 }
 
 ignores_IDEs = {

--- a/src/scancode/resource.py
+++ b/src/scancode/resource.py
@@ -73,7 +73,12 @@ from commoncode.fileutils import fsencode
 from commoncode.fileutils import parent_directory
 from commoncode.fileutils import splitext_name
 
-from commoncode import ignore
+from commoncode.ignore import ignores_Linux
+from commoncode.ignore import ignores_MacOSX
+from commoncode.ignore import ignores_VCS
+from commoncode.ignore import ignores_Windows
+from commoncode.ignore import is_ignored
+
 from commoncode.system import on_linux
 from commoncode.system import py2
 from commoncode.system import py3
@@ -398,7 +403,12 @@ class Codebase(object):
 
         def skip_ignored(_loc):
             """Always ignore VCS and some special filetypes."""
-            ignored = partial(ignore.is_ignored, ignores=ignore.ignores_VCS)
+            ignored = partial(
+                is_ignored,
+                ignores=dict(
+                    ignores_VCS.items() + ignores_Linux.items() + ignores_MacOSX.items() + ignores_Windows.items()
+                )
+            )
 
             if TRACE_DEEP:
                 logger_debug()


### PR DESCRIPTION
When we create a codebase, we only ignored the immaterial VCS files when we should have also ignored OS-related files at the same time. This PR adds `/dev/` and `/sys` to the list of patterns to ignore and also properly ignores directories when creating a codebase.