### PR TITLE
fix the bug "cannot import name RPM"

### DIFF
--- a/src/packagedcode/rpm.py
+++ b/src/packagedcode/rpm.py
@@ -35,7 +35,7 @@ from six import string_types
 
 from packagedcode import models
 from packagedcode import nevra
-from packagedcode.pyrpm import RPM
+from packagedcode.pyrpm import rpm
 from packagedcode.utils import build_description
 import typecode.contenttype
 

--- a/tests/packagedcode/test_rpm.py
+++ b/tests/packagedcode/test_rpm.py
@@ -94,7 +94,7 @@ class TestRpmBasics(FileBasedTesting):
 
     def test_pyrpm_basic(self):
         test_file = self.get_test_loc('rpm/header/python-glc-0.7.1-1.src.rpm')
-        from packagedcode.pyrpm import RPM
+        from packagedcode.pyrpm import rpm
         raw_rpm = RPM(open(test_file, 'rb'))
         alltags = raw_rpm.get_tags()
         expected = {


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #1875

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [ ] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [ ] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
