### PR TITLE
Fix for issue 1876 - Updated the batch file to replace "%" in arguments with an arbitrary …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ pyvenv.cfg
 lib64
 tcl
 /.env
+
+*.orig

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
-
+vNext
+-----
+ - Updated scancode.bat to handle % signs in the arguments #1876
 
 v3.2.2rc3 (2020-09-21)
 ----------------------

--- a/scancode.bat
+++ b/scancode.bat
@@ -24,6 +24,4 @@ if %errorlevel% neq 0 (
 @rem without this things may not always work on Windows 10, but this makes things slower
 set PYTHONDONTWRITEBYTECODE=1
 
-@rem Revert the placeholders back to single percent signs before passing through to ScanCode executable
-echo "%SCANCODE_ROOT_DIR%Scripts\scancode %*" >> d:\ScanCode.txt
 "%SCANCODE_ROOT_DIR%Scripts\scancode" %*

--- a/scancode.bat
+++ b/scancode.bat
@@ -17,7 +17,7 @@ set "SCANCODE_CMD_LINE_ARGS= "
 @rem Capture the current argument value
 	set CurrentParam=%1
     if ""%1""=="""" goto continue
-	@rem Replace a % sign with an arbitrary placeholder sting
+	@rem Replace a % sign with an arbitrary placeholder string
 	@rem Note: the double percent sign (%%) is required to escape the percent sign.
 	@rem The statement "set CurrentParam=!CurrentParam:%%=##PC##!" takes the value
 	@rem of CurrentParam, replaces any percent signs with ##PC## and assigns it back to CurrentParam

--- a/scancode.bat
+++ b/scancode.bat
@@ -3,6 +3,9 @@
 
 @rem  A wrapper to ScanCode command line entry point
 
+@rem Delayed expansion is required to allow the content of the variables to be manipulated prior to use
+setlocal EnableDelayedExpansion
+
 set SCANCODE_ROOT_DIR=%~dp0
 set SCANCODE_CONFIGURED_PYTHON=%SCANCODE_ROOT_DIR%Scripts\python.exe
 
@@ -11,8 +14,15 @@ set SCANCODE_CONFIGURED_PYTHON=%SCANCODE_ROOT_DIR%Scripts\python.exe
 set "SCANCODE_CMD_LINE_ARGS= "
 
 :collectarg
+@rem Capture the current argument value
+	set CurrentParam=%1
     if ""%1""=="""" goto continue
-    call set SCANCODE_CMD_LINE_ARGS=%SCANCODE_CMD_LINE_ARGS% %1
+	@rem Replace a % sign with an arbitrary placeholder sting
+	@rem Note: the double percent sign (%%) is required to escape the percent sign.
+	@rem The statement "set CurrentParam=!CurrentParam:%%=##PC##!" takes the value
+	@rem of CurrentParam, replaces any percent signs with ##PC## and assigns it back to CurrentParam
+	set CurrentParam=!CurrentParam:%%=##PC##!
+    call set SCANCODE_CMD_LINE_ARGS=%SCANCODE_CMD_LINE_ARGS% %CurrentParam%
     shift
 goto collectarg
 
@@ -36,4 +46,6 @@ if %errorlevel% neq 0 (
 @rem without this things may not always work on Windows 10, but this makes things slower
 set PYTHONDONTWRITEBYTECODE=1
 
+@rem Revert the placeholders back to single percent signs before passing through to ScanCode executable
+set SCANCODE_CMD_LINE_ARGS=!SCANCODE_CMD_LINE_ARGS:##PC##=%%!
 "%SCANCODE_ROOT_DIR%Scripts\scancode" %SCANCODE_CMD_LINE_ARGS%

--- a/scancode.bat
+++ b/scancode.bat
@@ -3,30 +3,8 @@
 
 @rem  A wrapper to ScanCode command line entry point
 
-@rem Delayed expansion is required to allow the content of the variables to be manipulated prior to use
-setlocal EnableDelayedExpansion
-
 set SCANCODE_ROOT_DIR=%~dp0
 set SCANCODE_CONFIGURED_PYTHON=%SCANCODE_ROOT_DIR%Scripts\python.exe
-
-@rem Collect all command line arguments in a variable
-@rem Use a trailing space in the next line sets the variable to an empty string (rather than unseting it)
-set "SCANCODE_CMD_LINE_ARGS= "
-
-:collectarg
-@rem Capture the current argument value
-	set CurrentParam=%1
-    if ""%1""=="""" goto continue
-	@rem Replace a % sign with an arbitrary placeholder string
-	@rem Note: the double percent sign (%%) is required to escape the percent sign.
-	@rem The statement "set CurrentParam=!CurrentParam:%%=##PC##!" takes the value
-	@rem of CurrentParam, replaces any percent signs with ##PC## and assigns it back to CurrentParam
-	set CurrentParam=!CurrentParam:%%=##PC##!
-    call set SCANCODE_CMD_LINE_ARGS=%SCANCODE_CMD_LINE_ARGS% %CurrentParam%
-    shift
-goto collectarg
-
-:continue
 
 if not exist "%SCANCODE_CONFIGURED_PYTHON%" goto configure
 goto scancode
@@ -47,5 +25,5 @@ if %errorlevel% neq 0 (
 set PYTHONDONTWRITEBYTECODE=1
 
 @rem Revert the placeholders back to single percent signs before passing through to ScanCode executable
-set SCANCODE_CMD_LINE_ARGS=!SCANCODE_CMD_LINE_ARGS:##PC##=%%!
-"%SCANCODE_ROOT_DIR%Scripts\scancode" %SCANCODE_CMD_LINE_ARGS%
+echo "%SCANCODE_ROOT_DIR%Scripts\scancode %*" >> d:\ScanCode.txt
+"%SCANCODE_ROOT_DIR%Scripts\scancode" %*


### PR DESCRIPTION
…placeholder "##PC##" during the "collectargs" routine and then restoring the "%" signs prior to passing to the scancode executable

Signed-off-by: Duncan Howe <duncan.howe@live.co.uk>

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #1876

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
