### PR TITLE
Improve dual AFPL/GPL license detection #2242

### DIFF
--- a/src/licensedcode/data/rules/afpl-9.0_or_gpl-1.0-plus_1.RULE
+++ b/src/licensedcode/data/rules/afpl-9.0_or_gpl-1.0-plus_1.RULE
@@ -1,0 +1,1 @@
+available under a dual AFPL/GPL license

--- a/src/licensedcode/data/rules/afpl-9.0_or_gpl-1.0-plus_1.yml
+++ b/src/licensedcode/data/rules/afpl-9.0_or_gpl-1.0-plus_1.yml
@@ -1,0 +1,3 @@
+license_expression: afpl-9.0 OR gpl-1.0-plus
+is_license_notice: yes
+relevance: 90

--- a/src/licensedcode/data/rules/afpl-9.0_or_gpl-1.0-plus_2.RULE
+++ b/src/licensedcode/data/rules/afpl-9.0_or_gpl-1.0-plus_2.RULE
@@ -1,0 +1,2 @@
+Thanks to L. Peter Deutsch <ghost@aladdin.com> for making gdevdjet.c
+and gdevdljm.[ch] available under a dual AFPL/GPL license.

--- a/src/licensedcode/data/rules/afpl-9.0_or_gpl-1.0-plus_2.yml
+++ b/src/licensedcode/data/rules/afpl-9.0_or_gpl-1.0-plus_2.yml
@@ -1,0 +1,5 @@
+license_expression: afpl-9.0 OR gpl-1.0-plus
+is_license_reference: yes
+is_false_positive: yes
+relevance: 100
+notes: just a note of credit instead of a license. See https://github.com/nexB/scancode-toolkit/issues/2242#issuecomment-698371970


### PR DESCRIPTION
1. Add a rule to match the 'dual AFPL/GPL license'
2. Add a false-positive rule for a text in package 'ghostscript'.
   See more here: https://github.com/nexB/scancode-toolkit/issues/2242#issuecomment-698371970

Reported-by: @lemoshi
Signed-off-by: Lemon Shi <shir@vmware.com>

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #2242

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
