### PR TITLE
Detect copyrights in reuse-compliant code #2432

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -411,6 +411,9 @@ patterns = [
     (r'^AssemblyCopyright.?$', 'COPY'),
     (r'^AppCopyright?$', 'COPY'),
 
+    # SPDX-FileCopyrightText as defined by the FSFE Reuse project
+    (r'^[Ss][Pp][Dd][Xx]-[Ff]ile[Cc]opyright[Tt]ext', 'COPY'),
+
     ############################################################################
     # ALL Rights Reserved.
     ############################################################################
@@ -2722,6 +2725,7 @@ HOLDERS_JUNK = frozenset([
 
 
 def remove_dupe_copyright_words(c):
+    c = c.replace('SPDX-FileCopyrightText', 'Copyright')
     # from .net assemblies
     c = c.replace('AssemblyCopyright', 'Copyright')
     c = c.replace('AppCopyright', 'Copyright')

--- a/tests/cluecode/data/copyrights/spdx-reuse.c
+++ b/tests/cluecode/data/copyrights/spdx-reuse.c
@@ -1,0 +1,5 @@
+/*
+ * SPDX-FileCopyrightText: 2019 Jane Doe <jane@example.com>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */

--- a/tests/cluecode/data/copyrights/spdx-reuse.c.yml
+++ b/tests/cluecode/data/copyrights/spdx-reuse.c.yml
@@ -1,0 +1,7 @@
+what:
+  - copyrights
+  - holders
+copyrights:
+  - Copyright 2019 Jane Doe <jane@example.com>
+holders:
+  - Jane Doe


### PR DESCRIPTION
We now simply treat SPDX-FileCopyrightText as "Copyright" token
and effectively replace SPDX-FileCopyrightText with "Copyright" in a
post detection cleanup.

Reported-by: Daniel Eder @daniel-eder
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>


@carmenbianca @mxmehl FYI :) (Note also that there is also a comprehensive Debian copyright file processor/detector in ScanCode)

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
