### PR TITLE
Update package scan for package.json file

### DIFF
--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -265,7 +265,7 @@ def build_package(package_data):
     version = package_data.get('version')
     homepage = package_data.get('homepage', '')
 
-    if not name or not version:
+    if not name:
         # a package.json without name and version is not a usable npm package
         # FIXME: raise error?
         return

--- a/tests/packagedcode/data/npm/with_name/package.json
+++ b/tests/packagedcode/data/npm/with_name/package.json
@@ -1,0 +1,8 @@
+{ "name" :            "bson"
+    , "description" :     "A bson parser for node.js and the browser"
+    , "main":             "../"
+    , "directories" :   { "lib" : "../lib/bson" }
+    , "engines" :       { "node" : ">=0.6.0" }
+    , "licenses" :    [ { "type" :  "Apache License, Version 2.0"
+                        , "url" :   "http://www.apache.org/licenses/LICENSE-2.0" } ]
+    }

--- a/tests/packagedcode/data/npm/with_name/package.json.expected
+++ b/tests/packagedcode/data/npm/with_name/package.json.expected
@@ -1,0 +1,40 @@
+[
+  {
+    "type": "npm",
+    "namespace": null,
+    "name": "bson",
+    "version": null,
+    "qualifiers": {},
+    "subpath": null,
+    "primary_language": "JavaScript",
+    "description": "A bson parser for node.js and the browser",
+    "release_date": null,
+    "parties": [],
+    "keywords": [],
+    "homepage_url": null,
+    "download_url": "https://registry.npmjs.org/bson/-/bson-None.tgz",
+    "size": null,
+    "sha1": null,
+    "md5": null,
+    "sha256": null,
+    "sha512": null,
+    "bug_tracking_url": null,
+    "code_view_url": null,
+    "vcs_url": null,
+    "copyright": null,
+    "license_expression": "apache-2.0",
+    "declared_license": [{
+        "type": "Apache License, Version 2.0",
+        "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }],
+    "notice_text": null,
+    "root_path": null,
+    "dependencies": [],
+    "contains_source_code": null,
+    "source_packages": [],
+    "purl": "pkg:npm/bson",
+    "repository_homepage_url": "https://www.npmjs.com/package/bson",
+    "repository_download_url": "https://registry.npmjs.org/bson/-/bson-None.tgz",
+    "api_data_url": "https://registry.npmjs.org/bson"
+  }
+]

--- a/tests/packagedcode/data/npm/without_name/package.json
+++ b/tests/packagedcode/data/npm/without_name/package.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.2.0",
+    "description": "A sample Node.js",
+    "main": "index.js",
+    "scripts": {
+      "start": "node index.js"
+    },
+    "dependencies": {
+      "express": "^4.13.3"
+    },
+    "engines": {
+      "node": "4.0.0"
+    },
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/heroku/node-js-sample"
+    },
+    "keywords": [
+      "node",
+      "heroku",
+      "express"
+    ],
+    "author": "Mark Pundsack",
+    "contributors": [
+      "Zeke Sikelianos <zeke@sikelianos.com> (http://zeke.sikelianos.com)"
+    ],
+    "license": "MIT"
+  }

--- a/tests/packagedcode/test_npm.py
+++ b/tests/packagedcode/test_npm.py
@@ -245,6 +245,19 @@ class TestNpm(PackageTester):
         packages = npm.parse(test_file)
         self.check_packages(packages, expected_loc, regen=False)
 
+    def test_parse_with_name(self):
+        test_file = self.get_test_loc('npm/with_name/package.json')
+        expected_loc = self.get_test_loc('npm/with_name/package.json.expected')
+        packages = npm.parse(test_file)
+        self.check_packages(packages, expected_loc, regen=False)
+
+    def test_parse_without_name(self):
+        test_file = self.get_test_loc('npm/without_name/package.json')
+        try:
+            npm.parse(test_file)
+        except AttributeError as e:
+            assert "'NoneType' object has no attribute 'to_dict'" in str(e)
+
     def test_parse_yarn_lock(self):
         test_file = self.get_test_loc('npm/yarn-lock/yarn.lock')
         expected_loc = self.get_test_loc(


### PR DESCRIPTION
Fixes #2382

Checks for existance of name constraint only instead of both name and version.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁