### PR TITLE
Make Docker image smaller (1.21GB → 558MB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,13 @@
 # limitations under the License.
 #
 
-FROM python:3.6 
+FROM python:3.6-slim-buster 
 
 # Requirements as per https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html
 RUN apt-get update \
- && apt-get install -y bzip2 xz-utils zlib1g libxml2-dev libxslt1-dev \
- && rm -rf /var/lib/apt/lists/*
+ && apt-get install -y bzip2 xz-utils zlib1g libxml2-dev libxslt1-dev libgomp1 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man/?? /usr/share/man/??_*
 
 # Create directory for scancode sources
 RUN mkdir scancode-toolkit

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM python:3.6-slim-buster
 RUN apt-get update \
  && apt-get install -y bzip2 xz-utils zlib1g libxml2-dev libxslt1-dev libgomp1 \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man/?? /usr/share/man/??_*
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Create directory for scancode sources
 RUN mkdir scancode-toolkit


### PR DESCRIPTION
What these changes are about:

- switch from `python:3.6` to `python:3.6-slim-buster`
- install `libgomp1` (it's missed in `slim-buster` images)
- clean apt caches even more than before

The result: Docker image size reduced from 1.21GB to **558MB** (local, non-compressed size).
Didn't find the tests for Docker images, but checked: everything is working as before, but the image is smaller, easier to download from Docker Hub, and use! 

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
