### PR TITLE
Revert "Make SPDX license key as default #2200"

### DIFF
--- a/src/licensedcode/data/licenses/here-proprietary.yml
+++ b/src/licensedcode/data/licenses/here-proprietary.yml
@@ -3,4 +3,5 @@ short_name: HERE Proprietary
 name: HERE Proprietary License
 category: Commercial
 owner: HERE Global B.V.
-spdx_license_key: LicenseRef-Proprietary-HERE
+other_spdx_license_keys:
+    - LicenseRef-Proprietary-HERE


### PR DESCRIPTION
All other .yml files always use IDs which are on the SPDX license list
as value for the field `spdx_license_key`, thus this entry is an
exception. Furthermore it is the only ID starting with 'LicenseRef-'.

Since this change seems not to bring much value, undo it for simplicity.

This reverts commit aec1535d5c3ba8e40d622accbaeea6c430dcafb3.

Signed-off-by: Frank Viernau <frank.viernau@here.com>

