### PR TITLE
Add test for copyright with year range #2140

### DIFF
--- a/tests/cluecode/data/copyrights/florian_notice.txt
+++ b/tests/cluecode/data/copyrights/florian_notice.txt
@@ -1,0 +1,11 @@
+Spring Framework 5.2.6.RELEASE
+Copyright (c) 2002-2020 Pivotal, Inc.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.
+
+This product may include a number of subcomponents with separate
+copyright notices and license terms. Your use of the source code for
+these subcomponents is subject to the terms and conditions of the
+subcomponent's license, as noted in the license.txt file.

--- a/tests/cluecode/data/copyrights/florian_notice.txt.yml
+++ b/tests/cluecode/data/copyrights/florian_notice.txt.yml
@@ -1,0 +1,11 @@
+what:
+  - copyrights
+  - holders
+  - holders_summary
+copyrights:
+  - Copyright (c) 2002-2020 Pivotal, Inc.
+holders:
+  - Pivotal, Inc.
+holders_summary:
+  - value: Pivotal, Inc.
+    count: 1


### PR DESCRIPTION
This issue existed on 3.0.2 and was fixed with commit:
7ca51158e50ad24f17f3596503cad3334ddbb261
This is for #2140

Reported-by: @FlorianSW
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>
### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
