### PR TITLE
Fix memory leak in consolidation plugin

### DIFF
--- a/src/summarycode/plugin_consolidate.py
+++ b/src/summarycode/plugin_consolidate.py
@@ -388,15 +388,16 @@ def get_holders_consolidated_components(codebase):
     # going top-down through the Codebase and creating a mapping of holder key
     # -> directory resource, where the resource is the highest common ancestor
     # for a holder
-    common_holder_ancestors = {}
+    common_holder_ancestors_rids = {}
     for resource in codebase.walk(topdown=True):
         current_holders = resource.extra_data.get('current_holders', set())
         for holder in current_holders:
-            if holder not in common_holder_ancestors:
-                common_holder_ancestors[holder] = resource
+            if holder not in common_holder_ancestors_rids:
+                common_holder_ancestors_rids[holder] = resource.rid
 
     # Step 3: Consolidate Resources at the common holder ancestors that we discovered
-    for holder_key, ancestor in common_holder_ancestors.items():
+    for holder_key, ancestor_rid in common_holder_ancestors_rids.items():
+        ancestor = codebase.get_resource(ancestor_rid)
         for c in create_consolidated_components(ancestor, codebase, holder_key):
             yield c
 

--- a/src/summarycode/plugin_consolidate.py
+++ b/src/summarycode/plugin_consolidate.py
@@ -34,6 +34,7 @@ from collections import OrderedDict
 import attr
 
 from cluecode.copyrights import CopyrightDetector
+from commoncode.system import py3
 from commoncode.text import python_safe_name
 from license_expression import Licensing
 from packagedcode import get_package_instance
@@ -44,6 +45,10 @@ from plugincode.post_scan import post_scan_impl
 from scancode import CommandLineOption
 from scancode import POST_SCAN_GROUP
 from summarycode import copyright_summary
+
+
+if py3:
+    unicode = str
 
 
 # Tracing flags
@@ -391,8 +396,7 @@ def get_holders_consolidated_components(codebase):
     # holders we have already created a consolidation for.
     has_been_consolidated = set()
     for resource in codebase.walk(topdown=True):
-        current_holders = resource.extra_data.get('current_holders', set())
-        for holder in current_holders:
+        for holder in resource.extra_data.get('current_holders', set()):
             if holder in has_been_consolidated:
                 continue
             has_been_consolidated.add(holder)


### PR DESCRIPTION
This PR alleviates the memory bloat described in #1894 caused by an unnecessary dictionary exploding in size when processing a large codebase (https://github.com/nexB/scancode-toolkit/blob/develop/src/summarycode/plugin_consolidate.py#L391) This is done by creating consolidations at the same time we determine the highest common Resource for a given copyright holder.