### PR TITLE
Parse METADATA.bzl files

### DIFF
--- a/src/packagedcode/__init__.py
+++ b/src/packagedcode/__init__.py
@@ -78,6 +78,7 @@ PACKAGE_TYPES = [
     build.AutotoolsPackage,
     conda.CondaPackage,
     win_pe.WindowsExecutable,
+    build.MetadataBzl,
 ]
 
 

--- a/src/packagedcode/build.py
+++ b/src/packagedcode/build.py
@@ -172,6 +172,11 @@ class BuckPackage(StarlarkManifestPackage):
 
 @attr.s()
 class MetadataBzl(BaseBuildManifestPackage):
+    metafiles = ('METADATA.bzl',)
+    # TODO: Not sure what the default type should be, change this to something
+    # more appropriate later
+    default_type = 'METADATA.bzl'
+
     @classmethod
     def recognize(cls, location):
         if not cls._is_build_manifest(location):
@@ -184,18 +189,62 @@ class MetadataBzl(BaseBuildManifestPackage):
         for statement in tree.body:
             if not (hasattr(statement, 'targets') and isinstance(statement, ast.Assign)):
                 continue
+            # We are looking for a dictionary assigned to the variable `METADATA`
             for target in statement.targets:
                 if not (target.id == 'METADATA' and isinstance(statement.value, ast.Dict)):
                     continue
+                # Once we find the dictionary assignment, get and store its contents
                 statement_keys = statement.value.keys
                 statement_values = statement.value.values
                 for statement_k, statement_v in zip(statement_keys, statement_values):
                     if isinstance(statement_k, ast.Str):
                         key_name = statement_k.s
+                    # The list values in a `METADATA.bzl` file seem to only contain strings
                     if isinstance(statement_v, ast.List):
-                        value = [e.s for e in statement_v.elts]
+                        value = []
+                        for e in statement_v.elts:
+                            if not isinstance(e, ast.Str):
+                                continue
+                            value.append(e.s)
                     if isinstance(statement_v, ast.Str):
                         value = statement_v.s
                     metadata_fields[key_name] = value
 
-        # TODO: Create function that determines package type from download URL, then create a package of that package type from the metadata info
+        parties = []
+        maintainers = metadata_fields.get('maintainers', [])
+        for maintainer in maintainers:
+            parties.append(
+                models.Party(
+                    type=models.party_org,
+                    name=maintainer,
+                    role='maintainer',
+                )
+            )
+
+        # TODO: Create function that determines package type from download URL,
+        # then create a package of that package type from the metadata info
+        yield cls(
+            type=metadata_fields.get('upstream_type', ''),
+            name=metadata_fields.get('name', ''),
+            version=metadata_fields.get('version', ''),
+            declared_license=metadata_fields.get('licenses', []),
+            parties=parties,
+            homepage_url=metadata_fields.get('upstream_address', ''),
+            # TODO: Store 'upstream_hash` somewhere
+        )
+
+    def compute_normalized_license(self):
+        """
+        Return a normalized license expression string detected from a list of
+        declared license strings.
+        """
+        if not self.declared_license:
+            return
+
+        detected_licenses = []
+        for declared in self.declared_license:
+            detected_license = models.compute_normalized_license(declared)
+            detected_licenses.append(detected_license)
+
+        if detected_licenses:
+            return combine_expressions(detected_licenses)

--- a/tests/packagedcode/data/build/metadatabzl/METADATA.bzl
+++ b/tests/packagedcode/data/build/metadatabzl/METADATA.bzl
@@ -1,0 +1,13 @@
+METADATA = {
+    "licenses": [
+        "BSD-3-Clause",
+    ],
+    "maintainers": [
+        "oss_foundation",
+    ],
+    "name": "example",
+    "upstream_address": "https://github.com/example/example",
+    "upstream_hash": "deadbeef",
+    "upstream_type": "github",
+    "version": "0.0.1",
+}

--- a/tests/packagedcode/data/plugin/help.txt
+++ b/tests/packagedcode/data/plugin/help.txt
@@ -1,4 +1,9 @@
 --------------------------------------------
+Package: METADATA.bzl
+  class: packagedcode.build:MetadataBzl
+  metafiles: METADATA.bzl
+
+--------------------------------------------
 Package: about
   class: packagedcode.about:AboutPackage
   metafiles: *.ABOUT

--- a/tests/packagedcode/test_build.py
+++ b/tests/packagedcode/test_build.py
@@ -10,6 +10,7 @@
 import os.path
 
 from packagedcode import build
+from packagedcode import models
 from scancode.cli_test_utils import check_json_scan
 from scancode.cli_test_utils import run_scan_click
 from commoncode.resource import Codebase
@@ -71,6 +72,27 @@ class TestBuild(PackageTester):
                 name='app',
                 declared_license=['LICENSE'],
             )
+        ]
+        compare_package_results(expected_packages, result_packages)
+
+    def test_MetadataBzl_recognize(self):
+        test_file = self.get_test_loc('metadatabzl/METADATA.bzl')
+        result_packages = build.MetadataBzl.recognize(test_file)
+        expected_packages = [
+            build.MetadataBzl(
+                type='github',
+                name='example',
+                version='0.0.1',
+                declared_license=['BSD-3-Clause'],
+                parties=[
+                    models.Party(
+                        type=models.party_org,
+                        name='oss_foundation',
+                        role='maintainer'
+                    )
+                ],
+                homepage_url='https://github.com/example/example',
+            ),
         ]
         compare_package_results(expected_packages, result_packages)
 


### PR DESCRIPTION
This PR adds to scancode the ability to parse METADATA.bzl files. These files store metadata in a Python dictionary that has been assigned to the variable `METADATA`. 