### PR TITLE
Add RTD config File #2345

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Where the Sphinx conf.py file is located
+sphinx:
+  configuration: docs/source/conf.py
+
+# Setting the python version and location of the requirements file
+python:
+  version: 3.6
+  install:
+    - requirements: docs/requirements-doc.txt


### PR DESCRIPTION
Adds a .readthedocs.yml file to comply with the v2 of rtd configuration.
This fixes the broken documentation builds.

Signed-off-by: Ayan Sinha Mahapatra <ayansmahapatra@gmail.com>

Fixes #2345 

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
