### PR TITLE
Add emails and urls to HTML output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,9 @@ Important API changes:
    that contains each package instance that can be aggregating data from
    multiple manifests for a single package instance.
 
+ - The data structure for HTML output has been changed to include emails and urls under the 
+   "infos" object. Now HTML template will output holders, authors, emails, and 
+   urls into separate tables like "licenses" and "copyrights".
 
 Copyright detection:
 ~~~~~~~~~~~~~~~~~~~~

--- a/src/formattedcode/output_html.py
+++ b/src/formattedcode/output_html.py
@@ -155,8 +155,6 @@ def generate_output(results, version, template):
     LICENSES = 'licenses'
     COPYRIGHTS = 'copyrights'
     PACKAGES = 'packages'
-    URLS = 'urls'
-    EMAILS = 'emails'
 
     # Create a flattened data dict keyed by path
     for scanned_file in results:
@@ -197,7 +195,7 @@ def generate_output(results, version, template):
         # denormalizing the list here??
         converted_infos[path] = {}
         for name, value in scanned_file.items():
-            if name in (LICENSES, PACKAGES, COPYRIGHTS, EMAILS, URLS):
+            if name in (LICENSES, PACKAGES, COPYRIGHTS):
                 continue
             converted_infos[path][name] = value
 

--- a/src/formattedcode/templates/html/template.html
+++ b/src/formattedcode/templates/html/template.html
@@ -131,6 +131,106 @@
         {% endfor %}
       </tbody>
     </table>
+    <table>
+      <caption>Holders</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>holder</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for path, row in files.infos.items() %}
+        {% if row.holders %}
+        {% for data in row.holders %}
+        <tr>
+          <td>{{ path }}</td>
+          <td>{{ data.value }}</td>
+          <td>{{ data.start_line }}</td>
+          <td>{{ data.end_line }}</td>
+        </tr>
+        {% endfor %}
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+    <table>
+      <caption>Authors</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>Author</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for path, row in files.infos.items() %}
+        {% if row.authors %}
+        {% for data in row.authors %}
+        <tr>
+          <td>{{ path }}</td>
+          <td>{{ data.value }}</td>
+          <td>{{ data.start_line }}</td>
+          <td>{{ data.end_line }}</td>
+        </tr>
+        {% endfor %}
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+    <table>
+      <caption>Emails</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>email</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for path, row in files.infos.items() %}
+        {% if row.emails %}
+        {% for data in row.emails %}
+        <tr>
+          <td>{{ path }}</td>
+          <td>{{ data.email |urlize(target='_blank') }}</td>
+          <td>{{ data.start_line }}</td>
+          <td>{{ data.end_line }}</td>
+        </tr>
+        {% endfor %}
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+    <table>
+      <caption>Urls</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>url</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for path, row in files.infos.items() %}
+        {% if row.urls %}
+        {% for data in row.urls %}
+        <tr>
+          <td>{{ path }}</td>
+          <td>{{ data.url |urlize(target='_blank') }}</td>
+          <td>{{ data.start_line }}</td>
+          <td>{{ data.end_line }}</td>
+        </tr>
+        {% endfor %}
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
     {% endif %}
 
     {% if files.packages %}

--- a/tests/formattedcode/data/templated/sample-template.html
+++ b/tests/formattedcode/data/templated/sample-template.html
@@ -62,7 +62,7 @@
     </style>
   </head>
   <body>
-    <p> Scanned with ScanCode version {{ version }} </p>
+    <p> Scanned with ScanCode </p>
     {% if files.license_copyright %}
     <table>
       <caption>Copyrights and Licenses Information</caption>
@@ -104,7 +104,6 @@
           <th>type</th>
           <th>name</th>
           <th>extension</th>
-          <th>date</th>
           <th>size</th>
           <th>sha1</th>
           <th>md5</th>
@@ -127,7 +126,6 @@
               <td>{{ row.type }}</td>
               <td>{{ row.name }}</td>
               <td>{{ row.extension }}</td>
-              <td>{{ row.date }}</td>
               <td>{{ row.size }}</td>
               <td>{{ row.sha1 }}</td>
               <td>{{ row.md5 }}</td>
@@ -142,6 +140,106 @@
               <td>{{ row.is_source }}</td>
               <td>{{ row.is_script }}</td>
             </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <table>
+      <caption>Holders</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>holder</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for path, row in files.infos.items() %}
+        {% if row.holders %}
+        {% for data in row.holders %}
+        <tr>
+          <td>{{ path }}</td>
+          <td>{{ data.value }}</td>
+          <td>{{ data.start_line }}</td>
+          <td>{{ data.end_line }}</td>
+        </tr>
+        {% endfor %}
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+    <table>
+      <caption>Authors</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>Author</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for path, row in files.infos.items() %}
+        {% if row.authors %}
+        {% for data in row.authors %}
+        <tr>
+          <td>{{ path }}</td>
+          <td>{{ data.value }}</td>
+          <td>{{ data.start_line }}</td>
+          <td>{{ data.end_line }}</td>
+        </tr>
+        {% endfor %}
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+    <table>
+      <caption>Emails</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>email</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for path, row in files.infos.items() %}
+        {% if row.emails %}
+        {% for data in row.emails %}
+        <tr>
+          <td>{{ path }}</td>
+          <td>{{ data.email |urlize(target='_blank') }}</td>
+          <td>{{ data.start_line }}</td>
+          <td>{{ data.end_line }}</td>
+        </tr>
+        {% endfor %}
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+    <table>
+      <caption>Urls</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>url</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for path, row in files.infos.items() %}
+        {% if row.urls %}
+        {% for data in row.urls %}
+        <tr>
+          <td>{{ path }}</td>
+          <td>{{ data.url |urlize(target='_blank') }}</td>
+          <td>{{ data.start_line }}</td>
+          <td>{{ data.end_line }}</td>
+        </tr>
+        {% endfor %}
+        {% endif %}
         {% endfor %}
       </tbody>
     </table>

--- a/tests/formattedcode/data/templated/simple-expected.html
+++ b/tests/formattedcode/data/templated/simple-expected.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+  <head>
+    <meta charset="utf-8">
+    <title>Custom Template</title>
+    <style type="text/css">
+      table  {
+        border-collapse:collapse;
+        border: 1px solid gray;
+        margin-bottom: 20px;
+      }
+      td{
+        padding: 5px 5px;
+        border-style: solid;
+        border-width: 1px;
+        overflow: hidden;
+      }
+      th{
+        padding:10px 5px;
+        border-style: solid;
+        border-width: 1px;
+        overflow: hidden;
+        border-color: gray;
+        color: #fff;
+        background-color: #5E81B7;
+      }
+      tr:nth-child(even)  { background-color:#FFFFFF; }
+      tr:nth-child(odd) { background-color:#F9F9F9; }
+      tr:hover {background-color: #EEEEEE;}
+      * {
+        font-family: Helvetica, Arial, sans-serif;
+        font-weight: normal;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <p> Scanned with ScanCode </p>
+    
+    <table>
+      <caption>Copyrights and Licenses Information</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>start</th>
+          <th>end</th>
+          <th>what</th>
+          <th>value</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+          
+            <tr>
+              <td>simple/copyright_acme_c-c.c</td>
+              <td>1</td>
+              <td>1</td>
+              <td>copyright</td>
+              
+                <td>Copyright (c) 2000 ACME, Inc.</td>
+              
+            </tr>
+          
+        
+      </tbody>
+    </table>
+    
+
+    
+    <table>
+      <caption>File Information</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>type</th>
+          <th>name</th>
+          <th>extension</th>
+          <th>size</th>
+          <th>sha1</th>
+          <th>md5</th>
+          <th>files_count</th>
+          <th>mime_type</th>
+          <th>file_type</th>
+          <th>programming_language</th>
+          <th>is_binary</th>
+          <th>is_text</th>
+          <th>is_archive</th>
+          <th>is_media</th>
+          <th>is_source</th>
+          <th>is_script</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+            <tr>
+              <td>simple</td>
+              <td>directory</td>
+              <td>simple</td>
+              <td></td>
+              <td>0</td>
+              <td>None</td>
+              <td>None</td>
+              <td></td>
+              <td>None</td>
+              <td>None</td>
+              <td>None</td>
+              <td>False</td>
+              <td>False</td>
+              <td>False</td>
+              <td>False</td>
+              <td>False</td>
+              <td>False</td>
+            </tr>
+        
+            <tr>
+              <td>simple/copyright_acme_c-c.c</td>
+              <td>file</td>
+              <td>copyright_acme_c-c.c</td>
+              <td>.c</td>
+              <td>55</td>
+              <td>e2466d5b764d27fb301ceb439ffb5da22e43ab1d</td>
+              <td>bdf7c572beb4094c2059508fa73c05a4</td>
+              <td></td>
+              <td>text/plain</td>
+              <td>UTF-8 Unicode text, with no line terminators</td>
+              <td>C</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+            </tr>
+        
+      </tbody>
+    </table>
+    <table>
+      <caption>Holders</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>holder</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+        
+        
+        
+        <tr>
+          <td>simple/copyright_acme_c-c.c</td>
+          <td>ACME, Inc.</td>
+          <td>1</td>
+          <td>1</td>
+        </tr>
+        
+        
+        
+      </tbody>
+    </table>
+    <table>
+      <caption>Authors</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>Author</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+        
+        
+        
+      </tbody>
+    </table>
+    <table>
+      <caption>Emails</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>email</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+        
+        
+        
+      </tbody>
+    </table>
+    <table>
+      <caption>Urls</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>url</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+        
+        
+        
+      </tbody>
+    </table>
+    
+
+    
+    <table>
+      <caption>Package Information</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>type</th>
+          <th>packaging</th>
+          <th>primary_language</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+          
+        
+          
+        
+      </tbody>
+    </table>
+    
+
+    
+  </body>
+  <footer>
+    <p>Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    No content created from ScanCode should be considered or used as legal advice. Consult an Attorney for any legal advice.
+    ScanCode is a free software code scanning tool from nexB Inc. and others.
+    Visit <a href="http://www.nexb.com/">http://www.nexb.com</a> and <a href="https://github.com/nexB/scancode-toolkit/">https://github.com/nexB/scancode-toolkit/</a> for support and download.
+  </footer>
+</html>

--- a/tests/formattedcode/data/templated/tree/expected.html
+++ b/tests/formattedcode/data/templated/tree/expected.html
@@ -1,0 +1,557 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+  <head>
+    <meta charset="utf-8">
+    <title>Custom Template</title>
+    <style type="text/css">
+      table  {
+        border-collapse:collapse;
+        border: 1px solid gray;
+        margin-bottom: 20px;
+      }
+      td{
+        padding: 5px 5px;
+        border-style: solid;
+        border-width: 1px;
+        overflow: hidden;
+      }
+      th{
+        padding:10px 5px;
+        border-style: solid;
+        border-width: 1px;
+        overflow: hidden;
+        border-color: gray;
+        color: #fff;
+        background-color: #5E81B7;
+      }
+      tr:nth-child(even)  { background-color:#FFFFFF; }
+      tr:nth-child(odd) { background-color:#F9F9F9; }
+      tr:hover {background-color: #EEEEEE;}
+      * {
+        font-family: Helvetica, Arial, sans-serif;
+        font-weight: normal;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <p> Scanned with ScanCode </p>
+    
+    <table>
+      <caption>Copyrights and Licenses Information</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>start</th>
+          <th>end</th>
+          <th>what</th>
+          <th>value</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+          
+            <tr>
+              <td>copy1.c</td>
+              <td>1</td>
+              <td>1</td>
+              <td>copyright</td>
+              
+                <td>Copyright (c) 2000 ACME, Inc.</td>
+              
+            </tr>
+          
+        
+          
+            <tr>
+              <td>copy2.c</td>
+              <td>1</td>
+              <td>1</td>
+              <td>copyright</td>
+              
+                <td>Copyright (c) 2000 ACME, Inc.</td>
+              
+            </tr>
+          
+        
+          
+            <tr>
+              <td>copy3.c</td>
+              <td>1</td>
+              <td>1</td>
+              <td>copyright</td>
+              
+                <td>Copyright (c) 2000 ACME, Inc.</td>
+              
+            </tr>
+          
+        
+          
+            <tr>
+              <td>subdir/copy1.c</td>
+              <td>1</td>
+              <td>1</td>
+              <td>copyright</td>
+              
+                <td>Copyright (c) 2000 ACME, Inc.</td>
+              
+            </tr>
+          
+        
+          
+            <tr>
+              <td>subdir/copy2.c</td>
+              <td>1</td>
+              <td>1</td>
+              <td>copyright</td>
+              
+                <td>Copyright (c) 2000 ACME, Inc.</td>
+              
+            </tr>
+          
+        
+          
+            <tr>
+              <td>subdir/copy3.c</td>
+              <td>1</td>
+              <td>1</td>
+              <td>copyright</td>
+              
+                <td>Copyright (c) 2000 ACME, Inc.</td>
+              
+            </tr>
+          
+        
+          
+            <tr>
+              <td>subdir/copy4.c</td>
+              <td>1</td>
+              <td>1</td>
+              <td>copyright</td>
+              
+                <td>Copyright (c) 2000 ACME, Inc.</td>
+              
+            </tr>
+          
+        
+      </tbody>
+    </table>
+    
+
+    
+    <table>
+      <caption>File Information</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>type</th>
+          <th>name</th>
+          <th>extension</th>
+          <th>size</th>
+          <th>sha1</th>
+          <th>md5</th>
+          <th>files_count</th>
+          <th>mime_type</th>
+          <th>file_type</th>
+          <th>programming_language</th>
+          <th>is_binary</th>
+          <th>is_text</th>
+          <th>is_archive</th>
+          <th>is_media</th>
+          <th>is_source</th>
+          <th>is_script</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+            <tr>
+              <td>copy1.c</td>
+              <td>file</td>
+              <td>copy1.c</td>
+              <td>.c</td>
+              <td>91</td>
+              <td>3922760d8492eb8f853c10a627f5a73f9eaec6ff</td>
+              <td>fc7f53659b7a9db8b6dff0638641778e</td>
+              <td></td>
+              <td>text/plain</td>
+              <td>UTF-8 Unicode text</td>
+              <td>C</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+            </tr>
+        
+            <tr>
+              <td>copy2.c</td>
+              <td>file</td>
+              <td>copy2.c</td>
+              <td>.c</td>
+              <td>91</td>
+              <td>3922760d8492eb8f853c10a627f5a73f9eaec6ff</td>
+              <td>fc7f53659b7a9db8b6dff0638641778e</td>
+              <td></td>
+              <td>text/plain</td>
+              <td>UTF-8 Unicode text</td>
+              <td>C</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+            </tr>
+        
+            <tr>
+              <td>copy3.c</td>
+              <td>file</td>
+              <td>copy3.c</td>
+              <td>.c</td>
+              <td>91</td>
+              <td>c91811eb5fdc7ab440355f9f8d1580e1518b0c2f</td>
+              <td>e999e21c9d7de4d0f943aefbb6f21b99</td>
+              <td></td>
+              <td>text/plain</td>
+              <td>UTF-8 Unicode text</td>
+              <td>C</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+            </tr>
+        
+            <tr>
+              <td>subdir</td>
+              <td>directory</td>
+              <td>subdir</td>
+              <td></td>
+              <td>0</td>
+              <td>None</td>
+              <td>None</td>
+              <td></td>
+              <td>None</td>
+              <td>None</td>
+              <td>None</td>
+              <td>False</td>
+              <td>False</td>
+              <td>False</td>
+              <td>False</td>
+              <td>False</td>
+              <td>False</td>
+            </tr>
+        
+            <tr>
+              <td>subdir/copy1.c</td>
+              <td>file</td>
+              <td>copy1.c</td>
+              <td>.c</td>
+              <td>91</td>
+              <td>3922760d8492eb8f853c10a627f5a73f9eaec6ff</td>
+              <td>fc7f53659b7a9db8b6dff0638641778e</td>
+              <td></td>
+              <td>text/plain</td>
+              <td>UTF-8 Unicode text</td>
+              <td>C</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+            </tr>
+        
+            <tr>
+              <td>subdir/copy2.c</td>
+              <td>file</td>
+              <td>copy2.c</td>
+              <td>.c</td>
+              <td>91</td>
+              <td>3922760d8492eb8f853c10a627f5a73f9eaec6ff</td>
+              <td>fc7f53659b7a9db8b6dff0638641778e</td>
+              <td></td>
+              <td>text/plain</td>
+              <td>UTF-8 Unicode text</td>
+              <td>C</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+            </tr>
+        
+            <tr>
+              <td>subdir/copy3.c</td>
+              <td>file</td>
+              <td>copy3.c</td>
+              <td>.c</td>
+              <td>84</td>
+              <td>389af7e629a9853056e42b262d5e30bf4579a74f</td>
+              <td>290627a1387288ef77ae7e07946f3ecf</td>
+              <td></td>
+              <td>text/plain</td>
+              <td>UTF-8 Unicode text</td>
+              <td>C</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+            </tr>
+        
+            <tr>
+              <td>subdir/copy4.c</td>
+              <td>file</td>
+              <td>copy4.c</td>
+              <td>.c</td>
+              <td>95</td>
+              <td>58748872d25374160692f1ed7075d0fe80a544b1</td>
+              <td>88e46475db9b1a68f415f6a3544eeb16</td>
+              <td></td>
+              <td>text/plain</td>
+              <td>UTF-8 Unicode text</td>
+              <td>C</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+              <td>False</td>
+              <td>True</td>
+              <td>False</td>
+            </tr>
+        
+      </tbody>
+    </table>
+    <table>
+      <caption>Holders</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>holder</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+        
+        <tr>
+          <td>copy1.c</td>
+          <td>ACME, Inc.</td>
+          <td>1</td>
+          <td>1</td>
+        </tr>
+        
+        
+        
+        
+        
+        <tr>
+          <td>copy2.c</td>
+          <td>ACME, Inc.</td>
+          <td>1</td>
+          <td>1</td>
+        </tr>
+        
+        
+        
+        
+        
+        <tr>
+          <td>copy3.c</td>
+          <td>ACME, Inc.</td>
+          <td>1</td>
+          <td>1</td>
+        </tr>
+        
+        
+        
+        
+        
+        
+        
+        <tr>
+          <td>subdir/copy1.c</td>
+          <td>ACME, Inc.</td>
+          <td>1</td>
+          <td>1</td>
+        </tr>
+        
+        
+        
+        
+        
+        <tr>
+          <td>subdir/copy2.c</td>
+          <td>ACME, Inc.</td>
+          <td>1</td>
+          <td>1</td>
+        </tr>
+        
+        
+        
+        
+        
+        <tr>
+          <td>subdir/copy3.c</td>
+          <td>ACME, Inc.</td>
+          <td>1</td>
+          <td>1</td>
+        </tr>
+        
+        
+        
+        
+        
+        <tr>
+          <td>subdir/copy4.c</td>
+          <td>ACME, Inc.</td>
+          <td>1</td>
+          <td>1</td>
+        </tr>
+        
+        
+        
+      </tbody>
+    </table>
+    <table>
+      <caption>Authors</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>Author</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+      </tbody>
+    </table>
+    <table>
+      <caption>Emails</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>email</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+      </tbody>
+    </table>
+    <table>
+      <caption>Urls</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>url</th>
+          <th>start</th>
+          <th>end</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+      </tbody>
+    </table>
+    
+
+    
+    <table>
+      <caption>Package Information</caption>
+      <thead>
+        <tr>
+          <th>path</th>
+          <th>type</th>
+          <th>packaging</th>
+          <th>primary_language</th>
+        </tr>
+      </thead>
+      <tbody>
+        
+          
+        
+          
+        
+          
+        
+          
+        
+          
+        
+          
+        
+          
+        
+          
+        
+      </tbody>
+    </table>
+    
+
+    
+  </body>
+  <footer>
+    <p>Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    No content created from ScanCode should be considered or used as legal advice. Consult an Attorney for any legal advice.
+    ScanCode is a free software code scanning tool from nexB Inc. and others.
+    Visit <a href="http://www.nexb.com/">http://www.nexb.com</a> and <a href="https://github.com/nexB/scancode-toolkit/">https://github.com/nexB/scancode-toolkit/</a> for support and download.
+  </footer>
+</html>

--- a/tests/formattedcode/test_output_templated.py
+++ b/tests/formattedcode/test_output_templated.py
@@ -114,17 +114,29 @@ def test_custom_format_with_custom_filename_fails_for_directory():
 def normalize_quotes(s):
     return s.replace("'", '"')
 
+@pytest.mark.scanslow
+def test_scan_custom_html_output_for_a_directory():
+    test_dir = test_env.get_test_loc('templated/tree/scan/')
+    custom_template = test_env.get_test_loc('templated/sample-template.html')
+    expected_file = test_env.get_test_loc('templated/tree/expected.html')
+    result_file = test_env.get_temp_file('html')
+    args = ['-clip', '--strip-root', '--custom-template', custom_template, '--custom-output', result_file, test_dir]
+    run_scan_click(args)
+    results = open(result_file).read()
+    expected = open(expected_file).read()
+    assert expected == results
 
 @pytest.mark.scanslow
 def test_custom_format_with_custom_filename():
     test_dir = test_env.get_test_loc('templated/simple')
     custom_template = test_env.get_test_loc('templated/sample-template.html')
+    expected_file = test_env.get_test_loc('templated/simple-expected.html')
     result_file = test_env.get_temp_file('html')
-    args = ['--info', '--custom-template', custom_template, '--custom-output', result_file, test_dir]
+    args = ['-clip', '--custom-template', custom_template, '--custom-output', result_file, test_dir]
     run_scan_click(args)
     results = open(result_file).read()
-    assert 'Custom Template' in results
-    assert __version__ in results
+    expected = open(expected_file).read()
+    assert expected == results
 
 
 @pytest.mark.scanslow


### PR DESCRIPTION
Add emails and urls in converted_infos. Earlier emails and urls were excluded from infos so these informations weren't fed into html template. Add holders, authors, emails and urls information in html template.

Signed-off-by: Sarita Singh <saritasingh.0425@gmail.com>
Co-authored-by: Avinal Kumar <avinal.xlvii@gmail.com>

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Partially Solves #1359 

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
