### PR TITLE
Do not fail if Debian status is missing

### DIFF
--- a/src/packagedcode/debian.py
+++ b/src/packagedcode/debian.py
@@ -197,16 +197,20 @@ class DebianPackage(models.Package):
                 return copyright_loc
 
 
-def get_installed_packages(root_dir, distro='debian', detect_licenses=False):
+def get_installed_packages(root_dir, distro='debian', detect_licenses=False, **kwargs):
     """
     Given a directory to a rootfs, yield a DebianPackage and a list of `installed_files`
     (path, md5sum) tuples.
     """
-    # guard from recursive import
-    from packagedcode import debian_copyright
 
     base_status_file_loc = os.path.join(root_dir, 'var/lib/dpkg/status')
+    if not os.path.exists(base_status_file_loc):
+        return
+
     var_lib_dpkg_info_dir = os.path.join(root_dir, 'var/lib/dpkg/info/')
+
+    # guard from recursive import
+    from packagedcode import debian_copyright
 
     for package in parse_status_file(base_status_file_loc, distro=distro):
         package.populate_installed_files(var_lib_dpkg_info_dir)

--- a/tests/packagedcode/test_debian.py
+++ b/tests/packagedcode/test_debian.py
@@ -54,6 +54,11 @@ class TestDebianPackageGetInstalledPackages(PackageTester):
         expected = self.get_test_loc('debian/basic-rootfs-with-licenses-expected.json')
         check_result_equals_expected_json(result, expected, regen=False)
 
+    def test_get_installed_packages_should_not_fail_on_rootfs_without_installed_debian_packages(self):
+        test_rootfs = self.get_temp_dir()
+        result = list(debian.get_installed_packages(test_rootfs))
+        assert [] == result
+
 
 class TestDebian(PackageTester):
     test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
@@ -62,6 +67,14 @@ class TestDebian(PackageTester):
         test_file = self.get_test_loc('debian/not-a-status-file')
         test_packages = list(debian.parse_status_file(test_file))
         assert [] == test_packages
+
+    def test_parse_status_file_non_existing_file(self):
+        test_file = os.path.join(self.get_test_loc('debian'), 'foobarbaz')
+        try:
+            list(debian.parse_status_file(test_file))
+            self.fail('FileNotFoundError not raised')
+        except FileNotFoundError:
+            pass
 
     def test_parse_status_file_basic(self):
         test_file = self.get_test_loc('debian/basic/status')

--- a/tests/packagedcode/test_debian.py
+++ b/tests/packagedcode/test_debian.py
@@ -27,13 +27,14 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os.path
+from unittest.case import skipIf
 
+from commoncode.system import py2
+from commoncode.system import on_windows
 from packagedcode import debian
 from packagedcode import models
 from packages_test_utils import PackageTester
 from packages_test_utils import check_result_equals_expected_json
-from unittest.case import skipIf
-from commoncode.system import on_windows
 
 
 @skipIf(on_windows, 'These tests contain files that are not legit on Windows.')
@@ -68,6 +69,7 @@ class TestDebian(PackageTester):
         test_packages = list(debian.parse_status_file(test_file))
         assert [] == test_packages
 
+    @skipIf(py2, 'FileNotFoundError is not defined on Python2')
     def test_parse_status_file_non_existing_file(self):
         test_file = os.path.join(self.get_test_loc('debian'), 'foobarbaz')
         try:


### PR DESCRIPTION
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #0000

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
