### PR TITLE
Do not install typing after Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -197,6 +197,8 @@ setup(
         'colorama >= 0.3.9',
         'pluggy >= 0.4.0, < 1.0',
         'attrs >= 18.1, !=20.1.0',
+        # Importing typing causes errors after python 3.6.
+        # See https://github.com/python/typing/issues/573
         'typing >=3.6, < 3.7; python_version < "3.7"',
 
         # scancode outputs

--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,7 @@ setup(
         'colorama >= 0.3.9',
         'pluggy >= 0.4.0, < 1.0',
         'attrs >= 18.1, !=20.1.0',
-        'typing >=3.6, < 3.7',
+        'typing >=3.6, < 3.7; python_version < "3.7"',
 
         # scancode outputs
         'jinja2 >= 2.7.0, < 3.0.0',


### PR DESCRIPTION
Applying the same fix here than in
https://github.com/nexB/commoncode/pull/5

Signed-off-by: Conley Owens <cco3@google.com>
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>
