### PR TITLE
Fix wrong rule match for MIT license in utils-merge

### DIFF
--- a/src/licensedcode/data/rules/mit_in_npm_1.RULE
+++ b/src/licensedcode/data/rules/mit_in_npm_1.RULE
@@ -1,0 +1,3 @@
+licenses":
+"type": "MIT",
+"url": "http://opensource.org/licenses/MIT"

--- a/src/licensedcode/data/rules/mit_in_npm_1.yml
+++ b/src/licensedcode/data/rules/mit_in_npm_1.yml
@@ -1,0 +1,5 @@
+license_expression: mit
+is_license_tag: yes
+relevance: 100
+ignorable_urls:
+  - http://opensource.org/licenses/MIT

--- a/src/licensedcode/data/rules/mit_or_gpl-2.0_46.yml
+++ b/src/licensedcode/data/rules/mit_or_gpl-2.0_46.yml
@@ -4,3 +4,4 @@ relevance: 100
 ignorable_urls:
     - http://opensource.org/licenses/MIT
     - http://www.gnu.org/licenses/gpl-2.0.html
+minimum_coverage: 60

--- a/tests/licensedcode/data/datadriven/lic4/2523-utils-merge_package.json
+++ b/tests/licensedcode/data/datadriven/lic4/2523-utils-merge_package.json
@@ -1,0 +1,40 @@
+{
+  "name": "utils-merge",
+  "version": "1.0.1",
+  "description": "merge() utility function",
+  "keywords": [
+    "util"
+  ],
+  "author": {
+    "name": "Jared Hanson",
+    "email": "jaredhanson@gmail.com",
+    "url": "http://www.jaredhanson.net/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jaredhanson/utils-merge.git"
+  },
+  "bugs": {
+    "url": "http://github.com/jaredhanson/utils-merge/issues"
+  },
+  "license": "MIT",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://opensource.org/licenses/MIT"
+    }
+  ],
+  "main": "./index",
+  "dependencies": {},
+  "devDependencies": {
+    "make-node": "0.3.x",
+    "mocha": "1.x.x",
+    "chai": "1.x.x"
+  },
+  "engines": {
+    "node": ">= 0.4.0"
+  },
+  "scripts": {
+    "test": "node_modules/.bin/mocha --reporter spec --require test/bootstrap/node test/*.test.js"
+  }
+}

--- a/tests/licensedcode/data/datadriven/lic4/2523-utils-merge_package.json.yml
+++ b/tests/licensedcode/data/datadriven/lic4/2523-utils-merge_package.json.yml
@@ -1,0 +1,4 @@
+license_expressions:
+  - mit
+  - mit
+notes: Based on https://raw.githubusercontent.com/jaredhanson/utils-merge/v1.0.1/package.json


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #2523

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
Signed-off-by: Hanna Modica <Hanna.Modica@bosch.io>