### PR TITLE
Fix docstring for compute_relevance

### DIFF
--- a/src/licensedcode/models.py
+++ b/src/licensedcode/models.py
@@ -1103,7 +1103,7 @@ class Rule(object):
         "relevance" attribute or computed base on the rule length here using
         this approach:
 
-        - a false positive or a negative rule has a relevance of zero.
+        - a false positive or a negative rule has a relevance of 100.
         - a rule of length equal to or larger than a threshold has a 100 relevance
         - a rule of length smaller than a threshold has a relevance of
           100/threshold, rounded down.


### PR DESCRIPTION
Fixes a docstring error, which was explaining the relevance scores
of negative and false positive rules.

Signed-off-by: Ayan Sinha Mahapatra <ayansmahapatra@gmail.com>

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
