### PR TITLE
scancode_config: improve DistributionNotFound

### DIFF
--- a/src/scancode_config.py
+++ b/src/scancode_config.py
@@ -72,14 +72,17 @@ def _create_dir(location):
 # current installation location. This is where the source code and static data
 # lives.
 
-
+# in case package is not installed or we do not have setutools/pkg_resources
+# on hand fall back to this version
+__version__ = '21.3.31'
 try:
     from pkg_resources import get_distribution, DistributionNotFound
-    __version__ = get_distribution('scancode-toolkit').version
-except (DistributionNotFound, ImportError):
-    # package is not installed or we do not have setutools/pkg_resources
-    # on hand
-    __version__ = '21.3.31'
+    try:
+        __version__ = get_distribution('scancode-toolkit').version
+    except DistributionNotFound:
+        pass
+except ImportError:
+    pass
 
 system_temp_dir = tempfile.gettempdir()
 scancode_src_dir = dirname(__file__)


### PR DESCRIPTION
In before get_distribution was run in the same scope as the import of
pkg_resources, but in the parent scope of the function
DistributionNotFound was used in the exception handler, leading to the
effect that on a failed import an undefined symbol was part of the ast.

Improve the handling by handing DistributionNotFound in the correct
inner scope, while handling ImportError of the outer one

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
