### PR TITLE
Fix `dist_mapper()` in packagedcode/npm.py

### DIFF
--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -577,9 +577,9 @@ def dist_mapper(dist, package):
     integrity = dist.get('integrity') or None
     if integrity:
         algo, _, b64value = integrity.partition('-')
-        assert 'sha512' == algo
         algo = algo.lower()
-        sha512 = hashlib.sha512(base64.b64decode(b64value)).hexdigest()
+        assert 'sha512' == algo
+        sha512 = base64.b64decode(b64value).hex()
         package.sha512 = sha512
 
     sha1 = dist.get('shasum')

--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -26,9 +26,11 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import base64
 from collections import defaultdict
 from collections import OrderedDict
 from functools import partial
+import hashlib
 import io
 import json
 import logging
@@ -577,7 +579,7 @@ def dist_mapper(dist, package):
         algo, _, b64value = integrity.partition('-')
         assert 'sha512' == algo
         algo = algo.lower()
-        sha512 = b64value.decode('base64').encode('hex')
+        sha512 = hashlib.sha512(base64.b64decode(b64value)).hexdigest()
         package.sha512 = sha512
 
     sha1 = dist.get('shasum')

--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -38,6 +38,7 @@ import re
 import attr
 from packageurl import PackageURL
 from six import string_types
+from six import binary_type
 
 from commoncode import filetype
 from commoncode import fileutils
@@ -580,9 +581,9 @@ def dist_mapper(dist, package):
         assert 'sha512' == algo
 
         decoded_b64value = base64.b64decode(b64value)
-        if type(decoded_b64value) == str:
+        if isinstance(decoded_b64value, string_types):
             sha512 = decoded_b64value.encode('hex')
-        elif type(decoded_b64value) == bytes:
+        elif isinstance(decoded_b64value, binary_type):
             sha512 = decoded_b64value.hex()
         package.sha512 = sha512
         

--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -1,5 +1,5 @@
 
-# Copyright (c) 2018-2020 nexB Inc. and others. All rights reserved.
+# Copyright (c) nexB Inc. and others. All rights reserved.
 # http://nexb.com and https://github.com/nexB/scancode-toolkit/
 # The ScanCode software is licensed under the Apache License version 2.0.
 # Data generated with ScanCode require an acknowledgment.
@@ -30,7 +30,6 @@ import base64
 from collections import defaultdict
 from collections import OrderedDict
 from functools import partial
-import hashlib
 import io
 import json
 import logging
@@ -579,8 +578,14 @@ def dist_mapper(dist, package):
         algo, _, b64value = integrity.partition('-')
         algo = algo.lower()
         assert 'sha512' == algo
-        sha512 = base64.b64decode(b64value).hex()
+
+        decoded_b64value = base64.b64decode(b64value)
+        if type(decoded_b64value) == str:
+            sha512 = decoded_b64value.encode('hex')
+        elif type(decoded_b64value) == bytes:
+            sha512 = decoded_b64value.hex()
         package.sha512 = sha512
+        
 
     sha1 = dist.get('shasum')
     if sha1:

--- a/tests/packagedcode/data/npm/dist/package.json
+++ b/tests/packagedcode/data/npm/dist/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "angular-compare-validator",
+    "version": "0.1.1",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/GeorgDangl/angular-compare-validator.git"
+    },
+    "description": "Angular form validation directive to compare two inputs",
+    "main": "./dist/index.js",
+    "typings": "./dist/index",
+    "dependencies": {
+        "@angular/core": ">=2.0.0",
+        "@angular/forms": ">=2.0.0",
+        "@angular/common": ">=2.0.0",
+        "rxjs": ">=5.0.0-beta.12",
+        "zone.js": ">=0.6.21"
+    },
+    "bugs": {
+        "url": "https://github.com/GeorgDangl/angular-compare-validator/issues"
+    },
+    "homepage": "https://github.com/GeorgDangl/angular-compare-validator#readme",
+    "_id": "angular-compare-validator@0.1.1",
+    "_npmVersion": "5.2.0",
+    "_nodeVersion": "7.7.1",
+    "_npmUser": {
+        "name": "georgdangl",
+        "email": "npm@dan.gl"
+    },
+    "dist": {
+        "integrity": "sha512-j3DtXjUTGFrVj7KjEUdprJPd1og2zokUblhvwD4DrJPc+x8RNUrCb0CLdcDr9RZj1eTo4nw4dSo8Br3edJp8Aw==",
+        "shasum": "d35a0754c8587b0502874e3636cf0f19565d09b7",
+        "tarball": "https://registry.npmjs.org/angular-compare-validator/-/angular-compare-validator-0.1.1.tgz"
+    },
+    "maintainers": [
+        {
+            "name": "georgdangl",
+            "email": "npm@dan.gl"
+        }
+    ],
+    "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/angular-compare-validator-0.1.1.tgz_1506372149543_0.2524787310976535"
+    }
+}

--- a/tests/packagedcode/data/npm/dist/package.json.expected
+++ b/tests/packagedcode/data/npm/dist/package.json.expected
@@ -25,7 +25,7 @@
     "sha1": "d35a0754c8587b0502874e3636cf0f19565d09b7",
     "md5": null,
     "sha256": null,
-    "sha512": "45cc0a4edb678010e331eceb847236729ce6c9a940f24053a4ab2b5544d418b47abe1d78eadbace27b16f5a61926b55ec3fd63165c50d5eb1e45f78e10275b63",
+    "sha512": "8f70ed5e3513185ad58fb2a3114769ac93ddd68836ce89146e586fc03e03ac93dcfb1f11354ac26f408b75c0ebf51663d5e4e8e27c38752a3c06bdde749a7c03",
     "bug_tracking_url": "https://github.com/GeorgDangl/angular-compare-validator/issues",
     "code_view_url": null,
     "vcs_url": "git+https://github.com/GeorgDangl/angular-compare-validator.git",

--- a/tests/packagedcode/data/npm/dist/package.json.expected
+++ b/tests/packagedcode/data/npm/dist/package.json.expected
@@ -1,0 +1,88 @@
+[
+  {
+    "type": "npm",
+    "namespace": null,
+    "name": "angular-compare-validator",
+    "version": "0.1.1",
+    "qualifiers": {},
+    "subpath": null,
+    "primary_language": "JavaScript",
+    "description": "Angular form validation directive to compare two inputs",
+    "release_date": null,
+    "parties": [
+      {
+        "type": "person",
+        "role": "maintainer",
+        "name": "georgdangl",
+        "email": "npm@dan.gl",
+        "url": null
+      }
+    ],
+    "keywords": [],
+    "homepage_url": "https://github.com/GeorgDangl/angular-compare-validator#readme",
+    "download_url": "https://registry.npmjs.org/angular-compare-validator/-/angular-compare-validator-0.1.1.tgz",
+    "size": null,
+    "sha1": "d35a0754c8587b0502874e3636cf0f19565d09b7",
+    "md5": null,
+    "sha256": null,
+    "sha512": "45cc0a4edb678010e331eceb847236729ce6c9a940f24053a4ab2b5544d418b47abe1d78eadbace27b16f5a61926b55ec3fd63165c50d5eb1e45f78e10275b63",
+    "bug_tracking_url": "https://github.com/GeorgDangl/angular-compare-validator/issues",
+    "code_view_url": null,
+    "vcs_url": "git+https://github.com/GeorgDangl/angular-compare-validator.git",
+    "copyright": null,
+    "license_expression": "mit",
+    "declared_license": [
+      "MIT"
+    ],
+    "notice_text": null,
+    "root_path": null,
+    "dependencies": [
+      {
+        "purl": "pkg:npm/%40angular/core",
+        "requirement": ">=2.0.0",
+        "scope": "dependencies",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_resolved": false
+      },
+      {
+        "purl": "pkg:npm/%40angular/forms",
+        "requirement": ">=2.0.0",
+        "scope": "dependencies",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_resolved": false
+      },
+      {
+        "purl": "pkg:npm/%40angular/common",
+        "requirement": ">=2.0.0",
+        "scope": "dependencies",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_resolved": false
+      },
+      {
+        "purl": "pkg:npm/rxjs",
+        "requirement": ">=5.0.0-beta.12",
+        "scope": "dependencies",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_resolved": false
+      },
+      {
+        "purl": "pkg:npm/zone.js",
+        "requirement": ">=0.6.21",
+        "scope": "dependencies",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_resolved": false
+      }
+    ],
+    "contains_source_code": null,
+    "source_packages": [],
+    "purl": "pkg:npm/angular-compare-validator@0.1.1",
+    "repository_homepage_url": "https://www.npmjs.com/package/angular-compare-validator",
+    "repository_download_url": "https://registry.npmjs.org/angular-compare-validator/-/angular-compare-validator-0.1.1.tgz",
+    "api_data_url": "https://registry.npmjs.org/angular-compare-validator/0.1.1"
+  }
+]

--- a/tests/packagedcode/test_npm.py
+++ b/tests/packagedcode/test_npm.py
@@ -76,6 +76,12 @@ class TestNpm(PackageTester):
                 'url': 'http://example.com'}
         assert ('Isaac Z. Schlueter', 'me@this.com' , 'http://example.com') == npm.parse_person(test)
 
+    def test_parse_dist_with_string_values(self):
+        test_file = self.get_test_loc('npm/dist/package.json')
+        expected_loc = self.get_test_loc('npm/dist/package.json.expected')
+        packages = npm.parse(test_file)
+        self.check_packages(packages, expected_loc, regen=False)
+
     def test_parse_as_installed(self):
         test_file = self.get_test_loc('npm/as_installed/package.json')
         expected_loc = self.get_test_loc('npm/as_installed/package.json.expected')


### PR DESCRIPTION
* Properly handle base64 encoded strings in the npm dist_mapper()
  function.
* Add test case

Addresses: #2256

Signed-off-by: Steven Esser <sesser@nexb.com>