### PR TITLE
Update `select_ngrams()` to work in Python 3

### DIFF
--- a/src/licensedcode/tokenize.py
+++ b/src/licensedcode/tokenize.py
@@ -233,7 +233,7 @@ def select_ngrams(ngrams, with_pos=False):
                     or (py3 and isinstance(ng, str))):
                 ng = bytearray(ng, encoding='utf-8')
             else:
-                ng = bytearray(ng)
+                ng = bytearray(str(ng).encode('utf-8'))
             nghs.append(crc32(ng) & 0xffffffff)
         min_hash = min(nghs)
         if with_pos:

--- a/src/licensedcode/tokenize.py
+++ b/src/licensedcode/tokenize.py
@@ -37,9 +37,11 @@ except ImportError:
     # Python 3
     pass
 
+from binascii import crc32
 import re
-from zlib import crc32
 
+from commoncode.system import py2
+from commoncode.system import py3
 from licensedcode.stopwords import STOPWORDS
 from textcode.analysis import numbered_text_lines
 
@@ -225,7 +227,14 @@ def select_ngrams(ngrams, with_pos=False):
     last = None
     for pos, ngram in enumerate(ngrams):
         # FIXME: use a proper hash
-        nghs = [crc32(str(ng).encode('ascii')) & 0xffffffff for ng in ngram]
+        nghs = []
+        for ng in ngram:
+            if ((py2 and isinstance(ng, basestring))
+                    or (py3 and isinstance(ng, str))):
+                ng = bytearray(ng, encoding='utf-8')
+            else:
+                ng = bytearray(ng)
+            nghs.append(crc32(ng) & 0xffffffff)
         min_hash = min(nghs)
         if with_pos:
             ngram = (pos, ngram,)

--- a/tests/licensedcode/test_tokenize.py
+++ b/tests/licensedcode/test_tokenize.py
@@ -39,6 +39,7 @@ from commoncode.system import py3
 from commoncode.testcase import FileBasedTesting
 from licensedcode.tokenize import matched_query_text_tokenizer
 from licensedcode.tokenize import ngrams
+from licensedcode.tokenize import select_ngrams
 from licensedcode.tokenize import query_lines
 from licensedcode.tokenize import query_tokenizer
 from licensedcode.tokenize import tokens_and_non_tokens
@@ -513,6 +514,11 @@ class TestNgrams(FileBasedTesting):
             ('source', 'and', 'binary', 'are'),
             ('and', 'binary', 'are', 'permitted.')]
 
+        assert expected == result
+
+    def test_select_ngrams_with_unicode_inputs(self):
+        result = list(select_ngrams(x for x in [('b', 'ä', 'c'), ('ä', 'ä', 'c'), ('e', 'ä', 'c'), ('b', 'f', 'ä'), ('g', 'c', 'd')]))
+        expected = [('b', 'ä', 'c'), ('ä', 'ä', 'c'), ('e', 'ä', 'c'), ('b', 'f', 'ä'), ('g', 'c', 'd')]
         assert expected == result
 
 


### PR DESCRIPTION
This PR updates `select_ngrams()` from `src/licensedcode/tokenize.py` to work in Python 3 by:

1. Using `binascii.crc32()` instead of `zlib.crc32()` because `zlib.crc32()` has not been updated to handle Python 3 strings
2. Converting the inputs of `crc32()` to be `bytearray`s instead of strings

Signed-off-by: Jono Yang <jyang@nexb.com>