### PR TITLE
Mark any time a resource has a majority during Consolidation

### DIFF
--- a/src/scancode/plugin_consolidate.py
+++ b/src/scancode/plugin_consolidate.py
@@ -247,6 +247,8 @@ def get_consolidated_packages(codebase):
         for package_data in resource.packages:
             package = get_package_instance(package_data)
             package_root = package.get_package_root(resource, codebase)
+            package_root.extra_data['package_root'] = True
+            package_root.save(codebase)
             is_build_file = isinstance(package, BaseBuildManifestPackage)
             package_resources = list(package.get_package_resources(package_root, codebase))
             package_license_expression = package.license_expression
@@ -370,6 +372,7 @@ def get_license_holders_consolidated_components(codebase):
                 majority_holders, majority_license_expression = origin_translation_table[origin_key]
                 resource.extra_data['license_expression'] = majority_license_expression
                 resource.extra_data['holders'] = majority_holders
+                resource.extra_data['majority'] = True
                 resource.save(codebase)
 
                 # Create consolidated components for a child that has a majority
@@ -386,6 +389,8 @@ def get_license_holders_consolidated_components(codebase):
                             or (holders and holders != majority_holders)):
                         c = create_license_holders_consolidated_component(child, codebase)
                         if c:
+                            child.extra_data['majority'] = True
+                            child.save(codebase)
                             yield c
             else:
                 # If there is no majority, we see if any of our child directories had majorities
@@ -395,11 +400,15 @@ def get_license_holders_consolidated_components(codebase):
                         continue
                     c = create_license_holders_consolidated_component(child, codebase)
                     if c:
+                        child.extra_data['majority'] = True
+                        child.save(codebase)
                         yield c
 
     # Yield a Component for root if there is a majority
     c = create_license_holders_consolidated_component(root, codebase)
     if c:
+        root.extra_data['majority'] = True
+        root.save(codebase)
         yield c
 
 

--- a/tests/scancode/data/plugin_consolidate/majority_and_package_root.json
+++ b/tests/scancode/data/plugin_consolidate/majority_and_package_root.json
@@ -1,0 +1,850 @@
+{
+  "headers": [
+    {
+      "tool_name": "scancode-toolkit",
+      "tool_version": "3.1.1.post262.c8e1a6329",
+      "options": {
+        "input": [
+          "majority_and_package_root/"
+        ],
+        "--copyright": true,
+        "--email": true,
+        "--info": true,
+        "--json-pp": "majority_and_package_root.json",
+        "--license": true,
+        "--package": true,
+        "--url": true
+      },
+      "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+      "start_timestamp": "2019-11-26T202519.646068",
+      "end_timestamp": "2019-11-26T202555.255152",
+      "message": null,
+      "errors": [],
+      "extra_data": {
+        "files_count": 8
+      }
+    }
+  ],
+  "files": [
+    {
+      "path": "majority_and_package_root",
+      "type": "directory",
+      "name": "majority_and_package_root",
+      "base_name": "majority_and_package_root",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "copyrights": [],
+      "holders": [],
+      "authors": [],
+      "packages": [],
+      "emails": [],
+      "urls": [],
+      "files_count": 8,
+      "dirs_count": 3,
+      "size_count": 738,
+      "scan_errors": []
+    },
+    {
+      "path": "majority_and_package_root/build",
+      "type": "directory",
+      "name": "build",
+      "base_name": "build",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "copyrights": [],
+      "holders": [],
+      "authors": [],
+      "packages": [],
+      "emails": [],
+      "urls": [],
+      "files_count": 1,
+      "dirs_count": 0,
+      "size_count": 261,
+      "scan_errors": []
+    },
+    {
+      "path": "majority_and_package_root/build/BUCK",
+      "type": "file",
+      "name": "BUCK",
+      "base_name": "BUCK",
+      "extension": "",
+      "size": 261,
+      "date": "2019-10-17",
+      "sha1": "9c34c25b3c03dfd10ecdea708760ca28f1ded7cb",
+      "md5": "c0ec3769ff4b88cac753fb58fea83cfb",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "copyrights": [],
+      "holders": [],
+      "authors": [],
+      "packages": [
+        {
+          "type": "buck",
+          "namespace": null,
+          "name": "demo",
+          "version": null,
+          "qualifiers": {},
+          "subpath": null,
+          "primary_language": null,
+          "description": null,
+          "release_date": null,
+          "parties": [],
+          "keywords": [],
+          "homepage_url": null,
+          "download_url": null,
+          "size": null,
+          "sha1": null,
+          "md5": null,
+          "sha256": null,
+          "sha512": null,
+          "bug_tracking_url": null,
+          "code_view_url": null,
+          "vcs_url": null,
+          "copyright": null,
+          "license_expression": null,
+          "declared_license": null,
+          "notice_text": null,
+          "root_path": "majority_and_package_root/build",
+          "dependencies": [],
+          "contains_source_code": null,
+          "source_packages": [],
+          "purl": "pkg:buck/demo",
+          "repository_homepage_url": null,
+          "repository_download_url": null,
+          "api_data_url": null
+        }
+      ],
+      "emails": [],
+      "urls": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "majority_and_package_root/component",
+      "type": "directory",
+      "name": "component",
+      "base_name": "component",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "copyrights": [],
+      "holders": [],
+      "authors": [],
+      "packages": [],
+      "emails": [],
+      "urls": [],
+      "files_count": 4,
+      "dirs_count": 0,
+      "size_count": 202,
+      "scan_errors": []
+    },
+    {
+      "path": "majority_and_package_root/component/src1",
+      "type": "file",
+      "name": "src1",
+      "base_name": "src1",
+      "extension": "",
+      "size": 56,
+      "date": "2019-10-17",
+      "sha1": "f3eae084a5690638fd1ada38e653a94179f14263",
+      "md5": "7e0e8162de50e718e248ccd7a2d2cb65",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "apache-2.0",
+          "score": 50.0,
+          "name": "Apache License 2.0",
+          "short_name": "Apache 2.0",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "Apache Software Foundation",
+          "homepage_url": "http://www.apache.org/licenses/",
+          "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+          "spdx_license_key": "Apache-2.0",
+          "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+          "start_line": 2,
+          "end_line": 2,
+          "matched_rule": {
+            "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+            "license_expression": "apache-2.0",
+            "licenses": [
+              "apache-2.0"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false,
+            "matcher": "2-aho",
+            "rule_length": 3,
+            "matched_length": 3,
+            "match_coverage": 100.0,
+            "rule_relevance": 50.0
+          }
+        }
+      ],
+      "license_expressions": [
+        "apache-2.0"
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) The Apache Software Foundation",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "holders": [
+        {
+          "value": "The Apache Software Foundation",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "authors": [],
+      "packages": [],
+      "emails": [],
+      "urls": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "majority_and_package_root/component/src2",
+      "type": "file",
+      "name": "src2",
+      "base_name": "src2",
+      "extension": "",
+      "size": 56,
+      "date": "2019-10-17",
+      "sha1": "f3eae084a5690638fd1ada38e653a94179f14263",
+      "md5": "7e0e8162de50e718e248ccd7a2d2cb65",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "apache-2.0",
+          "score": 50.0,
+          "name": "Apache License 2.0",
+          "short_name": "Apache 2.0",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "Apache Software Foundation",
+          "homepage_url": "http://www.apache.org/licenses/",
+          "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+          "spdx_license_key": "Apache-2.0",
+          "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+          "start_line": 2,
+          "end_line": 2,
+          "matched_rule": {
+            "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+            "license_expression": "apache-2.0",
+            "licenses": [
+              "apache-2.0"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false,
+            "matcher": "2-aho",
+            "rule_length": 3,
+            "matched_length": 3,
+            "match_coverage": 100.0,
+            "rule_relevance": 50.0
+          }
+        }
+      ],
+      "license_expressions": [
+        "apache-2.0"
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) The Apache Software Foundation",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "holders": [
+        {
+          "value": "The Apache Software Foundation",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "authors": [],
+      "packages": [],
+      "emails": [],
+      "urls": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "majority_and_package_root/component/src3",
+      "type": "file",
+      "name": "src3",
+      "base_name": "src3",
+      "extension": "",
+      "size": 56,
+      "date": "2019-10-17",
+      "sha1": "f3eae084a5690638fd1ada38e653a94179f14263",
+      "md5": "7e0e8162de50e718e248ccd7a2d2cb65",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "apache-2.0",
+          "score": 50.0,
+          "name": "Apache License 2.0",
+          "short_name": "Apache 2.0",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "Apache Software Foundation",
+          "homepage_url": "http://www.apache.org/licenses/",
+          "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+          "spdx_license_key": "Apache-2.0",
+          "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+          "start_line": 2,
+          "end_line": 2,
+          "matched_rule": {
+            "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+            "license_expression": "apache-2.0",
+            "licenses": [
+              "apache-2.0"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false,
+            "matcher": "2-aho",
+            "rule_length": 3,
+            "matched_length": 3,
+            "match_coverage": 100.0,
+            "rule_relevance": 50.0
+          }
+        }
+      ],
+      "license_expressions": [
+        "apache-2.0"
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) The Apache Software Foundation",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "holders": [
+        {
+          "value": "The Apache Software Foundation",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "authors": [],
+      "packages": [],
+      "emails": [],
+      "urls": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "majority_and_package_root/component/src4",
+      "type": "file",
+      "name": "src4",
+      "base_name": "src4",
+      "extension": "",
+      "size": 34,
+      "date": "2019-10-17",
+      "sha1": "ce82bf2d5d3e79dabf5960159d1e14e46560da63",
+      "md5": "5817e002d5c6420ebcd4dfa66e500f10",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "lgpl-2.0",
+          "score": 80.0,
+          "name": "GNU Library General Public License 2.0",
+          "short_name": "LGPL 2.0",
+          "category": "Copyleft Limited",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.0.html",
+          "text_url": "http://www.gnu.org/licenses/lgpl-2.0.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:lgpl-2.0",
+          "spdx_license_key": "LGPL-2.0-only",
+          "spdx_url": "https://spdx.org/licenses/LGPL-2.0-only",
+          "start_line": 2,
+          "end_line": 2,
+          "matched_rule": {
+            "identifier": "lgpl-2.0_bare_id.RULE",
+            "license_expression": "lgpl-2.0",
+            "licenses": [
+              "lgpl-2.0"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": false,
+            "is_license_tag": true,
+            "matcher": "2-aho",
+            "rule_length": 3,
+            "matched_length": 3,
+            "match_coverage": 100.0,
+            "rule_relevance": 80.0
+          }
+        }
+      ],
+      "license_expressions": [
+        "lgpl-2.0"
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) nexB, Inc.",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "holders": [
+        {
+          "value": "nexB, Inc.",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "authors": [],
+      "packages": [],
+      "emails": [],
+      "urls": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "majority_and_package_root/package",
+      "type": "directory",
+      "name": "package",
+      "base_name": "package",
+      "extension": "",
+      "size": 0,
+      "date": null,
+      "sha1": null,
+      "md5": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "copyrights": [],
+      "holders": [],
+      "authors": [],
+      "packages": [],
+      "emails": [],
+      "urls": [],
+      "files_count": 3,
+      "dirs_count": 0,
+      "size_count": 275,
+      "scan_errors": []
+    },
+    {
+      "path": "majority_and_package_root/package/package.json",
+      "type": "file",
+      "name": "package.json",
+      "base_name": "package",
+      "extension": ".json",
+      "size": 141,
+      "date": "2019-10-17",
+      "sha1": "a4a4a28858425dfb6795ff4eb7b397846f03fda9",
+      "md5": "e10ff141105dc64fbde2dc77c61275db",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "apache-2.0",
+          "score": 100.0,
+          "name": "Apache License 2.0",
+          "short_name": "Apache 2.0",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "Apache Software Foundation",
+          "homepage_url": "http://www.apache.org/licenses/",
+          "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+          "spdx_license_key": "Apache-2.0",
+          "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+          "start_line": 5,
+          "end_line": 5,
+          "matched_rule": {
+            "identifier": "apache-2.0_65.RULE",
+            "license_expression": "apache-2.0",
+            "licenses": [
+              "apache-2.0"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": false,
+            "is_license_tag": true,
+            "matcher": "2-aho",
+            "rule_length": 4,
+            "matched_length": 4,
+            "match_coverage": 100.0,
+            "rule_relevance": 100.0
+          }
+        }
+      ],
+      "license_expressions": [
+        "apache-2.0"
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) The Apache Software",
+          "start_line": 4,
+          "end_line": 5
+        }
+      ],
+      "holders": [
+        {
+          "value": "The Apache Software",
+          "start_line": 4,
+          "end_line": 5
+        }
+      ],
+      "authors": [],
+      "packages": [
+        {
+          "type": "npm",
+          "namespace": null,
+          "name": "test-package",
+          "version": "0.0.1",
+          "qualifiers": {},
+          "subpath": null,
+          "primary_language": "JavaScript",
+          "description": null,
+          "release_date": null,
+          "parties": [],
+          "keywords": [],
+          "homepage_url": null,
+          "download_url": "https://registry.npmjs.org/test-package/-/test-package-0.0.1.tgz",
+          "size": null,
+          "sha1": null,
+          "md5": null,
+          "sha256": null,
+          "sha512": null,
+          "bug_tracking_url": null,
+          "code_view_url": null,
+          "vcs_url": null,
+          "copyright": null,
+          "license_expression": "apache-2.0",
+          "declared_license": [
+            "apache-2.0"
+          ],
+          "notice_text": null,
+          "root_path": "majority_and_package_root/package",
+          "dependencies": [],
+          "contains_source_code": null,
+          "source_packages": [],
+          "purl": "pkg:npm/test-package@0.0.1",
+          "repository_homepage_url": "https://www.npmjs.com/package/test-package",
+          "repository_download_url": "https://registry.npmjs.org/test-package/-/test-package-0.0.1.tgz",
+          "api_data_url": "https://registry.npmjs.org/test-package/0.0.1"
+        }
+      ],
+      "emails": [],
+      "urls": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "majority_and_package_root/package/src1",
+      "type": "file",
+      "name": "src1",
+      "base_name": "src1",
+      "extension": "",
+      "size": 56,
+      "date": "2019-10-24",
+      "sha1": "f3eae084a5690638fd1ada38e653a94179f14263",
+      "md5": "7e0e8162de50e718e248ccd7a2d2cb65",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "apache-2.0",
+          "score": 50.0,
+          "name": "Apache License 2.0",
+          "short_name": "Apache 2.0",
+          "category": "Permissive",
+          "is_exception": false,
+          "owner": "Apache Software Foundation",
+          "homepage_url": "http://www.apache.org/licenses/",
+          "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:apache-2.0",
+          "spdx_license_key": "Apache-2.0",
+          "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+          "start_line": 2,
+          "end_line": 2,
+          "matched_rule": {
+            "identifier": "spdx_license_id_apache-2.0_for_apache-2.0.RULE",
+            "license_expression": "apache-2.0",
+            "licenses": [
+              "apache-2.0"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false,
+            "matcher": "2-aho",
+            "rule_length": 3,
+            "matched_length": 3,
+            "match_coverage": 100.0,
+            "rule_relevance": 50.0
+          }
+        }
+      ],
+      "license_expressions": [
+        "apache-2.0"
+      ],
+      "copyrights": [
+        {
+          "value": "Copyright (c) The Apache Software Foundation",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "holders": [
+        {
+          "value": "The Apache Software Foundation",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "authors": [],
+      "packages": [],
+      "emails": [],
+      "urls": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "majority_and_package_root/package/src2",
+      "type": "file",
+      "name": "src2",
+      "base_name": "src2",
+      "extension": "",
+      "size": 78,
+      "date": "2019-10-24",
+      "sha1": "ddbbd1133bac042f1c1bcbd4aa31337756837271",
+      "md5": "79cb837ae2b9a134e62b7bf3762b5ddc",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "unknown",
+          "score": 16.0,
+          "name": "Unknown license detected but not recognized",
+          "short_name": "unknown",
+          "category": "Unstated License",
+          "is_exception": false,
+          "owner": "Unspecified",
+          "homepage_url": null,
+          "text_url": "",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:unknown",
+          "spdx_license_key": null,
+          "spdx_url": "",
+          "start_line": 2,
+          "end_line": 2,
+          "matched_rule": {
+            "identifier": "lead-in_unknown_25.RULE",
+            "license_expression": "unknown",
+            "licenses": [
+              "unknown"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false,
+            "matcher": "2-aho",
+            "rule_length": 3,
+            "matched_length": 3,
+            "match_coverage": 100.0,
+            "rule_relevance": 16
+          }
+        },
+        {
+          "key": "gpl-1.0-plus",
+          "score": 100.0,
+          "name": "GNU General Public License 1.0 or later",
+          "short_name": "GPL 1.0 or later",
+          "category": "Copyleft",
+          "is_exception": false,
+          "owner": "Free Software Foundation (FSF)",
+          "homepage_url": "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html",
+          "text_url": "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html",
+          "reference_url": "https://enterprise.dejacode.com/urn/urn:dje:license:gpl-1.0-plus",
+          "spdx_license_key": "GPL-1.0-or-later",
+          "spdx_url": "https://spdx.org/licenses/GPL-1.0-or-later",
+          "start_line": 2,
+          "end_line": 2,
+          "matched_rule": {
+            "identifier": "gpl-1.0-plus_33.RULE",
+            "license_expression": "gpl-1.0-plus",
+            "licenses": [
+              "gpl-1.0-plus"
+            ],
+            "is_license_text": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
+            "is_license_tag": false,
+            "matcher": "2-aho",
+            "rule_length": 5,
+            "matched_length": 5,
+            "match_coverage": 100.0,
+            "rule_relevance": 100.0
+          }
+        }
+      ],
+      "license_expressions": [
+        "unknown",
+        "gpl-1.0-plus"
+      ],
+      "copyrights": [
+        {
+          "value": "copyright (c) 2017 IBM Corp.",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "holders": [
+        {
+          "value": "IBM Corp.",
+          "start_line": 1,
+          "end_line": 2
+        }
+      ],
+      "authors": [],
+      "packages": [],
+      "emails": [],
+      "urls": [],
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    }
+  ]
+}


### PR DESCRIPTION
This is useful for cases where we want increased granularity of where majorities occur. Since this is a new flag in  `extra_data`, this will not impact scan outputs or results.