### PR TITLE
Do not use attrs 20.1.0 as a workaround for #2201

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -208,8 +208,10 @@ jobs:
             displayName: 'Build installable releases'
 
           - script: ./etc/release/pip-install.sh
-            displayName: 'Test pip installation'
+            displayName: 'Test pip wheel installation'
 
+          - script: ./etc/release/pip-install-editable.sh
+            displayName: 'Test pip editable installation'
 
 ################################################################################
 # These jobs are using VMs and Azure-provided Pythons 3.6

--- a/etc/release/pip-install-editable.sh
+++ b/etc/release/pip-install-editable.sh
@@ -11,14 +11,14 @@ set -e
 # un-comment to trace execution
 set -x
 
-echo "###  Installing ScanCode release with pip ###"
+echo "###  Installing ScanCode release with pip editable###"
 
-mkdir -p tmp/pip
-python -m venv tmp/pip
-tmp/pip/bin/pip install dist/scancode_toolkit*.whl
+mkdir -p tmp/pipe
+python -m venv tmp/pipe
+tmp/pipe/bin/pip install -e .
 
 # perform a minimal check of the results for https://github.com/nexB/scancode-toolkit/issues/2201
-if [ `tmp/pip/bin/scancode -i --json-pp - NOTICE | grep -c "scan_timings"` == 1 ]; then
+if [ `tmp/pipe/bin/scancode -i --json-pp - NOTICE | grep -c "scan_timings"` == 1 ]; then
    echo "Failed scan that includes timings"
    exit 1
 else

--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ setup(
         'click >= 6.0.0, < 7.0.0',
         'colorama >= 0.3.9',
         'pluggy >= 0.4.0, < 1.0',
-        'attrs >=18.1',
+        'attrs >=18.1, !=20.1.0',
         'typing >=3.6, < 3.7',
 
         # scancode outputs


### PR DESCRIPTION
Prohibit attrs v 20.1.0 in install requires.
Add smoke tests for a wheel and editable installation.

This is a fix for #2201
Big thanks to @hynek for the help.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>