### PR TITLE
Correct corner cases for empty rpm locations

### DIFF
--- a/src/packagedcode/rpm_installed.py
+++ b/src/packagedcode/rpm_installed.py
@@ -40,7 +40,7 @@ def parse_rpm_xmlish(location, detect_licenses=False):
     Yield RpmPackage(s) from a RPM XML'ish file at `location`. This is a file
     created with rpm and the xml query option.
     """
-    if not os.path.exists(location):
+    if not location or not os.path.exists(location):
         return
 
     # there are smetimes weird encodings. We avoid issues there

--- a/tests/packagedcode/test_rpm_installed.py
+++ b/tests/packagedcode/test_rpm_installed.py
@@ -57,6 +57,11 @@ class TestRpmInstalled(PackageTester):
         result = json.loads(json.dumps(result))
         check_result_equals_expected_json(result, expected, regen=False)
 
+    def test_parse_rpm_xmlish_does_not_with_empty_or_missing_location(self):
+        rpm_installed.parse_rpm_xmlish(None)
+        rpm_installed.parse_rpm_xmlish('')
+        rpm_installed.parse_rpm_xmlish('/foo/bar/does-not-exists')
+
     def test_parse_rpm_xmlish_can_detect_license(self):
         test_installed = self.get_test_loc('rpm_installed/xmlish/centos-5-rpms.xmlish')
         expected = self.get_test_loc('rpm_installed/xmlish/centos-5-rpms.xmlish-with-license-expected.json')


### PR DESCRIPTION
Reported in ScanCode.io
https://github.com/nexB/scancode.io/issues/173

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
