### PR TITLE
Prep release 21.3.31

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,7 +39,7 @@ License scanning:
 
 
 
-v21.3.30
+v21.3.31
 --------
 
 This is a major version with no breaking API changes. Heads-up: the next version

--- a/setup-mini.cfg
+++ b/setup-mini.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = scancode-toolkit-mini
-version = 21.3.30
+version = 21.3.31
 license = Apache-2.0 AND CC-BY-4.0 AND LicenseRef-scancode-other-permissive AND LicenseRef-scancode-other-copyleft
 
 description = ScanCode is a tool to scan code for license, copyright, package and their documented dependencies and other interesting facts. scancode-toolkit-mini is a special build that does not come with pre-built binary dependencies by default. These are instead installed separately or with the extra_requires scancode-toolkit-mini[full]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = scancode-toolkit
-version = 21.3.30
+version = 21.3.31
 license = Apache-2.0 AND CC-BY-4.0 AND LicenseRef-scancode-other-permissive AND LicenseRef-scancode-other-copyleft
 
 description = ScanCode is a tool to scan code for license, copyright, package and their documented dependencies and other interesting facts.

--- a/src/licensedcode/cache.py
+++ b/src/licensedcode/cache.py
@@ -266,16 +266,16 @@ def build_unknown_spdx_symbol(licenses_db=None):
     return LicenseSymbolLike(licenses[u'unknown-spdx'])
 
 
-def get_cache():
+def get_cache(check_consistency=SCANCODE_DEV_MODE):
     """
     Optionally return and either load or build and cache a LicenseCache.
     """
-    populate_cache()
+    populate_cache(check_consistency=check_consistency)
     global _LICENSE_CACHE
     return _LICENSE_CACHE
 
 
-def populate_cache():
+def populate_cache(check_consistency=SCANCODE_DEV_MODE):
     """
     Load or build and cache a LicenseCache. Return None.
     """
@@ -284,7 +284,7 @@ def populate_cache():
         _LICENSE_CACHE = LicenseCache.load_or_build(
             licensedcode_cache_dir=licensedcode_cache_dir,
             scancode_cache_dir=scancode_cache_dir,
-            check_consistency=SCANCODE_DEV_MODE,
+            check_consistency=check_consistency,
             # used for testing only
             timeout=LICENSE_INDEX_LOCK_TIMEOUT,
             tree_base_dir=scancode_src_dir,
@@ -338,39 +338,42 @@ def tree_checksum(tree_base_dir=licensedcode_dir, _ignored=_ignored_from_hash):
     return md5(hashable).hexdigest()
 
 
-def get_index():
+def get_index(check_consistency=SCANCODE_DEV_MODE):
     """
     Return and eventually build and cache a LicenseIndex.
     """
-    return get_cache().index
+    return get_cache(check_consistency=check_consistency).index
 
 
-def get_licenses_db():
+get_cached_index = get_index
+
+
+def get_licenses_db(check_consistency=SCANCODE_DEV_MODE):
     """
     Return a mapping of license key -> license object.
     """
-    return get_cache().db
+    return get_cache(check_consistency=check_consistency).db
 
 
-def get_licensing():
+def get_licensing(check_consistency=SCANCODE_DEV_MODE):
     """
     Return a license_expression.Licensing objet built from the all the licenses.
     """
-    return get_cache().licensing
+    return get_cache(check_consistency=check_consistency).licensing
 
 
-def get_unknown_spdx_symbol():
+def get_unknown_spdx_symbol(check_consistency=SCANCODE_DEV_MODE):
     """
     Return the unknown SPDX license symbol.
     """
-    return get_cache().unknown_spdx_symbol
+    return get_cache(check_consistency=check_consistency).unknown_spdx_symbol
 
 
-def get_spdx_symbols(licenses_db=None):
+def get_spdx_symbols(licenses_db=None, check_consistency=SCANCODE_DEV_MODE):
     """
     Return a mapping of {lowercased SPDX license key: LicenseSymbolLike} where
     LicenseSymbolLike wraps a License object
     """
     if licenses_db:
         return build_spdx_symbols(licenses_db)
-    return get_cache().spdx_symbols
+    return get_cache(check_consistency=check_consistency).spdx_symbols

--- a/src/licensedcode/plugin_license.py
+++ b/src/licensedcode/plugin_license.py
@@ -25,10 +25,10 @@ def reindex_licenses(ctx, param, value):
         return
 
     # TODO: check for temp file configuration and use that for the cache!!!
-    from licensedcode.cache import get_cached_index
+    from licensedcode.cache import get_index
     import click
     click.echo('Checking and rebuilding the license index...')
-    get_cached_index(check_consistency=True,)
+    get_index(check_consistency=True)
     click.echo('Done.')
     ctx.exit(0)
 

--- a/src/scancode_config.py
+++ b/src/scancode_config.py
@@ -79,7 +79,7 @@ try:
 except (DistributionNotFound, ImportError):
     # package is not installed or we do not have setutools/pkg_resources
     # on hand
-    __version__ = '21.3.1'
+    __version__ = '21.3.31'
 
 system_temp_dir = tempfile.gettempdir()
 scancode_src_dir = dirname(__file__)

--- a/tests/licensedcode/test_plugin_license.py
+++ b/tests/licensedcode/test_plugin_license.py
@@ -68,6 +68,11 @@ def test_license_option_reports_license_texts_diag_long_lines():
     check_json_scan(test_loc, result_file, regen=False)
 
 
+def test_reindex_licenses_works():
+    args = ['--reindex-licenses']
+    run_scan_click(args)
+
+
 @pytest.mark.scanslow
 def test_scan_license_with_url_template():
     test_dir = test_env.get_test_loc('plugin_license/license_url', copy=True)


### PR DESCRIPTION
There was a minor issue with v21.3.30 which has been yanked.
This makes --reindex-licenses work
