### PR TITLE
add --replace-originals flag to extractcode

### DIFF
--- a/src/extractcode/extract.py
+++ b/src/extractcode/extract.py
@@ -116,7 +116,8 @@ def extract(location, kinds=extractcode.default_kinds, recurse=False, replace_or
     archives If `recurse` is false, then do not extract further an already
     extracted archive identified by the corresponding extract suffix location.
 
-    If `replace_originals` is True, the archives will be extracted in place.
+    If `replace_originals` is True, the extracted archives are replaced by the
+    extracted content.
 
     Note that while the original file system is walked top-down, breadth-first,
     if recurse and a nested archive is found, it is extracted to full depth

--- a/src/scancode/api.py
+++ b/src/scancode/api.py
@@ -312,7 +312,7 @@ def get_file_info(location, **kwargs):
     return result
 
 
-def extract_archives(location, recurse=True):
+def extract_archives(location, recurse=True, replace_originals=False):
     """
     Yield ExtractEvent while extracting archive(s) and compressed files at
     `location`. If `recurse` is True, extract nested archives-in-archives
@@ -323,5 +323,5 @@ def extract_archives(location, recurse=True):
     """
     from extractcode.extract import extract
     from extractcode import default_kinds
-    for xevent in extract(location, kinds=default_kinds, recurse=recurse):
+    for xevent in extract(location, kinds=default_kinds, recurse=recurse, replace_originals=replace_originals):
         yield xevent

--- a/src/scancode/extract_cli.py
+++ b/src/scancode/extract_cli.py
@@ -89,11 +89,12 @@ Try 'extractcode --help' for help on options and arguments.'''
 @click.option('--verbose', is_flag=True, default=False, help='Print verbose file-by-file progress messages.')
 @click.option('--quiet', is_flag=True, default=False, help='Do not print any summary or progress message.')
 @click.option('--shallow', is_flag=True, default=False, help='Do not extract recursively nested archives (e.g. not archives in archives).')
+@click.option('--replace-originals', is_flag=True, default=False, help='Replace extracted archives by the extracted content.')
 
 @click.help_option('-h', '--help')
 @click.option('--about', is_flag=True, is_eager=True, callback=print_about, help='Show information about ScanCode and licensing and exit.')
 @click.option('--version', is_flag=True, is_eager=True, callback=print_version, help='Show the version and exit.')
-def extractcode(ctx, input, verbose, quiet, shallow, *args, **kwargs):  # NOQA
+def extractcode(ctx, input, verbose, quiet, shallow, replace_originals, *args, **kwargs):  # NOQA
     """extract archives and compressed files found in the <input> file or directory tree.
 
     Use this command before scanning proper as an <input> preparation step.
@@ -157,7 +158,7 @@ def extractcode(ctx, input, verbose, quiet, shallow, *args, **kwargs):  # NOQA
 
     extract_results = []
     has_extract_errors = False
-    extractibles = extract_archives(abs_location, recurse=not shallow)
+    extractibles = extract_archives(abs_location, recurse=not shallow, replace_originals=replace_originals)
 
     if not quiet:
         echo_stderr('Extracting archives...', fg='green')

--- a/tests/extractcode/test_extract.py
+++ b/tests/extractcode/test_extract.py
@@ -238,6 +238,55 @@ class TestExtract(FileBasedTesting):
         check_no_error(result)
         check_files(test_dir, expected)
 
+    def test_extract_tree_recursive_replace_originals(self):
+        expected = (
+            'a/a.txt',
+            'a/a.tar.gz/a/b/a.txt',
+            'a/a.tar.gz/a/b/b.txt',
+            'a/a.tar.gz/a/c/c.txt',
+            'b/a.txt',
+            'b/b.tar.gz/b/.svn/all-wcprops',
+            'b/b.tar.gz/b/.svn/entries',
+            'b/b.tar.gz/b/.svn/format',
+            'b/b.tar.gz/b/a/a.txt',
+            'b/b.tar.gz/b/a/.svn/all-wcprops',
+            'b/b.tar.gz/b/a/.svn/entries',
+            'b/b.tar.gz/b/a/.svn/format',
+            'b/b.tar.gz/b/a/.svn/prop-base/a.tar.gz.svn-base',
+            'b/b.tar.gz/b/a/.svn/text-base/a.tar.gz.svn-base',
+            'b/b.tar.gz/b/a/.svn/text-base/a.txt.svn-base',
+            'b/b.tar.gz/b/a/a.tar.gz/a/b/a.txt',
+            'b/b.tar.gz/b/a/a.tar.gz/a/b/b.txt',
+            'b/b.tar.gz/b/a/a.tar.gz/a/c/c.txt',
+            'b/b.tar.gz/b/b/a.txt',
+            'b/b.tar.gz/b/b/.svn/all-wcprops',
+            'b/b.tar.gz/b/b/.svn/entries',
+            'b/b.tar.gz/b/b/.svn/format',
+            'b/b.tar.gz/b/b/.svn/text-base/a.txt.svn-base',
+            'b/b.tar.gz/b/c/a.txt',
+            'b/b.tar.gz/b/c/.svn/all-wcprops',
+            'b/b.tar.gz/b/c/.svn/entries',
+            'b/b.tar.gz/b/c/.svn/format',
+            'b/b.tar.gz/b/c/.svn/prop-base/a.tar.gz.svn-base',
+            'b/b.tar.gz/b/c/.svn/text-base/a.tar.gz.svn-base',
+            'b/b.tar.gz/b/c/.svn/text-base/a.txt.svn-base',
+            'b/b.tar.gz/b/c/a.tar.gz/a/b/a.txt',
+            'b/b.tar.gz/b/c/a.tar.gz/a/b/b.txt',
+            'b/b.tar.gz/b/c/a.tar.gz/a/c/c.txt',
+            'c/a.txt',
+            'c/a.tar.gz/a/b/a.txt',
+            'c/a.tar.gz/a/b/b.txt',
+            'c/a.tar.gz/a/c/c.txt',
+        )
+        test_dir = self.get_test_loc('extract/tree', copy=True)
+        result = list(extract.extract(test_dir, recurse=True, replace_originals=True))
+        check_no_error(result)
+        check_files(test_dir, expected)
+        # again
+        result = list(extract.extract(test_dir, recurse=True))
+        check_no_error(result)
+        check_files(test_dir, expected)
+
     def test_extract_tree_shallow_then_recursive(self):
         shallow = (
             'a/a.tar.gz',


### PR DESCRIPTION
This adds the flag `--remove-originals` to `extractcode`. This modifies the behavior to remove the archive that was extracted from the file tree.

Related to: https://github.com/nexB/scancode-toolkit/issues/14

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://aboutcode.readthedocs.io/en/latest/scancode-toolkit/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
