### PR TITLE
Add new license detection HESSLA

### DIFF
--- a/src/licensedcode/data/licenses/hessla.LICENSE
+++ b/src/licensedcode/data/licenses/hessla.LICENSE
@@ -1,0 +1,933 @@
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION, USE AND/OR MODIFICATION
+
+0. DEFINITIONS. The following are defined terms that, whenever used in
+this License Agreement, have the following meanings:
+
+0.1 Author: "Author" shall mean the copyright holder of an Original
+Work (the "Program") released by the Author under this License
+Agreement.
+
+0.2 Copy: "Copy" shall mean everything and anything that constitutes a
+copy according to copyright law, without limitation. A "copy" does not
+become anything other than a "copy" merely because, for example, a
+governmental or institutional employee duplicates the Program or a
+part of it for another employee of the same institution or
+Governmental Entity, or merely because it is copied from one computer
+to another, or from one medium to another, or multiple copies are made
+on the same medium, within the same institutional or Governmental
+Entity.
+
+0.3 Derivative Work: A "Derivative Work" or "work based on the
+Program" shall mean either the Program itself or any work containing
+the Program or a portion of it, either verbatim or with modifications
+and/or translated into another language. (Hereinafter, translation is
+included without limitation in the term "modification."). In the
+unlikely event that, and to the extent that, this contractual
+definition of "Derivative Work" is later determined by any tribunal or
+dispute-resolution body to be different is scope from the meaning of
+"derivative work" under the copyright law of any country, then the
+broadest and most encompassing possible definition either the
+contractual definition of "Derivative Work," or any broader and more
+encompassing statutory or legal definition, shall control. Acceptance
+of this contractually-defined scope of the term "Derivative Work" is a
+mandatory pre-condition for You to receive any of the benefits offered
+by this License Agreement.
+
+0.3.1 Mere aggregation of another work not based on the Program with
+the Program (or with a Derivative Work based on the Program) on a
+volume of a storage or distribution medium does not bring the other
+work under the scope of this License Agreement.
+
+0.4 License Agreement: When used in this License Agreement, the terms
+"this License" or "this License Agreement" shall mean The Hactivismo
+Enhanced-Source Software License Agreement, v. 0.1, or any subsequent
+version made applicable under the terms of Section 15.
+
+0.5 Licensee: The term "Licensee" shall mean You or any other
+Licensee, whether or not a Qualified Licensee.
+
+0.6 Original Work: "Original Work" shall mean a Program or other work
+of authorship, or portion thereof, that is not a Derivative Work.
+
+0.7 Program: The "Program," to which this License Agreement applies,
+is the Original Work (including, but not limited to, computer
+software) released by the Author under this License Agreement.
+
+0.8 Qualified Licensee: A "Qualified Licensee" means a Licensee that
+remains in full compliance with all terms and conditions of this
+License Agreement. You are no longer a Qualified Licensee if, at any
+time, You violate any terms of this License Agreement. Neither the
+Program nor any Software based on the Program may be copied,
+distributed, performed, displayed, used or modified by You, even for
+Your own purposes, unless You are a Qualified Licensee. A Licensee
+other than a Qualified Licensee remains subject to all terms and
+conditions of this License Agreement, and to all remedies for each
+cumulative violation as set forth herein. Loss of the status of
+Qualified Licensee signifies that violation of any terms of the
+License Agreement subjects a Licensee to loss of most of the benefits
+that Qualified Licensees enjoy under this License Agreement, and to
+additional remedies for all violations occurring after the first
+violation.
+
+0.9 Software: "Software" or "the Software" shall mean the Program, any
+Derivative Work based on the Program or a portion thereof, and/or any
+modified version of the Program or portion thereof, without
+limitation.
+
+0.10 Source Code: The term "Source Code" shall mean the preferred form
+of a Program or Original Work for making modifications to it and all
+available documentation describing how to access and modify that
+Program or Original Work.
+
+0.10.1 For an executable work, complete Source Code means all the
+Source Code for all modules it contains, plus any associated interface
+definition files, plus the scripts used to control compilation and
+installation of the executable. However, as a special exception, the
+Source Code distributed need not include anything that is normally
+distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+0.10.2 "Object Code:" Because of certain peculiarities of current
+export-control rules, "object code" of the Program, or any modified
+version of the Program, or Derivative Work based on the Program, must
+not be exported except by way of distribution that is ancillary to the
+distribution of the Source Code. The "Source Code" shall be understood
+as the primary content transferred or exported by You, and the "object
+code" shall be considered as merely an ancillary component of any such
+export distribution.
+
+0.11 Strong Cryptography: "Strong Cryptography" shall mean
+cryptography no less secure than (for example, and without limitation)
+a 2048-bit minimum key size for RSA encryption, 1024-bit minimum key
+size for Diffie-Hellman (El Gamal), or a 256-bit minimum key size for
+AES and similar symmetric ciphers.
+
+0.12 Substandard Key-Selection Technique: The term "Substandard
+Key-Selection Technique" shall mean a method or technique to cause
+encryption keys to be more easily guessed or less secure, such as by
+(i) causing the selection of keys to be less than random, or (ii)
+employing a selection process that selects among only a subset of
+possible keys, instead of from among the largest set of possible keys
+that can securely be used consistent with contemporary knowledge about
+the cryptographic techniques employed by You. The following
+illustrations elaborate on the foregoing definition:
+
+0.12.1 If the key-generation or key-selection technique for the
+encryption algorithm You employ involves the selection of one or more
+prime numbers, or involves one or more mathematical functions or
+concatenations performed on one or more prime numbers, then each prime
+number should be selected from a very large set of candidate prime
+numbers, but not necessarily from the set of all possible prime
+numbers (e.g., inclusion of the number 1 in the candidate set, for
+example, may in some instances reduce rather than enhance security),
+and absolutely not from any artificially small set of candidate primes
+that makes the guessing of a key easier than would be the case if a
+secure key-generation technique were employed. In all instances, the
+primes should be selected at random from among the candidate set. If
+there is a customary industry standard for maximizing the security
+associated with the key-generation or key-selection technique for the
+cryptosystem You select, then (with attention also to the requirements
+of Section 0.11), You should employ a key-generation or selection
+technique no less secure than the customary industry standard for
+secure use of the cryptosystem.
+
+0.12.2 If the key-generation or key-selection technique for the
+encryption algorithm You employ involves the selection of a random
+integer, or the transformation of a random integer through one or more
+mathematical processes, then the selection of the integer shall be at
+random from the largest possible set of all possible integers
+consistent with the secure functioning of the encryption algorithm. It
+shall not be selected from an artificially small set of integers
+(e.g., if a 256-bit random integer serves as the key, then You could
+not set 200 of the 256 bits as "0," and randomly generate only the
+remaining 56 bits producing effectively a 56-bit keylength instead of
+using the full 256 bits).
+
+0.12.3 In other words, Your key-generation technique must promote
+security to the maximum extent permitted by the cryptographic
+method(s) and keylength You elect to employ, rather than facilitating
+eavesdropping or surveillance in any way. The example of GSM
+telephones, in which 16 of 56 bits in each encryption key were set at
+"0," thereby reducing the security of the system by a factor of
+65,536, is particularly salient. Such artificial techniques to reduce
+the security of a cryptosystem by selecting keys from only a
+less-secure or suboptimal subset of possible keys, is prohibited and
+will violate this License Agreement if any such technique is employed
+in any Software.
+
+0.13 You: Each Licensee (including, without limitation, Licensees that
+have violated the License Agreement and who are no longer Qualified
+Licensees, but who nevertheless remain subject to all requirements of
+this License Agreement and to all cumulative remedies for each
+successive violation), is referred to as "You."
+
+0.13.1 Governmental Entity: "You" explicitly includes any and all
+"Governmental Entities," without limitation. "Governmental Entity" or
+"Governmental Entities," when used in this License Agreement, shall
+mean national governments, sub-national governments (for example, and
+without limitation, provincial, state, regional, local and municipal
+governments, autonomous governing units, special districts, and other
+such entities), governmental subunits (without limitation,
+governmental agencies, offices, departments, government corporations,
+and the like), supra-national governmental entities such as the
+European Union, and entities through which one or more governments
+perform governmental functions or exercise governmental power in
+coordination, cooperation or unison.
+
+0.13.2 Governmental Person: "You" also explicitly includes
+"Governmental Persons." The terms "Governmental Person" or
+"Governmental Persons," when used in this License Agreement, shall
+mean the officials, officers, employees, representatives, contractors
+and agents of any Governmental Entity.
+
+1. Application of License Agreement. This License Agreement applies to
+any Program or other Original Work of authorship that contains a
+notice placed by the Author saying it may be distributed under the
+terms of this License Agreement. The preferred manner of placing such
+a notice is to include the following statement immediately after the
+copyright notice for such an Original Work:
+
+    "Licensed under the Hacktivismo Enhanced-Source Software License
+    Agreement, Version 0.1"
+
+2. Means of Acceptance Use, Copying, Distribution or Modification By
+Anyone Constitutes Acceptance. Subject to Section 14.1 (concerning the
+special case of certain Governmental Entities) any copying,
+modification, distribution, or use by You of the Program or any
+Software, shall constitute Your acceptance of all terms and conditions
+of this License Agreement.
+
+2.1 As a Licensee, You may not authorize, permit, or enable any person
+to use the Program or any Software or Derivative Work based on it
+(including any use of Your copy or copies of the Program) unless such
+person has accepted this License Agreement and has become a Licensee
+subject to all its terms and conditions.
+
+2.2 You may not make any copy for Your own use unless You have
+accepted this License Agreement and subjected yourself to all its
+terms and conditions.
+
+2.3 You may not make a copy for the use of any other person, or
+transfer a copy to any other person, unless such person is a Licensee
+that has accepted this License Agreement and such person is subject to
+all terms and conditions of this License Agreement.
+
+2.4 It is not the position of Hacktivismo that copyright law confers
+an exclusive right to use, as opposed to the exclusive right to copy
+the Software. However, for purposes of contract law, any use of the
+Software shall be considered to constitute acceptance of this License
+Agreement. Moreover, all copying is prohibited unless the recipient of
+a copy has accepted the License Agreement. Because each such recipient
+Licensee is contractually obligated not to permit anyone to access,
+use, or secure a copy of the Software, without first accepting the
+terms and conditions of this License Agreement, use by non-Licensees
+is effectively prohibited contractually because nobody can obtain a
+copy of, or access to a copy of, any Software without (1) accepting
+the License Agreement through use, and (2) triggering some Licensee's
+obligation to require acceptance as a precondition of copying or
+access.
+
+3. "Qualified Licensee" Requirement: Neither the Program nor any
+Software or Derivative Work based on the Program may be copied,
+distributed, displayed, performed, used or modified by You, even for
+Your own purposes, unless You are a "Qualified Licensee." To remain a
+Qualified Licensee, You must remain in full compliance with all terms
+and conditions of this License Agreement.
+
+4. License Agreement Is Exclusive Source of All Your Rights:
+
+4.1 You may not copy, modify, or distribute the Program, or obtain any
+copy, except as expressly provided under this License Agreement. Any
+attempt otherwise to copy, modify, obtain a copy, sublicense or
+distribute the Program is void, and will automatically terminate Your
+rights under this License Agreement and subject You to all cumulative
+remedies for each successive violation that may be available to the
+Author. However, Qualified Licensees who have received copies from You
+(and thereby have received rights from the Author) under this License
+Agreement, and who would otherwise qualify as Qualified Licensees,
+will not have their rights under their License Agreements suspended or
+restricted on account of anything You do, so long as such parties
+remain in full compliance.
+
+4.2 You are not required to accept this License Agreement and prior to
+the time You elect to become a Licensee and accept this License
+Agreement, You may always elect instead not to copy, use, modify,
+distribute, compile, or perform the Program or any Software released
+under this License Agreement. However, nothing else grants You
+permission to copy, to obtain or possess a copy, to compile a copy in
+object code or executable code from a copy in source code, to modify,
+or to distribute the Program or any Software based on the
+Program. These actions are prohibited by law if You do not accept this
+License Agreement. Additionally, as set forth in Section 2, any use,
+copying or modification of the Software constitutes acceptance of this
+License Agreement by You.
+
+4.3 Each time You redistribute the Program (or any Software or
+Derivative Work based on the Program), the recipient automatically
+receives a License Agreement from the Author to copy, distribute,
+modify, perform or display the Software, subject to the terms and
+conditions of this License Agreement. You may not impose any further
+restrictions on the recipients' exercise of the rights granted
+herein. You are not responsible for enforcing compliance by third
+parties to this License Agreement. Enforcement is the responsibility
+of the Author.
+
+5. Grant of Source Code License.
+
+5.1 Source Code Always Available from Author: Author hereby promises
+and agrees except to the extent prohibited by export-control law to
+provide a machine-readable copy of the Source Code of the Program at
+the request of any Licensee. Author reserves the right to satisfy this
+obligation by placing a machine-readable copy of the Source Code of
+the most current version of the Program in an information repository
+reasonably calculated to permit inexpensive and convenient access by
+You for so long as Author continues to distribute the Program, and by
+publishing the address of that information repository in a notice
+immediately following the copyright notice that applies to the
+Program. Every copy of the Program distributed by Hacktivismo (but not
+necessarily every other Author) consists of the Source Code
+accompanied, in some instances, by an ancillary distribution of
+compiled Object Code, but the continued availability of the Source
+Code from the Author addresses the possibility that You might have
+(for any reason) not received from someone else a complete, current,
+copy of the Source Code (lack of which would, for example, prevent You
+from exporting copies to others without violating this license, see
+Section 8).
+
+5.2 Grant of License. If and only if, and for so long as You remain a
+Qualified Licensee, in accordance with Section 3 of this License
+Agreement, Author hereby grants You a world-wide, royalty-free,
+non-exclusive, non-sublicensable copyright license to do the
+following:
+
+5.2.1 to reproduce the Source Code of the Program in copies;
+
+5.2.2 to prepare Derivative Works based upon the Program and to edit
+or modify the Source Code in the process of preparing such Derivative
+Works;
+
+5.2.3 to distribute copies of the Source Code of the Original Work
+and/or of Derivative Works to others, with the proviso that copies of
+Original Work or Derivative Works that You distribute shall be
+licensed under this License Agreement, and that You shall fully inform
+all recipients of the terms of this License Agreement.
+
+6. Grant of Copyright License. If and only if, and for so long as You
+remain a Qualified Licensee, in accordance with Section 3 of this
+License Agreement, Author hereby grants You a world-wide,
+royalty-free, non-exclusive, non-sublicensable license to do the
+following:
+
+6.1 to reproduce the Program in copies;
+
+6.2 to prepare Derivative Works based upon the Program, or upon
+Software that itself is based on the Program;
+
+6.3 to distribute (either by distributing the Source Code, or by
+distributing compiled Object Code, but any export of Object Code must
+be ancillary to a distribution of Source Code) copies of the Program
+and Derivative Works to others, with the proviso that copies of the
+Program or Derivative Works that You distribute shall be licensed
+under this License Agreement, that You shall fully inform all
+recipients of the terms of this License Agreement;
+
+6.4 to perform the Program or a Derivative Work publicly;
+
+6.5 to display the Program or a Derivative Work publicly; and
+
+6.6 to charge a fee for the physical act of transferring a copy of the
+Program (You may also, at Your option, offer warranty protection in
+exchange for a fee).
+
+7. Grant of Patent License. If and only if, and for so long as You
+remain a Qualified Licensee, in accordance with Section 3 of this
+License Agreement, Author hereby grants You a world-wide,
+royalty-free, non-exclusive, non-sublicensable license Agreement,
+under patent claims owned or controlled by the Author that are
+embodied in the Program as furnished by the Author ("Licensed Claims")
+to make, use, sell and offer for sale the Program. Subject to the
+proviso that You grant all Licensees a world-wide, non-exclusive,
+royalty-free license under any patent claims embodied in any
+Derivative Work furnished by You, Author hereby grants You a
+world-wide, royalty-free, non-exclusive, non-sublicensable license
+under the Licensed Claims to make, use, sell and offer for sale
+Derivative Works.
+
+8. Exclusions From License Agreement Grants. Nothing in this License
+Agreement shall be deemed to grant any rights to trademarks,
+copyrights, patents, trade secrets or any other intellectual property
+of Licensor except as expressly stated herein. No patent license is
+granted to make, use, sell or offer to sell embodiments of any patent
+claims other than the Licensed Claims defined in Section 7. No right
+is granted to the trademarks of Author even if such marks are included
+in the Program. Nothing in this License Agreement shall be interpreted
+to prohibit Author from licensing under additional or different terms
+from this License Agreement any Original Work, Program, or Derivative
+Work that Author otherwise would have a right to License.
+
+8.1 Implied Endorsements Prohibited. Neither the name of the Author
+(in the case of Programs and Original Works released by Hacktivismo,
+the name "Hacktivismo"), nor the names of contributors who helped
+produce the Program may be used to endorse or promote modifications of
+the Program, any Derivative Work, or any Software other than the
+Program, without specific prior written permission of the
+Author. Neither the name of Hacktivismo nor the names of any
+contributors who helped write the Program may be used to endorse or
+promote any Program or Software released under this License Agreement
+by any person other than Hacktivismo.
+
+9. Modifications and Derivative Works. Only Qualified Licensees may
+modify the Software or prepare or distribute Derivative Works. If You
+are a Qualified Licensee, Your authorization to modify the Software or
+prepare or distribute Derivative Works (including permission to
+prepare and/or distribute Derivative Works, as provided in Sections
+5.2.2, 5.2.3, 6.2, 6.3, and 6.6) is subject to each and all of the
+following mandatory terms and conditions (9.1 through 9.6, inclusive):
+
+9.1 You must cause the modified files to carry prominent notices
+stating that You changed the files and the date of any change;
+
+9.2 If the modified Software normally reads commands interactively
+when run, You must cause it, when started running for such interactive
+use in the most ordinary way, to print or display an announcement
+including an appropriate copyright notice and a notice that there is
+no warranty (or else, saying that You provide a warranty) and that
+users may redistribute the program under this License Agreement, and
+telling the user how to view a copy of this License
+Agreement. (Exception: if the Program itself is interactive but does
+not normally print such an announcement, Your Derivative Work based on
+the Program is not required to print an announcement.);
+
+9.3 Any Program, Software, or modification thereof copied or
+distributed by You, that incorporates any portion of the Original
+Work, must not contain any code or functionality that subverts the
+security of the Software or the end-user's expectations of privacy,
+anonymity, confidentiality, authenticity, and trust, including
+(without limitation) any code or functionality that introduces any
+"backdoor," escrow mechanism, "spy-ware," or surveillance techniques
+or methods into any such Program, Software, or modification thereof;
+
+9.4 Any Program, Software, or modification thereof copied or
+distributed by You, that employs any cryptographic or other security,
+privacy, confidentiality, authenticity, and/or trust methods or
+techniques, including without limitation any Derivative Work that
+includes any changes or modifications to any cryptographic techniques
+in the Program, shall employ Strong Cryptography.
+
+9.5 Any Program, Software, or modification thereof copied or
+distributed by You, if it contains any key-generation or selection
+technique, must not employ any Substandard Key-Selection Technique.
+
+9.6 No Program or Software copied or distributed by You may transmit
+or communicate any symmetric key, any "private key" if an asymmetric
+cryptosystem is employed, or any part of such key, nor may it
+otherwise make any such key or part of such key known, to any person
+other than the end-user who generated the key, without the active
+consent and participation of that individual end-user. If a private or
+symmetric key is stored or recorded in any manner, it must not be
+stored or recorded in plaintext, and it must be protected from reading
+(at a minimum) by use of a password. Use of steganography or other
+techniques to disguise the fact that a private or symmetric key is
+even stored is strongly encouraged, but not absolutely required.
+
+10. Use Restrictions: Human Rights Violations Prohibited.
+
+10.1 Neither the Program, nor any Software or Derivative Work based on
+the Program may used by You for any of the following purposes (10.1.1
+through 10.1.5, inclusive):
+
+10.1.1 to violate or infringe any human rights or to deprive any
+person of human rights, including, without limitation, rights of
+privacy, security, collective action, expression, political freedom,
+due process of law, and individual conscience;
+
+10.1.2 to gather evidence against any person to be used to deprive any
+person of human rights;
+
+10.1.3 any other use as a part of any project or activity to deprive
+any person of human rights, including not only the above-listed
+rights, but also rights of physical security, liberty from physical
+restraint or incarceration, freedom from slavery, freedom from
+torture, freedom to take part in government, either directly or
+through lawfully elected representatives, and/or freedom from
+self-incrimination;
+
+10.1.4 any surveillance, espionage, or monitoring of individuals,
+whether done by a Governmental Entity, a Governmental Person, or by
+any non-governmental person or entity;
+
+10.1.5 censorship or "filtering" of any published information or expression.
+
+10.2 Additionally, the Program, any modification of it, or any
+Software or Derivative Work based on the Program may not be used by
+any Governmental Entity or other institution that has any policy or
+practice (whether official or unofficial) of violating the human
+rights of any persons.
+
+10.3 You may not authorize, permit, or enable any person (including,
+without limitation, any Governmental Entity or Governmental Person) to
+use the Program or any Software or Derivative Work based on it
+(including any use of Your copy or copies of the Program) unless such
+person has accepted this License Agreement and has become a Licensee
+subject to all its terms and conditions, including (without
+limitation) the use restrictions embodied in Section 10.1 and 10.2,
+inclusive.
+
+11. All Export Distributions Must Consist of or Be Ancillary to
+Distribution of Source Code. Because of certain peculiarities of
+current export-control law, any distribution by You of the Program or
+any Software may be in the form of Source Code only, or in the form or
+Source Code accompanied by compiled Object Code, but You may not
+export any Software in the form of compiled Object Code only. Such an
+export distribution of compiled executable code must in all cases be
+ancillary to a distribution of the complete corresponding
+machine-readable source code, which must be distributed on a medium,
+or by a method, customarily used for software interchange.
+
+12. EXPORT LAWS: THIS LICENSE AGREEMENT ADDS NO RESTRICTIONS TO THE
+EXPORT LAWS OF YOUR JURISDICTION. It is Your responsibility to comply
+with any export regulations applicable in Your jurisdiction. From the
+United States, Canada, or many countries in Europe, export or
+transmission of this Software to certain embargoed destinations
+(including, but not necessarily limited to, Cuba, Iran, Iraq, Libya,
+North Korea, Sudan, and Syria), may be prohibited. If Hacktivismo is
+identified as the Author of the Program (and it is not the property of
+some other Author), then export to any national of Cuba, Iran, Iraq,
+Libya, North Korea, Sudan or Syria, or into the territory of any of
+these countries, by any Licensee who has received this Software
+directly from Hacktivismo or from the Cult of the Dead Cow, or any of
+their members, is contractually prohibited and will constitute a
+violation of this License Agreement. You are advised to consult the
+current laws of any and all countries whose laws may apply to You,
+before exporting this Software to any destination. Special care should
+be taken to avoid export to any embargoed destination. An Author other
+than Hacktivismo may substitute that Author's legal name for
+"Hacktivismo" in this Paragraph, in relation to any Program released
+by that Author under this Paragraph.
+
+13. Contrary Judgments, Settlements and Court Orders. If, as a
+consequence of a court judgment or allegation of patent infringement
+or for any other reason (not limited to patent issues), conditions are
+imposed on You (whether by court order, agreement or otherwise) that
+contradict the conditions of this License Agreement, they do not
+excuse You from the conditions of this License Agreement. If You
+cannot distribute so as to satisfy simultaneously Your obligations
+under this License Agreement and any other pertinent obligations, then
+as a consequence You may not distribute the Software at all. For
+example, if a patent license would not permit royalty-free
+redistribution of the Program by all those who receive copies directly
+or indirectly through You, then the only way You could satisfy both it
+and this License Agreement would be to refrain entirely from
+distribution of the Program.
+
+It is not the purpose of this Section 13 to induce You to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this Section has the sole purpose of protecting the
+integrity of the software distribution system reflected in this
+License Agreement, which is implemented by public license
+practices. Many people have made generous contributions to the wide
+range of software distributed through related distribution systems, in
+reliance on consistent application of such distribution systems; it is
+up to the Author/donor to decide if he or she is willing to distribute
+software through any other system and a Licensee cannot impose that
+choice.
+
+14. Governmental Entities: Any Governmental Entity ("Governmental
+Entity" is defined broadly as set forth in Section 0.13.1) or
+Governmental Person (as "Governmental Person" is defined broadly in
+Section 0.13.2), that uses, modifies, changes, copies, displays,
+performs, or distributes the Program, or any Software or Derivative
+Work based on the Program, may do so if and only if all of the
+following terms and conditions (14.1 through 14.10, inclusive) are
+agreed to and fully met:
+
+14.1 If it is the position of any Governmental Entity (or, in the case
+of any "Governmental Person," if it is the position of that
+Governmental Person's Governmental Entity) that any doctrine or
+doctrines of law (including, without limitation, any doctrine(s) of
+immunity or any formalities of contract formation) may render this
+License Agreement unenforceable or less than fully enforceable against
+such Governmental Entity, or any Governmental Person of such
+Governmental Entity, then prior to any use, modification, change,
+display, performance, copy or distribution of the Program, or of any
+Software or Derivative Work based on the Program, or any part thereof,
+by the Governmental Entity, or by any Governmental Person of that
+Governmental Entity, the Governmental Entity shall be required to
+inform the Author in writing of each such doctrine that is believed to
+render this License Agreement or any part of it less than fully
+enforceable against such Governmental Entity or any Governmental
+Person of such entity, and to explain in reasonable detail what
+additional steps, if taken, would render the License Agreement fully
+enforceable against such entity or person. Failure to provide the
+required written notice to the Author in advance of any such use,
+modification, change, display, performance, copy or distribution,
+shall constitute an irrevocable and conclusive waiver of any and all
+reliance on any doctrine, by the Governmental Entity, that is not
+included or that is omitted from the required written notice (failure
+to provide any written notice means all reliance on any doctrine is
+irrevocably waived). Any Governmental Entity that provides written
+notice under this subsection is prohibited, as are all of the
+Governmental Persons of such Governmental Entity, from making any use,
+change, display, performance, copy, modification or distribution of
+the Software or any part thereof, until such time as a License
+Agreement is in place, agreed upon by the Author and by the
+Governmental Entity, that such entity concedes is
+fully-enforceable. Any use, modification, change, display,
+performance, copy, or distribution following written notice under this
+Paragraph, but without the implementation of an agreement as provided
+herein, shall constitute an irrevocable and conclusive waiver by the
+Governmental Entity (and any and all Governmental Persons of such
+Governmental Entity) of any and all reliance on any legal doctrine
+either referenced in such written notice or omitted from it.
+
+14.2 Any Governmental Entity that uses, copies, changes, modifies, or
+distributes, the Software or any part or portion thereof, or any
+Governmental Person who does so (whether that person's Governmental
+Entity contends the person's action was, or was not, authorized or
+official), permanently and irrevocably waives any defense based on
+sovereign immunity, official immunity, the Act of State Doctrine, or
+any other form of immunity, that might otherwise apply as a defense
+to, or a bar against, any legal action based on the terms of this
+License Agreement.
+
+14.2.1 With respect to any enforcement action brought by the Author in
+a United States court against a foreign Governmental Entity, the
+waiver by any Governmental Entity as provided in Subparagraphs 14.1
+and 14.2 is hereby expressly acknowledged by each such Governmental
+Entity to constitute a "case . . . in which the foreign state has
+waived its immunity," within the scope of 28 U.S.C. � 1605(a)(1) of
+the Foreign Sovereign Immunities Act of 1976 (as amended). Each such
+Governmental Entity also specifically agrees and concedes that the
+"commercial activity" exceptions to the FSIA, 28 U.S.C. � 1605(a)(2),
+(3) are also applicable. With respect to an action brought against the
+United States or any United States Governmental Entity, in the courts
+of any country, the U.S. Governmental Entity shall be understood to
+have voluntarily agreed to a corresponding waiver of immunity from
+actions in the courts of any other sovereign.
+
+14.2.2 With respect to any enforcement action brought by an authorized
+end-user (as a third-party beneficiary, under the terms of
+Subparagraphs 14.3 and 14.10) in a United States court against a
+foreign Governmental Entity, the waiver by any Governmental Entity as
+provided in Subparagraphs 14.1 and 14.2 is hereby expressly
+acknowledged by each such Governmental Entity to constitute a "case
+. . . in which the foreign state has waived its immunity," within the
+scope of 28 U.S.C. � 1605(a)(1) of the Foreign Sovereign Immunities
+Act of 1976 (as amended). . Each such Governmental Entity also
+specifically agrees and concedes that the "commercial activity"
+exceptions to the FSIA, 28 U.S.C. � 1605(a)(2), (3) are also
+applicable. With respect to an action brought against the United
+States or any United States Governmental Entity, in the courts of any
+country, the U.S. Governmental Entity shall be understood to have
+voluntarily agreed to a corresponding waiver of immunity from actions
+in the courts of any other sovereign.
+
+14.2.3 With respect to any action or effort by the Author in the
+United States to execute a judgment against a foreign Governmental
+Entity, by attaching or executing process against the property of such
+Governmental Entity, the waiver by any Governmental Entity as provided
+in Subparagraphs 14.1 and 14.2 is hereby expressly acknowledged by
+each such Governmental Entity to constitute a case in which "the
+foreign state has waived its immunity from attachment in aid of
+execution or from execution," in accordance with 28 U.S.C. �
+1610(a)(1) of the Foreign Sovereign Immunities Act of 1976 (as
+amended). Each such Governmental Entity also specifically agrees and
+concedes that the "commercial activity" exceptions to the FSIA, 28
+U.S.C. � 1610(a)(2), (d) are also applicable. With respect to an
+action brought against the United States or any United States
+Governmental Entity, in the courts of any country, the
+U.S. Governmental Entity shall be understood to have voluntarily
+agreed to a corresponding waiver of immunity from actions in the
+courts of any other sovereign.
+
+14.2.4 With respect to any action or effort brought by an authorized
+end-user (as a third-party beneficiary, in accordance with
+Subparagraphs 14.3 and 14.10) in the United States to execute a
+judgment against a foreign Governmental Entity, by attaching or
+executing process against the property of such Governmental Entity,
+the waiver by any Governmental Entity as provided in Subparagraphs
+14.1 and 14.2 is hereby expressly acknowledged by each such
+Governmental Entity to constitute a case in which "the foreign state
+has waived its immunity from attachment in aid of execution or from
+execution," in accordance with 28 U.S.C. � 1610(a)(1) of the Foreign
+Sovereign Immunities Act of 1976 (as amended). Each such Governmental
+Entity also specifically agrees and concedes that the "commercial
+activity" exceptions to the FSIA, 28 U.S.C. � 1610(a)(2), (d) are
+also applicable. With respect to an action brought against the United
+States or any United States Governmental Entity, in the courts of any
+country, the U.S. Governmental Entity shall be understood to have
+voluntarily agreed to a corresponding waiver of immunity from actions
+in the courts of any other sovereign.
+
+14.3 Any Governmental Entity that uses, copies, changes, modifies,
+displays, performs, or distributes the Software or any part thereof,
+or any Governmental Person who does so (whether that person's
+Governmental Entity contends the person's action was, or was not,
+authorized or official), and thereby violates any terms and conditions
+of Section 9 (restrictions on modification), or Paragraph 10 (use
+restrictions), agrees that the person or entity is subject not only to
+an action by the Author, for the enforcement of this License Agreement
+and for money damages and injunctive relief (as well as attorneys'
+fees, additional and statutory damages, and other remedies as provided
+by law), but such Governmental Entity and/or Person also shall be
+subject to a suit for money damages and injunctive relief by any
+person whose human rights have been violated or infringed, in
+violation of this License Agreement, or through the use of any
+Software in violation of this License Agreement. Any person who brings
+an action under this section against any Governmental Person or Entity
+must notify the Author promptly of the action and provide the Author
+the opportunity to intervene to assert the Author's own
+rights. Damages in such a third-party action shall be measured by the
+severity of the human rights violation and the copyright infringement
+or License Agreement violation, combined, and not merely by reference
+to the copyright infringement. All end-users, to the extent that they
+are entitled to bring suit against such Governmental Entity by way of
+this License Agreement, are intended third-party beneficiaries of this
+License Agreement. Punitive damages may be awarded in such a
+third-party action against a Governmental Entity or Governmental
+Person, and each and every such Governmental Entity or Person
+conclusively waives all restrictions on the amount of punitive
+damages, and all defenses to the award of punitive damages to the
+extend such limitations or defenses depend upon or are a function of
+such person or entity's status as a Governmental Person or
+Governmental Entity.
+
+14.4 Any State of the United States, or any subunit or Governmental
+Entity thereof, that uses, copies, changes, modifies, displays,
+performs, or distributes the Software of any part thereof, or any of
+whose Governmental Persons does so (whether that person's Governmental
+Entity contends the person's action was, or was not, authorized or
+official), unconditionally and irrevocably waives for purposes of any
+legal action (i) to enforce this License Agreement, (ii) to remedy
+infringement of the Author's copyright, or (iii) to invoke any of the
+third-party beneficiary rights set forth in Section 14.3 -- any
+immunity under the Eleventh Amendment of the United States
+Constitution or any other immunity doctrine (such as sovereign
+immunity or qualified, or other, official immunity) that may apply to
+state governments, subunits, or to their Governmental Persons.
+
+14.5 Any Governmental Entity (including, without limitation, any State
+of the United States), that uses, copies, changes, modifies, performs,
+displays, or distributes the Software or any part thereof, or any of
+whose Governmental Persons does so (whether that person's Governmental
+Entity contends the person's action was, or was not, authorized or
+official), unconditionally and irrevocably waives for purposes of any
+legal action (i) to enforce this License Agreement, (ii) to remedy
+infringement of the Author's copyright, or (iii) to invoke any of the
+third-party beneficiary rights set forth in Section 14.3 any doctrine
+(such as, but not limited to, the holding in the United States Supreme
+Court decision of Ex Parte Young) that might purport to limit remedies
+solely to prospective injunctive relief. Also explicitly and
+irrevocably waived is any underlying immunity doctrine that would
+require the recognition of such a limited exception for purposes of
+remedies. The remedies against such governmental entities and persons
+shall explicitly include money damages, additional damages, statutory
+damages, consequential damages, exemplary damages, punitive damages,
+costs and fees that might otherwise be barred or limited in amount on
+account of governmental status.
+
+14.6 Any Governmental Entity that uses, copies, changes, modifies,
+displays, performs, or distributes the Software or any part thereof,
+or any of whose Governmental Persons does so (whether that person's
+Governmental Entity contends the person's action was, or was not,
+authorized or official), unconditionally and irrevocably waives for
+purposes of any legal action (i) to enforce this License Agreement,
+(ii) to remedy infringement of the Author's copyright, or (iii) to
+invoke any of the third-party beneficiary rights set forth in Section
+14.3 any and all reliance on the Act of State doctrine, sovereign
+immunity, international comity, or any other doctrine of immunity
+whether such doctrine is recognized in that government's own courts,
+or in the courts of any other government or nation.
+
+14.6.1 Consistent with Subparagraphs 14.2.1 through 14.2.4, this
+waiver shall explicitly be understood to constitute a waiver not only
+against suit, but also against execution against property, for
+purposes of the Foreign Sovereign Immunities Act of 1976 (as
+amended). All United States Governmental Entities shall be understood
+to have agreed to a corresponding waiver of immunity against (i) suit
+in the courts of other sovereigns, and (ii) execution against property
+of the United States located within the territory of other countries.
+
+14.7 Governmental Persons, (i) who violate this License Agreement
+(whether that person's Governmental Entity contends the person's
+action was, or was not, authorized or official), or (ii) who are
+personally involved in any activity, policy or practice of a
+governmental entity that violates this License Agreement (whether that
+person's Governmental Entity contends the person's action was, or was
+not, authorized or official), or (iii) that use, copy, change, modify,
+perform, display or distribute, the Software or any part thereof, when
+their Governmental Entity is not permitted to do so, or is not a
+Qualified Licensee, or has violated the terms of this License
+Agreement, each and all individually waive and shall not be permitted
+to assert any defense of official immunity, "good faith" immunity,
+qualified immunity, absolute immunity, or other immunity based on his
+or her governmental status.
+
+14.8 No Governmental Entity, nor any Governmental Person thereof may,
+by legislative, regulatory, or other action, exempt such Governmental
+Entity, subunit, or person, from the terms of this License Agreement,
+if the Governmental Entity or any such person has voluntarily used,
+modified, copied, displayed, performed, or distributed the Software or
+any part thereof.
+
+14.9 Enforcement In Courts of Other Sovereigns Permitted. By using,
+modifying, changing, displaying, performing or distributing any
+Software covered by this License Agreement, any Governmental Entity
+hereby voluntarily and irrevocably consents, for purposes of (i) any
+action to enforce the terms of this License Agreement, and (ii) any
+action to enforce the Author's copyright (whether such suit be for
+injunctive relief, damages, or both) to the jurisdiction of any court
+or tribunal in any other country (or a court of competent jurisdiction
+of a subunit, province, or state of such country) in which the terms
+of this License Agreement are believed by the Author to be
+enforceable. Each such Governmental Entity hereby waives all
+objections to personal jurisdiction, all objections based on
+international comity, all objections based on the doctrine of forum
+non conveniens, and all objections based on sovereign or governmental
+status or immunity that might otherwise be asserted in the courts of
+some other sovereign.
+
+14.9.1 The Waiver by any Governmental Entity of a country other than
+the United States shall be understood explicitly to constitute a
+waiver for purposes of the Foreign Sovereign Immunities Act of 1976
+(see Subparagraphs 14.2.1to 14.2.4, inclusive, supra), and all United
+States Governmental Entities shall be understood to have agreed to a
+waive correspondingly broad in scope with respect to actions brought
+in the courts of other sovereigns.
+
+14.9.2 Forum Selection Non-U.S. Governmental Entities. Governmental
+Entities that are not United States Governmental Entities shall be
+subject to suit, and agree to be subject to suit, in the United States
+District Court for the District of Columbia. The Author or an
+authorized end-user may bring an action in another court in another
+country, but the United States District Court for the District of
+Columbia, shall always be available as an agreed-upon forum for such
+an action. At the optional election of any Author (or, in the case of
+a third-party claim, any end-user asserting rights under Subparagraphs
+14.3 and 14.10), such a suit against a non-U.S. Governmental Entity or
+Person may be brought in the United States District Court for the
+Southern District of New York, or the United States District Court for
+the Northern District of California, as a direct substitute for the
+United States District Court for the District of Columbia, for all
+purposes of this Subparagraph.
+
+14.9.3 Forum Selection U.S. Governmental Entities. All United States
+Governmental Entities shall be subject to suit, and agree to be
+subject to suit, in the following (non-exclusive) list of fora:
+Ottawa, Canada, London, England, and Paris, France. The Author or an
+authorized end-user may bring action in another court that can
+exercise jurisdiction. But the courts in these three locations shall
+always be available (at the option of the Author or an authorized
+end-user) as a forum for resolving any dispute with the United States
+or a governmental subunit thereof. Except as provided in Subparagraph
+14.10, any and all United States Governmental Persons shall be subject
+to suit wherever applicable rules of personal jurisdiction and venue
+shall permit such suit to be filed, but no such United States
+Governmental Person may assert any defense based on forum non
+conveniens or international comity, to the selection of any particular
+lawful venue.
+
+14.10 Enforcement Of Claims For Human Rights Violations. By using,
+copying, modifying, changing, performing, displaying or distributing
+the Software covered by this License Agreement, any Governmental
+Entity, or Governmental Person hereby voluntarily and irrevocably
+consents -- for purposes of any third-party action to remedy human
+rights violations and other violations of this License Agreement (as
+reflected in Section 14.3) -- to the jurisdiction of any court or
+tribunal in any other country (or a court of competent jurisdiction of
+a subunit, province, or state of such country) in which the
+third-party beneficiary reasonably believes the relevant terms of this
+License Agreement are enforceable. The Governmental Entity or Person
+hereby waives all objections to personal jurisdiction, all objections
+based on international comity, all objections based on the doctrine of
+forum non conveniens, and all objections based on sovereign or
+governmental status or immunity that might otherwise be asserted in
+the courts of some other sovereign.
+
+14.10.1 Waiver of Immunity and Forum Selection. The presumptively
+valid and preferred fora identified in Subparagraphs 14.9.2 and 14.9.3
+shall also apply for purposes of Subparagraph 14.10. All Governmental
+Entities are subject to the same Waiver of Immunity as set forth in
+Subparagraphs 14.2.1 to 14.2.4, inclusive.
+
+15. Subsequent Versions of HESSLA. Hacktivismo may publish revised
+and/or new versions of the Hacktivismo Enhanced-Source Software
+License Agreement from time to time. Such new versions will be similar
+in spirit to the present version, but may differ in detail to address
+new problems or concerns.
+
+Each version is given a distinguishing version number. Any Program
+released by Hacktivismo under a version of this License Agreement
+prior to Version 1.0, shall be considered released under Version 1.0
+of the Hacktivismo Enhanced-Source Software License Agreement, once
+Version 1.0 is formally released. Prior to Version 1.0, any Software
+released by Hacktivismo or a Licensee of Hacktivismo under a
+lower-numbered version of the HESSLA shall be considered automatically
+to be subject to a higher-number version of the HESSLA, whenever a
+later-numbered version has been released.
+
+Concerning the work of any other Author, if the Program specifies a
+version number of this License Agreement which applies to it and "any
+later version," You have the option of following the terms and
+conditions either of that version or of any later version published by
+Hacktivismo. If the Program does not specify a version number of this
+License Agreement, You may choose any version after 1.0, once version
+1.0 is published by Hacktivismo, and prior to publication of version
+1.0, You may choose any version of the Hacktivismo Software License
+Agreement then published by Hacktivismo. If the Program released by
+another Author, specifies only a version number, then that version
+number only shall apply. If "the latest version," is specified, then
+the latest version of the HESSLA published on the Hacktivismo Website
+shall always apply at all times.
+
+16. DISCLAIMER OF WARRANTY. THE SOFTWARE IS PROVIDED UNDER THIS
+LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY, EITHER EXPRESS OR
+IMPLIED, INCLUDING, WITHOUT LIMITATION, THE WARRANTY OF
+NON-INFRINGEMENT AND WARRANTIES THAT THE ORIGINAL WORK IS MERCHANTABLE
+OR FIT FOR A PARTICULAR PURPOSE. THE SOFTWARE IS PROVIDED WITH ALL
+FAULTS. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH
+YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL
+NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY
+CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO LICENSE TO ORIGINAL
+WORK IS GRANTED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+17. LIMITATION OF LIABILITY. UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL
+THEORY, WHETHER TORT (INCLUDING THE AUTHOR'S NEGLIGENCE), CONTRACT, OR
+OTHERWISE, SHALL THE AUTHOR BE LIABLE TO ANY PERSON FOR ANY DIRECT,
+INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY
+CHARACTER ARISING AS A RESULT OF THIS LICENSE OR THE USE OF THE
+SOFTWARE INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL,
+WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER
+COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PERSON SHALL HAVE BEEN
+INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF
+LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY
+RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW
+PROHIBITS SUCH LIMITATION, BUT SHALL EXCLUDE SUCH LIABILITY TO THE
+EXTENT PERMITTED BY LAW. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION
+OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS
+EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+18. ENCRYPTION KEYS AND PUBLIC KEY INFRASTRUCTURE. SOFTWARE RELEASED
+UNDER THIS LICENSE AGREEMENT MAY REQUIRE A DIGITAL CERTIFICATE, OR AN
+ENCRYPTION KEY "SIGNED" BY A TRUSTED PARTY, TO FUNCTION. AUTHOR
+UNDERTAKES NO RESPONSIBILITY FOR THE PROPER, SECURE, AND ADEQUATE
+FUNCTIONING OF ANY CRYPTOGRAPHIC SYSTEMS, OF ANY CRYPTOGRAPHIC KEYS,
+OR FOR THE TRUSTWORTHINESS OF ANY END-USER, ANY ISSUER OF
+CERTIFICATES, OR OF ANY SIGNER OF ENCRYPTION KEYS. USE OF THIS
+SOFTWARE IS AT THE END-USER'S SOLE AND EXCLUSIVE RISK. IN ANY
+PUBLIC-KEY INFRASTRUCTURE ("PKI") SYSTEM, AN END-USER'S LEGAL
+RELATIONSHIP WITH THE END-USER'S CERTIFICATION AUTHORITY DOES NOT
+INCLUDE OR ENCOMPASS ANY LEGAL RELATIONSHIP WITH THE AUTHOR, AND IS
+GOVERNED SOLELY AND EXCLUSIVELY BY THE CERTIFICATION AUTHORITY'S
+CERTIFICATION PRACTICE STATEMENT AND CERTIFICATION AGREEMENTS. AUTHOR
+ASSUMES NO RESPONSIBILITY FOR THE ACTIONS OR OMISSIONS OF ANY END-USER
+OR ANY CERTIFICATION AUTHORITY.
+
+18. Saving Clause. If any portion of this License Agreement is held
+invalid or unenforceable under any particular circumstance, the
+balance of the License Agreement is intended to apply and the License
+Agreement as a whole is intended to apply in other circumstances.
+
+END OF TERMS AND CONDITIONS 

--- a/src/licensedcode/data/licenses/hessla.yml
+++ b/src/licensedcode/data/licenses/hessla.yml
@@ -1,8 +1,9 @@
 key: hessla
 short_name: HESSLA 
 name: Hacktivismo Enhanced-Source Software License Agreement
-category: Proprietary
+category: Proprietary Free
 owner: Hacktivismo
 homepage_url: http://www.hacktivismo.com/about/hessla.php
-text_urls: https://directory.fsf.org/wiki/License:HESSLA
+text_urls: 
+    - https://directory.fsf.org/wiki/License:HESSLA
 

--- a/src/licensedcode/data/licenses/hessla.yml
+++ b/src/licensedcode/data/licenses/hessla.yml
@@ -1,0 +1,8 @@
+key: hessla
+short_name: HESSLA 
+name: Hacktivismo Enhanced-Source Software License Agreement
+category: Proprietary
+owner: Hacktivismo
+homepage_url: http://www.hacktivismo.com/about/hessla.php
+text_urls: https://directory.fsf.org/wiki/License:HESSLA
+


### PR DESCRIPTION
Fixes #2210

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

This PR adds new license text hessla.LICENSE  and corresponding YAML file to the dataset of licenses. This will enable detection of the HESSLA license which has been mentioned in the wiki page mentioned in the issue statement. The key used for the license is hessla and I have categorised it into proprietary licenses. Based on the reviews received for this PR, I will continue work to incorporate the remaining licenses mentioned in the wiki.

- Sankha Das
