### PR TITLE
Add minimal Debian copyright file output #2235

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -34,6 +34,7 @@ including:
 - https://github.com/nexB/thirdparty-packages/pypi/
 - https://github.com/nexB/scancode-plugins/
 - https://github.com/nexB/scancode-thirdparty-src/
+- https://github.com/nexB/thirdparty-packages/
 
 You may also contact us to request the source code by email at info@nexb.com or
 by postal mail at:

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ typecode==21.2.24
 typecode-libmagic==5.39.210223
 typing==3.6.4
 typing-extensions==3.7.4.3
-urllib3==1.26.2
+urllib3==1.26.4
 urlpy==0.5
 wcwidth==0.1.7
 webencodings==0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ chardet==3.0.4
 click==6.7
 colorama==0.4.4
 commoncode==21.1.21
-debut==0.9.9
+debian-inspector==0.9.10
 dparse2==0.5.0.4
 extractcode==21.2.24
 extractcode-7z==16.5.210223

--- a/setup-mini.cfg
+++ b/setup-mini.cfg
@@ -187,6 +187,7 @@ scancode_output =
     csv = formattedcode.output_csv:CsvOutput
     jsonlines = formattedcode.output_jsonlines:JsonLinesOutput
     template = formattedcode.output_html:CustomTemplateOutput
+    debian = formattedcode.output_debian:DebianCopyrightOutput
 
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ install_requires =
     click >= 6.7, !=7.0
     colorama >= 0.3.9
     commoncode >= 21.1.21
-    debut >= 0.9.9
+    debian-inspector >= 0.9.10
     dparse2
     fasteners
     fingerprints >= 0.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -187,6 +187,7 @@ scancode_output =
     csv = formattedcode.output_csv:CsvOutput
     jsonlines = formattedcode.output_jsonlines:JsonLinesOutput
     template = formattedcode.output_html:CustomTemplateOutput
+    debian = formattedcode.output_debian:DebianCopyrightOutput
 
 
 [tool:pytest]

--- a/src/formattedcode/output_debian.py
+++ b/src/formattedcode/output_debian.py
@@ -1,0 +1,223 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# ScanCode is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/scancode-toolkit for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+
+from debut.copyright import CopyrightFilesParagraph
+from debut.copyright import CopyrightHeaderParagraph
+from debut.copyright import DebianCopyright
+
+from license_expression import Licensing
+import saneyaml
+
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import OUTPUT_GROUP
+from formattedcode import FileOptionType
+from plugincode.output import output_impl
+from plugincode.output import OutputPlugin
+
+"""
+Output plugin to write scan results as Debian machine-readable copyright format
+a.k.a. DEP5
+
+See https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/ for details
+"""
+
+
+@output_impl
+class DebianCopyrightOutput(OutputPlugin):
+
+    options = [
+        PluggableCommandLineOption(('--debian', 'output_debian',),
+            type=FileOptionType(mode='w', lazy=True),
+            metavar='FILE',
+            help='Write scan output in machine-readable Debian copyright format to FILE.',
+            help_group=OUTPUT_GROUP,
+
+            # this is temporary , we should not needed these options explicitly
+            # but instead adapt to the available data
+            required_options=['copyright', 'license', 'license_text'],
+            sort_order=25),
+    ]
+
+    def is_enabled(self, output_debian, **kwargs):
+        return output_debian
+
+    def process_codebase(self, codebase, output_debian, **kwargs):
+        debian_copyright = build_debian_copyright(codebase, **kwargs)
+        write_debian_copyright(
+            debian_copyright=debian_copyright,
+            output_file=output_debian,
+        )
+
+
+def write_debian_copyright(debian_copyright, output_file):
+    """
+    Write `debian_copyright` DebianCopyright object to the `output_file` opened
+    file-like object.
+    """
+    # note the output_closing may feel contrived but is more or less dictated
+    # by the Click behaviour
+    close_of = False
+    try:
+        if isinstance(output_file, str):
+            output_file = open(output_file, 'w')
+            close_of = True
+        output_file.write(debian_copyright.dumps())
+        output_file.write('\n')
+    finally:
+        if close_of:
+            output_file.close()
+
+
+def build_debian_copyright(codebase, **kwargs):
+    """
+    Return a DebianCopyrightobject built from the codebase.
+    """
+    paragraphs = list(build_copyright_paragraphs(codebase, **kwargs))
+    return DebianCopyright(paragraphs=paragraphs)
+
+
+def build_copyright_paragraphs(codebase, **kwargs):
+    """
+    Yield paragraphs built from the codebase.
+    The codebase is assumed to contains license and copyright detections.
+    """
+
+    codebase.add_files_count_to_current_header()
+    header_para = CopyrightHeaderParagraph(
+        format='https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/',
+        # TODO: add some details, but not all these
+        # comment=saneyaml.dump(codebase.get_headers())
+    )
+    yield header_para
+
+    # TODO: create CopyrightLicenseParagraph for common licenses
+    # TODO: group files that share copyright and license
+    # TODO: infer files patterns
+
+    # for now this is dumb and will generate one paragraph per scanned file
+    for scanned_file in OutputPlugin.get_files(codebase, **kwargs):
+        if scanned_file['type'] == 'directory':
+            continue
+        dfiles = scanned_file['path']
+        dlicense = build_license(scanned_file)
+        dcopyright = build_copyright(scanned_file)
+
+        file_para = CopyrightFilesParagraph.from_dict(dict(
+            files=dfiles,
+            license=dlicense,
+            copyright=dcopyright,
+        ))
+
+        yield file_para
+
+
+def build_copyright(scanned_file):
+    """
+    Return a Debian-like text with one copyright per lien from the copyright
+    detected in `scanned_file` or None if no copyright is detected.
+    """
+    # TODO: format copyright notices the same way Debian does
+    holders = scanned_file.get('holders', [])
+    if not holders:
+        return
+    # TODO: reinjects copyright year ranges like they show up in Debian
+    return '\n'.join(holder['value'] for holder in holders)
+
+
+def build_license(scanned_file):
+    """
+    Return Debian-like text where the first line is the expression and the
+    remaining lines are the license text from licenses detected in
+    `scanned_file` or None if no license is detected.
+    """
+    # TODO: filter based on license scores and/or add warnings and or detailed comments with that info
+    license_expressions = scanned_file.get('license_expressions', [])
+    if not license_expressions:
+        return
+
+    # TODO: use either Debian license symbols or SPDX
+    # TODO: convert license expression to Debian style of expressions
+    expression = combine_expressions(license_expressions)
+
+    licenses = scanned_file.get('licenses', [])
+    text = '\n'.join(get_texts(licenses))
+    return f'{expression}\n{text}'
+
+
+# TODO: this has no readon to be here and should be part of the license_expression library
+def combine_expressions(expressions, relation='AND', licensing=Licensing()):
+    """
+    Return a combined license expression string with relation, given a list of
+    license expressions strings.
+
+    For example:
+    >>> a = 'mit'
+    >>> b = 'gpl'
+    >>> combine_expressions([a, b])
+    'mit AND gpl'
+    >>> assert 'mit' == combine_expressions([a])
+    >>> combine_expressions([])
+    >>> combine_expressions(None)
+    >>> combine_expressions(('gpl', 'mit', 'apache',))
+    'gpl AND mit AND apache'
+    """
+    if not expressions:
+        return
+
+    if not isinstance(expressions, (list, tuple)):
+        raise TypeError(
+            'expressions should be a list or tuple and not: {}'.format(
+                type(expressions)))
+
+    # Remove duplicate element in the expressions list
+    expressions = list(dict((x, True) for x in expressions).keys())
+
+    if len(expressions) == 1:
+        return expressions[0]
+
+    expressions = [licensing.parse(le, simple=True) for le in expressions]
+    if relation == 'OR':
+        return str(licensing.OR(*expressions))
+    else:
+        return str(licensing.AND(*expressions))
+
+
+def get_texts(detected_licenses):
+    """
+    Yield license texts detected in this file.
+
+    The current data structure has this format, with one item for each license
+    key from each license expression detected:
+
+    licenses": [
+        {
+          "key": "mit-old-style",
+          "score": 100.0,
+           ...
+          "start_line": 9,
+          "end_line": 15,
+          "matched_rule": {
+            "identifier": "mit-old-style_cmr-no_1.RULE",
+            "license_expression": "mit-old-style",
+            ...
+          },
+          "matched_text": "Permission to use, copy, modify, ...."
+        }
+      ],
+    """
+    # FIXME: the current license data structure is contrived and will soon be
+    # streamlined. See https://github.com/nexB/scancode-toolkit/issues/2416
+
+    # set of (start line, end line, matched_rule identifier)
+    seen = set()
+    for lic in detected_licenses:
+        key = lic['start_line'], lic['end_line'], lic['matched_rule']['identifier']
+        if key not in seen:
+            yield lic['matched_text']
+            seen.add(key)
+

--- a/src/formattedcode/output_debian.py
+++ b/src/formattedcode/output_debian.py
@@ -6,10 +6,8 @@
 # See https://github.com/nexB/scancode-toolkit for support or download.
 # See https://aboutcode.org for more information about nexB OSS projects.
 
-from debut.copyright import CopyrightField
 from debut.copyright import CopyrightFilesParagraph
 from debut.copyright import CopyrightHeaderParagraph
-from debut.copyright import CopyrightStatementField
 from debut.copyright import DebianCopyright
 from license_expression import Licensing
 
@@ -18,6 +16,8 @@ from commoncode.cliutils import OUTPUT_GROUP
 from formattedcode import FileOptionType
 from plugincode.output import output_impl
 from plugincode.output import OutputPlugin
+
+from scancode import notice
 
 """
 Output plugin to write scan results as Debian machine-readable copyright format
@@ -91,13 +91,14 @@ def build_copyright_paragraphs(codebase, **kwargs):
     header_para = CopyrightHeaderParagraph(
         format='https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/',
         # TODO: add some details, but not all these
-        # comment=saneyaml.dump(codebase.get_headers())
+        # comment=saneyaml.dump(codebase.get_headers()),
+        comment=notice,
     )
     yield header_para
 
     # TODO: create CopyrightLicenseParagraph for common licenses
     # TODO: group files that share copyright and license
-    # TODO: infer files patterns
+    # TODO: infer files patternsas in decopy
 
     # for now this is dumb and will generate one paragraph per scanned file
     for scanned_file in OutputPlugin.get_files(codebase, **kwargs):
@@ -126,8 +127,8 @@ def build_copyright_field(scanned_file):
     if not holders:
         return
     # TODO: reinjects copyright year ranges like they show up in Debian
-    statements = [CopyrightStatementField(h['value']) for h in holders]
-    return CopyrightField(statements)
+    statements = [h['value'] for h in holders]
+    return '\n'.join(statements)
 
 
 def build_license(scanned_file):

--- a/src/formattedcode/output_debian.py
+++ b/src/formattedcode/output_debian.py
@@ -6,12 +6,12 @@
 # See https://github.com/nexB/scancode-toolkit for support or download.
 # See https://aboutcode.org for more information about nexB OSS projects.
 
+from debut.copyright import CopyrightField
 from debut.copyright import CopyrightFilesParagraph
 from debut.copyright import CopyrightHeaderParagraph
+from debut.copyright import CopyrightStatementField
 from debut.copyright import DebianCopyright
-
 from license_expression import Licensing
-import saneyaml
 
 from commoncode.cliutils import PluggableCommandLineOption
 from commoncode.cliutils import OUTPUT_GROUP
@@ -40,7 +40,7 @@ class DebianCopyrightOutput(OutputPlugin):
             # this is temporary , we should not needed these options explicitly
             # but instead adapt to the available data
             required_options=['copyright', 'license', 'license_text'],
-            sort_order=25),
+            sort_order=60),
     ]
 
     def is_enabled(self, output_debian, **kwargs):
@@ -105,7 +105,7 @@ def build_copyright_paragraphs(codebase, **kwargs):
             continue
         dfiles = scanned_file['path']
         dlicense = build_license(scanned_file)
-        dcopyright = build_copyright(scanned_file)
+        dcopyright = build_copyright_field(scanned_file)
 
         file_para = CopyrightFilesParagraph.from_dict(dict(
             files=dfiles,
@@ -116,17 +116,18 @@ def build_copyright_paragraphs(codebase, **kwargs):
         yield file_para
 
 
-def build_copyright(scanned_file):
+def build_copyright_field(scanned_file):
     """
-    Return a Debian-like text with one copyright per lien from the copyright
-    detected in `scanned_file` or None if no copyright is detected.
+    Return a CopyrightField from the copyright statements detected in
+    `scanned_file` or None if no copyright is detected.
     """
     # TODO: format copyright notices the same way Debian does
-    holders = scanned_file.get('holders', [])
+    holders = scanned_file.get('holders', []) or []
     if not holders:
         return
     # TODO: reinjects copyright year ranges like they show up in Debian
-    return '\n'.join(holder['value'] for holder in holders)
+    statements = [CopyrightStatementField(h['value']) for h in holders]
+    return CopyrightField(statements)
 
 
 def build_license(scanned_file):

--- a/src/scancode/NOTICE
+++ b/src/scancode/NOTICE
@@ -1,60 +1,40 @@
-Software and Data license
-=========================
+ScanCode Licenses
+=================
 
-Copyright (c) nexB Inc. and others.
+Copyright (c) nexB Inc. and others. All rights reserved.
+ScanCode is a trademark of nexB Inc.
 
-Visit https://aboutcode.org and https://github.com/nexB/scancode-toolkit for
-support and download. ScanCode is a trademark of nexB Inc.
+SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0
 
-SPDX-License-Identifier: Apache-2.0 AND CC-BY-4.0 AND LicenseRef-scancode-other-permissive AND LicenseRef-scancode-other-copyleft
+ScanCode software is licensed under the Apache License version 2.0.
+ScanCode data is licensed under CC-BY-4.0.
 
-The ScanCode software is licensed under the Apache License version 2.0.
-The ScanCode open data is licensed under CC-BY-4.0.
+See https://www.apache.org/licenses/LICENSE-2.0 for the Apache-2.0 license text.
+See https://creativecommons.org/licenses/by/4.0/legalcode for the CC-BY-4.0 license text.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-
-License for ScanCode datasets
-=============================
-
-ScanCode includes datasets (e.g. for license detection) that are licensed under
-the Creative Commons Attribution 4.0 (CC-BY 4.0).
-
-The preferred way to attribute te data is this notice::
-
-    ScanCode open data by nexB Inc. and others licensed under CC-BY-4.0
-    Visit https://aboutcode.org and https://github.com/nexB/scancode-toolkit for
-    support and download. ScanCode is a trademark of nexB Inc.
+See https://github.com/nexB/scancode-toolkit for support or download. 
+See https://aboutcode.org for more information about nexB OSS projects
 
 
 Third-party software licenses
 =============================
 
 ScanCode embeds third-party free and open source software packages under various
-licenses including permissive, limited copyleft and copyleft licenses. Some of
-the third-party software packages are delivered as pre-built binaries. The
-origin and license of these packages is documented by .ABOUT files and included
-with each binary archives.
+licenses including permissive, limited copyleft and copyleft licenses. The
+origin and license of each package is documented by a .ABOUT file included
+in the ScanCode codetree and the releases archive.
 
 The corresponding source code for pre-compiled third-party software is available
-for immediate download from the same release page where you obtained ScanCode at
-these web addresses:
-- https://thirdparty.aboutcode.org/pypi/
-- https://thirdparty.aboutcode.org/generic/
-- https://pypi.org/project/scancode-toolkit/
+for immediate download from the same release page where you obtained ScanCode,
+including:
+
 - https://github.com/nexB/scancode-toolkit/
+- https://pypi.org/project/scancode-toolkit/
+- https://thirdparty.aboutcode.org/pypi/
+- https://github.com/nexB/thirdparty-packages/pypi/
 - https://github.com/nexB/scancode-plugins/
 - https://github.com/nexB/scancode-thirdparty-src/
+- https://github.com/nexB/thirdparty-packages/
 
 You may also contact us to request the source code by email at info@nexb.com or
 by postal mail at:
@@ -64,3 +44,19 @@ by postal mail at:
 
 Please indicate in your communication the ScanCode version for which you are
 requesting source code.
+
+
+ScanCode data attribution
+=========================
+
+ScanCode includes datasets (e.g. for license detection) that are licensed under
+CC-BY-4.0
+
+The preferred attribution for use of ScanCode data is::
+
+    Copyright (c) nexB Inc. and others. All rights reserved.
+    ScanCode is a trademark of nexB Inc.
+    SPDX-License-Identifier: CC-BY-4.0
+    See https://creativecommons.org/licenses/by/4.0/legalcode for the license text.
+    See https://github.com/nexB/scancode-toolkit for support or download. 
+    See https://aboutcode.org for more information about nexB OSS projects.

--- a/tests/formattedcode/data/debian/basic/expected.copyright
+++ b/tests/formattedcode/data/debian/basic/expected.copyright
@@ -1,0 +1,16 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: scan/copyright_acme_c-c.c
+Copyright: ACME, Inc.
+           nexB Inc.
+License: apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+

--- a/tests/formattedcode/data/debian/basic/expected.copyright
+++ b/tests/formattedcode/data/debian/basic/expected.copyright
@@ -1,4 +1,10 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Comment: Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+ OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+ ScanCode should be considered or used as legal advice. Consult an Attorney
+ for any legal advice.
+ ScanCode is a free software code scanning tool from nexB Inc. and others.
+ Visit https://github.com/nexB/scancode-toolkit/ for support and download.
 
 Files: scan/copyright_acme_c-c.c
 Copyright: ACME, Inc.

--- a/tests/formattedcode/data/debian/basic/scan/copyright_acme_c-c.c
+++ b/tests/formattedcode/data/debian/basic/scan/copyright_acme_c-c.c
@@ -1,0 +1,12 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+ Copyright (c) 2013-2017 nexB Inc. http://www.nexb.com/ - All rights reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.

--- a/tests/formattedcode/data/debian/multiple_files/expected.copyright
+++ b/tests/formattedcode/data/debian/multiple_files/expected.copyright
@@ -1,0 +1,122 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: scan/copy1.c
+Copyright: ACME, Inc.
+           nexB Inc.
+           Foobar, Inc.
+           Foobar, Inc.
+License: apache-2.0 AND lgpl-2.1-plus
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ .
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ 02110-1301  USA
+
+Files: scan/copy2.c
+Copyright: ACME, Inc.
+           Foobar, Inc.
+           Foobar, Inc.
+License: lgpl-2.1-plus
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ .
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ 02110-1301  USA
+
+Files: scan/copy3.c
+Copyright: ACME, Inc.
+           Foobar, Inc.
+License: lgpl-2.1-plus
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ .
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ 02110-1301  USA
+
+Files: scan/subdir/copy1.c
+Copyright: ACME, Inc.
+           Foobar, Inc.
+License: lgpl-2.1-plus
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ .
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ 02110-1301  USA
+
+Files: scan/subdir/copy2.c
+Copyright: ACME, Inc.
+           Foobar, Inc.
+License: gpl-2.0 OR apache-2.0
+ SPDX-License-Identifier: GPL-2.0-only OR Apache-2.0
+
+Files: scan/subdir/copy3.c
+Copyright: ACME, Inc.
+
+Files: scan/subdir/copy4.c
+Copyright: ACME, Inc.
+           Foobar, Inc.
+License: gpl-2.0
+ license gpl-2.0
+
+Files: scan/subdir/copy5.c
+License: lgpl-2.1-plus
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ .
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ 02110-1301  USA
+

--- a/tests/formattedcode/data/debian/multiple_files/expected.copyright
+++ b/tests/formattedcode/data/debian/multiple_files/expected.copyright
@@ -1,4 +1,10 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Comment: Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+ OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+ ScanCode should be considered or used as legal advice. Consult an Attorney
+ for any legal advice.
+ ScanCode is a free software code scanning tool from nexB Inc. and others.
+ Visit https://github.com/nexB/scancode-toolkit/ for support and download.
 
 Files: scan/copy1.c
 Copyright: ACME, Inc.

--- a/tests/formattedcode/data/debian/multiple_files/scan/copy1.c
+++ b/tests/formattedcode/data/debian/multiple_files/scan/copy1.c
@@ -1,0 +1,41 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+ Copyright (c) 2013-2017 nexB Inc. http://www.nexb.com/ - All rights reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+adasd
+ad
+asd
+as
+das
+da
+da
+dasd
+asd
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+02110-1301  USA
+/* Copyright © 2000 Foobar, Inc., All Rights Reserved */
+
+
+
+/* Copyright © 2000 Foobar, Inc., All Rights Reserved */
+
+

--- a/tests/formattedcode/data/debian/multiple_files/scan/copy2.c
+++ b/tests/formattedcode/data/debian/multiple_files/scan/copy2.c
@@ -1,0 +1,31 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+adasd
+ad
+asd
+as
+das
+da
+da
+dasd
+asd
+/* Copyright © 2000 Foobar, Inc., All Rights Reserved */
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+02110-1301  USA
+
+/* Copyright © 2000 Foobar, Inc., All Rights Reserved */
+
+

--- a/tests/formattedcode/data/debian/multiple_files/scan/copy3.c
+++ b/tests/formattedcode/data/debian/multiple_files/scan/copy3.c
@@ -1,0 +1,28 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+adasd
+ad
+asd
+as
+da
+dasdas
+dasd
+asd
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+02110-1301  USA
+
+/* Copyright © 2000 Foobar, Inc., All Rights Reserved */
+
+

--- a/tests/formattedcode/data/debian/multiple_files/scan/subdir/copy1.c
+++ b/tests/formattedcode/data/debian/multiple_files/scan/subdir/copy1.c
@@ -1,0 +1,29 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+adasd
+ad
+asd
+as
+das
+da
+da
+dasd
+asd
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+02110-1301  USA
+
+/* Copyright © 2000 Foobar, Inc., All Rights Reserved */
+
+

--- a/tests/formattedcode/data/debian/multiple_files/scan/subdir/copy2.c
+++ b/tests/formattedcode/data/debian/multiple_files/scan/subdir/copy2.c
@@ -1,0 +1,17 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+SPDX-License-Identifier: GPL-2.0-only OR Apache-2.0
+adasd
+ad
+asd
+as
+das
+da
+da
+dasd
+asd
+
+
+/* Copyright © 2000 Foobar, Inc., All Rights Reserved */
+
+

--- a/tests/formattedcode/data/debian/multiple_files/scan/subdir/copy3.c
+++ b/tests/formattedcode/data/debian/multiple_files/scan/subdir/copy3.c
@@ -1,0 +1,9 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+adasd
+ad
+asd
+as
+da
+dasd
+asd

--- a/tests/formattedcode/data/debian/multiple_files/scan/subdir/copy4.c
+++ b/tests/formattedcode/data/debian/multiple_files/scan/subdir/copy4.c
@@ -1,0 +1,17 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+fafsdfsdf
+
+
+adasd
+ad
+asd
+as
+da
+dasd
+asd
+
+license gpl-2.0
+
+/* Copyright © 2000 Foobar, Inc., All Rights Reserved */
+
+

--- a/tests/formattedcode/data/debian/multiple_files/scan/subdir/copy5.c
+++ b/tests/formattedcode/data/debian/multiple_files/scan/subdir/copy5.c
@@ -1,0 +1,14 @@
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+02110-1301  USA

--- a/tests/formattedcode/test_output_debian.py
+++ b/tests/formattedcode/test_output_debian.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# ScanCode is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/scancode-toolkit for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+import os
+import shutil
+
+from commoncode.testcase import FileDrivenTesting
+from scancode.cli_test_utils import run_scan_plain
+
+test_env = FileDrivenTesting()
+test_env.test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
+
+
+def check_debian_copyright_output(test_dir, expected_file, regen=False):
+    """
+    Rrun a scan on ``test_dir`` with a debian output and check if the created
+    file matches ``expected_file``.
+    """
+    result_file = test_env.get_temp_file('copyright')
+    args = [
+        '--copyright',
+        '--license',
+        '--license-text',
+        '--debian', result_file,
+        test_dir,
+    ]
+
+    run_scan_plain(args)
+
+    if regen:
+        shutil.copyfile(result_file, expected_file)
+
+    with open(expected_file) as exp:
+        expected = exp.read()
+
+    with open(result_file) as res:
+        result = res.read()
+
+    assert result == expected
+
+
+def test_debian_basic():
+    test_dir = test_env.get_test_loc('debian/basic/scan')
+    expected_file = test_env.get_test_loc('debian/basic/expected.copyright')
+    check_debian_copyright_output(test_dir, expected_file, regen=False)
+
+
+def test_debian_multiple_files():
+    test_dir = test_env.get_test_loc('debian/multiple_files/scan')
+    expected_file = test_env.get_test_loc('debian/multiple_files/expected.copyright')
+    check_debian_copyright_output(test_dir, expected_file, regen=False)


### PR DESCRIPTION
This is a minimal debian copyright file formatted output
It is dumb for now and creates one paragraph per file

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>
### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
