### PR TITLE
Fix outdated.py version checking logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,16 @@ matrix:
       python: "3.6"
       dist: bionic
 
+    - os: linux
+      sudo: required
+      script: 
+        # This checks .ABOUT file links using `about check`
+        - source bin/activate
+        - ./bin/about check thirdparty/
+      language: python
+      python: "3.6"
+      dist: bionic
+
     # Refer https://github.com/dkhamsing/awesome_bot#command-line for more info.
     - os: linux
       sudo: required
@@ -106,16 +116,8 @@ matrix:
         - awesome_bot *.rst --allow-redirect --allow-dupe --skip-save-results
         # This checks for broken links inside README.md files of plugins/plugins-builtin folders.
         - awesome_bot */**/*.md --allow-redirect --allow-dupe --skip-save-results
-
-    - os: linux
-      sudo: required
-      script: 
-        # This checks .ABOUT file links using `about check`
-        - source bin/activate
-        - ./bin/about check thirdparty/
-      language: python
-      python: "3.6"
-      dist: bionic
+        # This checks for broken links inside Thirdparty .ABOUT files
+        - awesome_bot */*.ABOUT --allow-redirect --allow-dupe --skip-save-results
 
 addons:
   homebrew:

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,8 +106,16 @@ matrix:
         - awesome_bot *.rst --allow-redirect --allow-dupe --skip-save-results
         # This checks for broken links inside README.md files of plugins/plugins-builtin folders.
         - awesome_bot */**/*.md --allow-redirect --allow-dupe --skip-save-results
-        # This checks for broken links inside Thirdparty .ABOUT files
-        - awesome_bot */*.ABOUT --allow-redirect --allow-dupe --skip-save-results
+
+    - os: linux
+      sudo: required
+      script: 
+        # This checks .ABOUT file links using `about check`
+        - source bin/activate
+        - ./bin/about check thirdparty/
+      language: python
+      python: "3.6"
+      dist: bionic
 
 addons:
   homebrew:

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ matrix:
         # This checks for broken links inside README.md files of plugins/plugins-builtin folders.
         - awesome_bot */**/*.md --allow-redirect --allow-dupe --skip-save-results
         # This checks for broken links inside Thirdparty .ABOUT files
-        - awesome_bot */*.ABOUT --allow-redirect --allow-dupe --skip-save-results
+        - awesome_bot thirdparty/*.ABOUT --allow-redirect --allow-dupe --skip-save-results
 
 addons:
   homebrew:

--- a/src/scancode/outdated.py
+++ b/src/scancode/outdated.py
@@ -155,6 +155,16 @@ def check_scancode_version(installed_version=scancode_version,
             % (installed_version, latest_version)
         )
 
+        # Our git version string is not PEP 440 compliant, and thus improperly parsed via
+        # most 3rd party version parsers. We handle this case by pulling out the "base"
+        # release version by split()-ting on "post".
+        # 
+        # For example, "3.1.2.post351.850399ba3" becomes "3.1.2"
+        if isinstance(installed_version, packaging_version.LegacyVersion):
+            installed_version = installed_version.split('post')
+            installed_version = installed_version[0]
+            installed_version = packaging_version.parse(installed_version)
+
         # Determine if our latest_version is older
         if (installed_version < latest_version
         and installed_version.base_version != latest_version.base_version):

--- a/tests/scancode/test_outdated.py
+++ b/tests/scancode/test_outdated.py
@@ -149,3 +149,27 @@ def test_check_scancode_version_no_new_version():
         )
         result = outdated.check_scancode_version(force=True)
         assert not result
+
+
+def test_check_scancode_version_local_git_version():
+    from unittest import mock
+    pypi_mock_releases = {
+        'releases': {
+            '2.0.0': [],
+            '2.0.0rc3': [],
+            '2.0.1': [],
+            '2.1.0': [],
+            '3.0.1': [],
+            '3.1.2': [],
+        }
+    }
+    def jget(*args, **kwargs):
+        return pypi_mock_releases
+
+    with mock.patch('requests.get') as mock_get:
+        mock_get.return_value = mock.Mock(
+            json=jget,
+            status_code=200
+        )
+        result = outdated.check_scancode_version(installed_version='3.1.2.post351.850399bc3', force=True)
+        assert not result


### PR DESCRIPTION
* Update check_scancode_version() to properly handle git-based versions
* Add test case

Addresses: #1723

Signed-off-by: Steven Esser <sesser@nexb.com>