### PR TITLE
Return number of lines for a text file

### DIFF
--- a/src/scancode/plugin_info.py
+++ b/src/scancode/plugin_info.py
@@ -23,6 +23,7 @@ class InfoScanner(ScanPlugin):
     basic checksums.
     """
     resource_attributes = dict([
+        ('lines', attr.ib(default=0, repr=False)),
         ('date', attr.ib(default=None, repr=False)),
         ('sha1', attr.ib(default=None, repr=False)),
         ('md5', attr.ib(default=None, repr=False)),


### PR DESCRIPTION
 Return the number of lines if a file is a text file.
Signed-off-by: Sarita Singh <saritasingh.0425@gmail.com>

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #1350 

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
