### PR TITLE
Add Lua License from FSF directory

### DIFF
--- a/src/licensedcode/data/licenses/lua.LICENSE
+++ b/src/licensedcode/data/licenses/lua.LICENSE
@@ -1,0 +1,6 @@
+Copyright © 1994–2019 Lua.org, PUC-Rio.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/licensedcode/data/licenses/lua.yml
+++ b/src/licensedcode/data/licenses/lua.yml
@@ -1,0 +1,8 @@
+key: lua
+short_name: Lua License
+name: Lua License
+category: Permissive
+owner: Lua.org, PUC-Rio 
+homepage_url: https://www.lua.org/
+text_urls:
+    - https://www.lua.org/license.html


### PR DESCRIPTION
Signed-off-by: sankha555 <f20190029@pilani.bits-pilani.ac.in>

Partially Fixes #2210 

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

In this PR, a new license text Lua and its corresponding YAML file has been added from the list of list of licenses mentioned in the FSF directory. This adds yet another license to the database. However there are still licenses left to be added from the FSF directory, for which I request the issue to be left open for future contributions.
