### PR TITLE
Fix logic error in is_empty

### DIFF
--- a/src/cluecode/plugin_filter_clues.py
+++ b/src/cluecode/plugin_filter_clues.py
@@ -207,6 +207,10 @@ def is_empty(clues):
     if clues:
         return not any([
             clues.copyrights, clues.holders, clues.authors, clues.urls, clues.emails])
+    else:
+        # The logic here is reversed - the function tests for *emptiness*, so a falsey 
+        # "clues" object should actually return True (it is empty)
+        return True
 
 
 def filter_ignorable_clues(detections, rules_by_id):


### PR DESCRIPTION
The logic in is_empty is reversed - the function tests for *emptiness*, so a falsey "clues" object should actually return True (it *is* empty). 

This prevents an error that manifests at line 241, where attributes of the ignorables object are used, but the object is None. The reversed logic test actually fails at 238, where the function should return (there are no ignorables), but the default None prevents the "and" operator from returning True, so the function continues at 242.

Fixes #2339

### Tasks

* [X] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass (Not yet - but they should not be changed by this fix)
* [X] Commits are in uniquely-named feature branch and has no merge conflicts 📁

Signed-off-by: VanL <van.lindberg@gmail.com>
