### PR TITLE
Factor out a detect_copyrights_from_lines() function that doesn't rely on textcode

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -17,7 +17,6 @@ from time import time
 from cluecode import copyrights_hint
 from commoncode.text import toascii
 from commoncode.text import unixlinesep
-from textcode import analysis
 
 # Tracing flags
 TRACE = False or os.environ.get('SCANCODE_DEBUG_COPYRIGHT', False)
@@ -60,6 +59,7 @@ The process consists in:
 
 def detect_copyrights(location, copyrights=True, holders=True, authors=True,
                       include_years=True, include_allrights=False,
+                      demarkup=True,
                       deadline=sys.maxsize):
     """
     Yield tuples of (detection type, detected string, start line, end line)
@@ -68,13 +68,35 @@ def detect_copyrights(location, copyrights=True, holders=True, authors=True,
     Valid detection types are: copyrights, authors, holders.
     These are included in the yielded tuples based on the values of `copyrights=True`, `holders=True`, `authors=True`,
     """
-    detector = CopyrightDetector()
-    numbered_lines = analysis.numbered_text_lines(location, demarkup=True)
+    from textcode.analysis import numbered_text_lines
+    numbered_lines = numbered_text_lines(location, demarkup=demarkup)
     numbered_lines = list(numbered_lines)
     if TRACE:
         numbered_lines = list(numbered_lines)
         for nl in numbered_lines:
             logger_debug('numbered_line:', repr(nl))
+
+    yield from detect_copyrights_from_lines(
+        numbered_lines,
+        copyrights=copyrights,
+        holders=holders,
+        authors=authors,
+        include_years=include_years,
+        include_allrights=include_allrights,
+        deadline=deadline)
+
+
+def detect_copyrights_from_lines(numbered_lines, copyrights=True, holders=True, authors=True,
+          include_years=True, include_allrights=False,
+          deadline=sys.maxsize):
+    """
+    Yield tuples of (detection type, detected string, start line, end line)
+    detected in numbered lines
+    Include years in copyrights if include_years is True.
+    Valid detection types are: copyrights, authors, holders.
+    These are included in the yielded tuples based on the values of `copyrights=True`, `holders=True`, `authors=True`,
+    """
+    detector = CopyrightDetector()
 
     for candidates in candidate_lines(numbered_lines):
 
@@ -92,6 +114,7 @@ def detect_copyrights(location, copyrights=True, holders=True, authors=True,
             yield detection
         if time() > deadline:
             break
+
 
 ################################################################################
 # DETECTION PROPER


### PR DESCRIPTION
Factor out a detect_copyrights_from_lines() function that doesn't rely on textcode.
