### PR TITLE
Improve copyright detection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,11 @@ Copyright detection:
  - The data structure in the JSON is now using consistently named attributes as
    opposed to a plain value.
 
+ - The copyright detection speed has been significantly improved with the tests
+   taking roughly 1/2 of the time to run. This is achieved mostly by replacing
+   NLTK with a the minimal and simplified subset we need in a new library named
+   pygmars.
+
 
 Package detection:
 ~~~~~~~~~~~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ license-expression==1.2
 lxml==4.6.3
 MarkupSafe==2.0.1
 more-itertools==8.8.0
-nltk==3.4.5
 normality==2.2.2
 packageurl-python==0.9.4
 packaging==20.9
@@ -50,6 +49,7 @@ publicsuffix2==2.20191221
 pyahocorasick==1.4.2
 pycparser==2.20
 Pygments==2.9.0
+pygmars==0.5.0
 pymaven-patch==0.3.0
 pyparsing==2.4.7
 PyYAML==5.4.1

--- a/setup-mini.cfg
+++ b/setup-mini.cfg
@@ -76,7 +76,6 @@ install_requires =
     license_expression >= 1.0
     lxml >= 4.6.3, < 5.0.0
     MarkupSafe >= 1.0
-    nltk >= 3.2, !=3.6, < 4.0
     packageurl_python >= 0.9.0
     packaging > 20
     pdfminer.six >= 20200101
@@ -86,6 +85,7 @@ install_requires =
     plugincode >= 21.1.21
     publicsuffix2
     pyahocorasick >= 1.4.0, < 1.5
+    pygmars
     pygments
     pymaven_patch >= 0.2.8
     requests >= 2.7.0, < 3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,6 @@ install_requires =
     license_expression >= 1.0
     lxml >= 4.6.3, < 5.0.0
     MarkupSafe >= 1.0
-    nltk >= 3.2, !=3.6, < 4.0
     packageurl_python >= 0.9.0
     packaging > 20
     pdfminer.six >= 20200101
@@ -86,6 +85,7 @@ install_requires =
     plugincode >= 21.1.21
     publicsuffix2
     pyahocorasick >= 1.4.0, < 1.5
+    pygmars
     pygments
     pymaven_patch >= 0.2.8
     requests >= 2.7.0, < 3.0.0

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -74,15 +74,15 @@ def detect_copyrights(
     Yield tuples of (detection type, detected string, start line, end line)
     detected in the file at ``location``.
 
-    "detection type" is one of : "copyrights", "authors", "holders".
+    "detection type" is one of: "copyrights", "authors", or "holders".
 
     These are included in the yielded tuples based on the values of
     ``copyrights=True``, ``holders=True``, ``authors=True``
 
-    - Include years in copyrights if ``include_years`` is True.
-    - Include trailing "all rights reserved"-style mentions if
+    - Include years in copyrights, if ``include_years`` is True.
+    - Include trailing "all rights reserved"-style mentions, if
       ``include_allrights`` is True.
-    - Strip markup from text if ``demarkup`` is True.
+    - Strip markup from text, if ``demarkup`` is True.
     - Run for up to ``deadline`` seconds and return results found so far.
     """
     from textcode.analysis import numbered_text_lines

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -2133,9 +2133,6 @@ grammar = """
     # (C) 2001-2009, <s>Takuo KITAME, Bart Martens, and  Canonical, LTD</s>
     COPYRIGHT: {<COPYRIGHT> <NNP> <COMPANY>}       #26381
 
-    #Copyright Holders Kevin Vandersloot <kfv101@psu.edu> Erik Johnsson <zaphod@linux.nu>
-    COPYRIGHT: {<COPY> <HOLDER> <NAME>}       #26383
-
     #Copyright (c) 1995, 1996 - Blue Sky Software Corp.
     COPYRIGHT: {<COPYRIGHT2> <DASH> <COMPANY>}       #2639
 
@@ -2300,6 +2297,12 @@ grammar = """
 
     # Copyright (c) 2008 Intel Corporation / Qualcomm Inc.
     COPYRIGHT: {<COPYRIGHT>  <DASH>  <COMPANY>} #copydash-co
+
+    #Copyright Holders Kevin Vandersloot <kfv101@psu.edu> Erik Johnsson <zaphod@linux.nu>
+    COPYRIGHT: {<COPY> <HOLDER> <NAME>}       #83000
+
+    #holder is Tim Hudson (tjh@mincom.oz.au).
+    COPYRIGHT: {<HOLDER> <JUNK> <NAME-EMAIL>}       #83001
 
 #######################################
 # Authors
@@ -2712,6 +2715,7 @@ HOLDERS_PREFIXES = frozenset(set.union(
         'reserved',
         'held',
         'by',
+        'is',
     ])
 ))
 

--- a/src/licensedcode/data/licenses/openssl-ssleay.yml
+++ b/src/licensedcode/data/licenses/openssl-ssleay.yml
@@ -13,17 +13,20 @@ text_urls:
     - http://www.openssl.org/source/license.html
 faq_url: http://www.openssl.org/support/faq.html
 minimum_coverage: 70
-ignorable_copyrights:
-    - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)
     - the OpenSSL Project
-ignorable_holders:
-    - Eric Young
-ignorable_urls:
-    - http://www.openssl.org/
+ignorable_copyrights:
+  - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_emails:
-    - eay@cryptsoft.com
-    - openssl-core@openssl.org
-    - tjh@cryptsoft.com
+  - eay@cryptsoft.com
+  - openssl-core@openssl.org
+  - tjh@cryptsoft.com
+ignorable_holders:
+  - Eric Young
+  - Tim Hudson
+ignorable_urls:
+  - http://www.openssl.org/
+

--- a/src/licensedcode/data/licenses/ssleay-windows.yml
+++ b/src/licensedcode/data/licenses/ssleay-windows.yml
@@ -12,6 +12,11 @@ other_urls:
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)
+ignorable_copyrights:
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_emails:
-    - eay@cryptsoft.com
-    - tjh@cryptsoft.com
+  - eay@cryptsoft.com
+  - tjh@cryptsoft.com
+ignorable_holders:
+  - Tim Hudson
+

--- a/src/licensedcode/data/licenses/ssleay.yml
+++ b/src/licensedcode/data/licenses/ssleay.yml
@@ -9,6 +9,11 @@ text_urls:
     - http://www.openssl.org/source/license.html
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
+ignorable_copyrights:
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_emails:
-    - eay@cryptsoft.com
-    - tjh@cryptsoft.com
+  - eay@cryptsoft.com
+  - tjh@cryptsoft.com
+ignorable_holders:
+  - Tim Hudson
+

--- a/src/licensedcode/data/rules/openssl-ssleay.SPDX.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay.SPDX.yml
@@ -4,8 +4,10 @@ minimum_coverage: 80
 notes: license text as published by SPDX
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_14.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_14.yml
@@ -4,9 +4,11 @@ minimum_coverage: 80
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
     - Copyright (c) 1998-2018 The OpenSSL Project
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
     - The OpenSSL Project
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_18.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_18.yml
@@ -4,9 +4,11 @@ minimum_coverage: 80
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
     - Copyright (c) The OpenSSL Project
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
     - The OpenSSL Project
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_3.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_3.yml
@@ -4,8 +4,10 @@ minimum_coverage: 80
 notes: full openssl/ssleay with extra headers
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_31.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_31.yml
@@ -1,12 +1,14 @@
 license_expression: openssl-ssleay
 is_license_text: yes
-notes: typo in "if the [rouines] from the library" 
+notes: typo in "if the [rouines] from the library"
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
     - Copyright (c) 1998-2008 The OpenSSL Project
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
     - The OpenSSL Project
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_34.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_34.yml
@@ -3,8 +3,10 @@ is_license_text: yes
 relevance: 100
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_35.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_35.yml
@@ -4,9 +4,11 @@ relevance: 100
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
     - Copyright (c) 1998-2016 The OpenSSL Project
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
     - The OpenSSL Project
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_36.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_36.yml
@@ -5,9 +5,11 @@ minimum_coverage: 90
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
     - Copyright (c) 1998-2003 The OpenSSL Project
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
     - The OpenSSL Project
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_37.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_37.yml
@@ -4,9 +4,11 @@ relevance: 100
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
     - Copyright (c) 1998-2002 The OpenSSL Project
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
     - The OpenSSL Project
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_4.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_4.yml
@@ -5,9 +5,11 @@ notes: full openssl/ssleay with extra headers
 ignorable_copyrights:
     - Copyright (c) Eric Young (eay@cryptsoft.com)
     - Copyright (c) The OpenSSL Project
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
     - The OpenSSL Project
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_40.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_40.yml
@@ -4,9 +4,11 @@ relevance: 100
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
     - Copyright (c) 1998-2017 The OpenSSL Project
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
     - The OpenSSL Project
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_55.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_55.yml
@@ -4,9 +4,11 @@ relevance: 100
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
     - Copyright (c) 1998-2008 The OpenSSL Project
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
     - The OpenSSL Project
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_56.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_56.yml
@@ -4,9 +4,11 @@ relevance: 100
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
     - Copyright (c) 1998-2019 The OpenSSL Project
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
     - The OpenSSL Project
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/openssl-ssleay_9.yml
+++ b/src/licensedcode/data/rules/openssl-ssleay_9.yml
@@ -4,9 +4,11 @@ minimum_coverage: 80
 ignorable_copyrights:
     - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
     - Copyright (c) 1998 The OpenSSL Project
+    - holder is Tim Hudson (tjh@cryptsoft.com)
 ignorable_holders:
     - Eric Young
     - The OpenSSL Project
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@cryptsoft.com)
     - Tim Hudson (tjh@cryptsoft.com)

--- a/src/licensedcode/data/rules/ssleay-windows_1.yml
+++ b/src/licensedcode/data/rules/ssleay-windows_1.yml
@@ -1,6 +1,10 @@
 license_expression: ssleay-windows
 is_license_text: yes
 notes: SSLEAY windows Variant with typos
+ignorable_copyrights:
+    - holder is Tim Hudson (tjh@cryptsoft.com)
+ignorable_holders:
+    - Tim Hudson
 ignorable_authors:
     - Tim Hudson (tjh@cryptsoft.com)
 ignorable_emails:

--- a/src/licensedcode/data/rules/ssleay-windows_2.yml
+++ b/src/licensedcode/data/rules/ssleay-windows_2.yml
@@ -1,6 +1,10 @@
 license_expression: ssleay-windows
 is_license_text: yes
 notes: Variant of  Original SSLeay License with Windows exception
+ignorable_copyrights:
+    - holder is Tim Hudson (tjh@mincom.oz.au)
+ignorable_holders:
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@mincom.oz.au)
     - Tim Hudson (tjh@mincom.oz.au)

--- a/src/licensedcode/data/rules/ssleay-windows_3.yml
+++ b/src/licensedcode/data/rules/ssleay-windows_3.yml
@@ -1,6 +1,10 @@
 license_expression: ssleay-windows
 is_license_text: yes
 notes: SSLEAY windows Variant with typos
+ignorable_copyrights:
+    - holder is Tim Hudson (tjh@cryptsoft.com)
+ignorable_holders:
+    - Tim Hudson
 ignorable_authors:
     - Tim Hudson (tjh@cryptsoft.com)
 ignorable_emails:

--- a/src/licensedcode/data/rules/ssleay-windows_4.yml
+++ b/src/licensedcode/data/rules/ssleay-windows_4.yml
@@ -1,6 +1,10 @@
 license_expression: ssleay-windows
 is_license_text: yes
 notes: SSLEAY windows Variant with typos
+ignorable_copyrights:
+    - holder is Tim Hudson (tjh@mincom.oz.au)
+ignorable_holders:
+    - Tim Hudson
 ignorable_authors:
     - Tim Hudson (tjh@mincom.oz.au)
 ignorable_emails:

--- a/src/licensedcode/data/rules/ssleay_3.yml
+++ b/src/licensedcode/data/rules/ssleay_3.yml
@@ -1,5 +1,9 @@
 license_expression: ssleay
 is_license_text: yes
+ignorable_copyrights:
+    - holder is Tim Hudson (tjh@cryptsoft.com)
+ignorable_holders:
+    - Tim Hudson
 ignorable_emails:
     - eay@cryptsoft.com
     - tjh@cryptsoft.com

--- a/src/licensedcode/data/rules/ssleay_4.yml
+++ b/src/licensedcode/data/rules/ssleay_4.yml
@@ -1,6 +1,10 @@
 license_expression: ssleay
 is_license_text: yes
 notes: Variant of SSLEay with typos
+ignorable_copyrights:
+    - holder is Tim Hudson (tjh@mincom.oz.au)
+ignorable_holders:
+    - Tim Hudson
 ignorable_emails:
     - eay@mincom.oz.au
     - tjh@mincom.oz.au

--- a/src/licensedcode/data/rules/ssleay_5.yml
+++ b/src/licensedcode/data/rules/ssleay_5.yml
@@ -2,8 +2,10 @@ license_expression: ssleay
 is_license_text: yes
 ignorable_copyrights:
     - Copyright (c) 1995-1997 Eric Young (eay@mincom.oz.au)
+    - holder is Tim Hudson (tjh@mincom.oz.au)
 ignorable_holders:
     - Eric Young
+    - Tim Hudson
 ignorable_authors:
     - Eric Young (eay@mincom.oz.au)
 ignorable_emails:

--- a/tests/cluecode/data/copyrights/author_young_c-c.c.yml
+++ b/tests/cluecode/data/copyrights/author_young_c-c.c.yml
@@ -4,8 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1997 Eric Young (eay@mincom.oz.au)
+  - holder is Tim Hudson (tjh@mincom.oz.au)
 holders:
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/copyrights/eric_young_c-c.c.yml
+++ b/tests/cluecode/data/copyrights/eric_young_c-c.c.yml
@@ -4,8 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1997 Eric Young (eay@mincom.oz.au)
+  - holder is Tim Hudson (tjh@mincom.oz.au)
 holders:
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/copyrights/holders.txt
+++ b/tests/cluecode/data/copyrights/holders.txt
@@ -1,0 +1,7 @@
+ * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+ * included with this distribution is covered by the same copyright terms
+ * except that the holder is Tim Hudson (tjh@mincom.oz.au).
+
+
+
+Copyright Holders Kevin Vandersloot <kfv101@psu.edu> Erik Johnsson <zaphod@linux.nu>

--- a/tests/cluecode/data/copyrights/holders.txt.yml
+++ b/tests/cluecode/data/copyrights/holders.txt.yml
@@ -1,0 +1,9 @@
+what:
+  - copyrights
+  - holders
+copyrights:
+  - holder is Tim Hudson (tjh@mincom.oz.au)
+  - Copyright Holders Kevin Vandersloot <kfv101@psu.edu> Erik Johnsson <zaphod@linux.nu>
+holders:
+  - Tim Hudson
+  - Kevin Vandersloot Erik Johnsson

--- a/tests/cluecode/data/copyrights/openoffice_org_report_builder_bin.copyright.yml
+++ b/tests/cluecode/data/copyrights/openoffice_org_report_builder_bin.copyright.yml
@@ -90,6 +90,7 @@ copyrights:
   - Copyright (c) 1998-2007 The OpenSSL Project
   - Copyright (c) 1998-2007 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 2001, 2002, 2003, 2004 Python Software Foundation
   - Copyright (c) 2000 BeOpen.com
   - Copyright (c) 1995-2001 Corporation for National Research Initiatives
@@ -124,6 +125,7 @@ copyrights:
   - Copyright (c) 1998-2007 The OpenSSL Project
   - Copyright (c) 1998-2007 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 2001, 2002, 2003, 2004 Python Software Foundation
   - Copyright (c) 2000 BeOpen.com
   - Copyright (c) 1995-2001 Corporation for National Research Initiatives
@@ -240,6 +242,7 @@ holders:
   - The OpenSSL Project
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
   - Python Software Foundation
   - BeOpen.com
   - Corporation for National Research Initiatives
@@ -274,6 +277,7 @@ holders:
   - The OpenSSL Project
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
   - Python Software Foundation
   - BeOpen.com
   - Corporation for National Research Initiatives
@@ -365,6 +369,8 @@ holders_summary:
   - value: Stuart Caie
     count: 2
   - value: The Khronos Group Inc.
+    count: 2
+  - value: Tim Hudson
     count: 2
   - value: Tommi Komulainen
     count: 2

--- a/tests/cluecode/data/copyrights/openssl-c.c.yml
+++ b/tests/cluecode/data/copyrights/openssl-c.c.yml
@@ -4,8 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1997 Eric Young (eay@mincom.oz.au)
+  - holder is Tim Hudson (tjh@mincom.oz.au)
 holders:
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/holders/holder_young_c-c.c.yml
+++ b/tests/cluecode/data/holders/holder_young_c-c.c.yml
@@ -3,6 +3,10 @@ what:
   - holders_summary
 holders:
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
     count: 1
+  - value: Tim Hudson
+    count: 1
+

--- a/tests/cluecode/data/ics/chromium-chrome-browser-resources/about_credits.html.yml
+++ b/tests/cluecode/data/ics/chromium-chrome-browser-resources/about_credits.html.yml
@@ -80,6 +80,7 @@ copyrights:
   - Copyright (c) 2008 The Khronos Group Inc.
   - Copyright (c) 1998-2008 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 2009 The Chromium Authors
   - Copyright 2007 Google Inc.
   - Copyright (c) 2010 The Chromium Authors
@@ -184,6 +185,7 @@ holders:
   - The Khronos Group Inc.
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
   - The Chromium Authors
   - Google Inc.
   - The Chromium Authors
@@ -349,6 +351,8 @@ holders_summary:
   - value: The University of Utah and the Regents of the University of California
     count: 1
   - value: Thomas Broyer, Charlie Bozeman and Daniel Veillard
+    count: 1
+  - value: Tim Hudson
     count: 1
   - value: University of Chicago
     count: 1

--- a/tests/cluecode/data/ics/openssl-apps/app_rand.c.yml
+++ b/tests/cluecode/data/ics/openssl-apps/app_rand.c.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2000 The OpenSSL Project
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-apps/apps.c.yml
+++ b/tests/cluecode/data/ics/openssl-apps/apps.c.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2001 The OpenSSL Project
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-apps/apps.h.yml
+++ b/tests/cluecode/data/ics/openssl-apps/apps.h.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2001 The OpenSSL Project
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-apps/asn1pars.c.yml
+++ b/tests/cluecode/data/ics/openssl-apps/asn1pars.c.yml
@@ -4,8 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 holders:
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-apps/openssl.c.yml
+++ b/tests/cluecode/data/ics/openssl-apps/openssl.c.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2006 The OpenSSL Project
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-apps/s_client.c.yml
+++ b/tests/cluecode/data/ics/openssl-apps/s_client.c.yml
@@ -4,10 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2006 The OpenSSL Project
   - Copyright 2005 Nokia
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
   - Nokia
 holders_summary:
@@ -16,4 +18,6 @@ holders_summary:
   - value: Nokia
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-apps/s_server.c.yml
+++ b/tests/cluecode/data/ics/openssl-apps/s_server.c.yml
@@ -4,11 +4,13 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2006 The OpenSSL Project
   - Copyright 2002 Sun Microsystems, Inc.
   - Copyright 2005 Nokia
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
   - Sun Microsystems, Inc.
   - Nokia
@@ -20,4 +22,6 @@ holders_summary:
   - value: Sun Microsystems, Inc.
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-apps/speed.c.yml
+++ b/tests/cluecode/data/ics/openssl-apps/speed.c.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright 2002 Sun Microsystems, Inc.
 holders:
   - Eric Young
+  - Tim Hudson
   - Sun Microsystems, Inc.
 holders_summary:
   - value: Eric Young
     count: 1
   - value: Sun Microsystems, Inc.
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-asn1/a_sign.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-asn1/a_sign.c.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2003 The OpenSSL Project
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-bf/bf_locl.h.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-bf/bf_locl.h.yml
@@ -4,8 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1997 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 holders:
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-bio/b_print.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-bio/b_print.c.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright Patrick Powell 1995
 holders:
   - Eric Young
+  - Tim Hudson
   - Patrick Powell
 holders_summary:
   - value: Eric Young
     count: 1
   - value: Patrick Powell
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-bn/bn.h.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-bn/bn.h.yml
@@ -4,10 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1997 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2006 The OpenSSL Project
   - Copyright 2002 Sun Microsystems, Inc.
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
@@ -16,4 +18,6 @@ holders_summary:
   - value: Sun Microsystems, Inc.
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-bn/bn_blind.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-bn/bn_blind.c.yml
@@ -5,11 +5,15 @@ what:
 copyrights:
   - Copyright (c) 1998-2006 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 holders:
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-bn/bn_exp.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-bn/bn_exp.c.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2005 The OpenSSL Project
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-bn/bn_lcl.h.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-bn/bn_lcl.h.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2000 The OpenSSL Project
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-bn/bn_mod.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-bn/bn_mod.c.yml
@@ -5,11 +5,15 @@ what:
 copyrights:
   - Copyright (c) 1998-2000 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 holders:
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-des/read2pwd.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-des/read2pwd.c.yml
@@ -5,11 +5,15 @@ what:
 copyrights:
   - Copyright (c) 2001-2002 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 holders:
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-des/rpc_des.h.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-des/rpc_des.h.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1986 by Sun Microsystems, Inc.
 holders:
   - Eric Young
+  - Tim Hudson
   - Sun Microsystems, Inc.
 holders_summary:
   - value: Eric Young
     count: 1
   - value: Sun Microsystems, Inc.
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-evp/m_ecdsa.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-evp/m_ecdsa.c.yml
@@ -5,11 +5,15 @@ what:
 copyrights:
   - Copyright (c) 1998-2002 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 holders:
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-pem/pem_all.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-pem/pem_all.c.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2002 The OpenSSL Project
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-rand/rand_win.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-rand/rand_win.c.yml
@@ -4,10 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2000 The OpenSSL Project
   - (c) Copyright Microsoft Corp. 1993
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
   - Microsoft Corp.
 holders_summary:
@@ -16,4 +18,6 @@ holders_summary:
   - value: Microsoft Corp.
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-ui/ui_openssl.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-ui/ui_openssl.c.yml
@@ -5,11 +5,15 @@ what:
 copyrights:
   - Copyright (c) 2001 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 holders:
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-x509/x509.h.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-x509/x509.h.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright 2002 Sun Microsystems, Inc.
 holders:
   - Eric Young
+  - Tim Hudson
   - Sun Microsystems, Inc.
 holders_summary:
   - value: Eric Young
     count: 1
   - value: Sun Microsystems, Inc.
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto/cryptlib.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto/cryptlib.c.yml
@@ -5,10 +5,12 @@ what:
 copyrights:
   - Copyright (c) 1998-2006 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright 2002 Sun Microsystems, Inc.
 holders:
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
   - Sun Microsystems, Inc.
 holders_summary:
   - value: Eric Young
@@ -16,4 +18,6 @@ holders_summary:
   - value: Sun Microsystems, Inc.
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-include-openssl/ssl.h.yml
+++ b/tests/cluecode/data/ics/openssl-include-openssl/ssl.h.yml
@@ -4,11 +4,13 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2007 The OpenSSL Project
   - Copyright 2002 Sun Microsystems, Inc.
   - Copyright 2005 Nokia
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
   - Sun Microsystems, Inc.
   - Nokia
@@ -20,4 +22,6 @@ holders_summary:
   - value: Sun Microsystems, Inc.
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-include-openssl/ssl3.h.yml
+++ b/tests/cluecode/data/ics/openssl-include-openssl/ssl3.h.yml
@@ -4,10 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2002 The OpenSSL Project
   - Copyright 2002 Sun Microsystems, Inc.
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
@@ -16,4 +18,6 @@ holders_summary:
   - value: Sun Microsystems, Inc.
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-include-openssl/tls1.h.yml
+++ b/tests/cluecode/data/ics/openssl-include-openssl/tls1.h.yml
@@ -4,11 +4,13 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2006 The OpenSSL Project
   - Copyright 2002 Sun Microsystems, Inc.
   - Copyright 2005 Nokia
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
   - Sun Microsystems, Inc.
   - Nokia
@@ -20,4 +22,6 @@ holders_summary:
   - value: Sun Microsystems, Inc.
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/d1_both.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/d1_both.c.yml
@@ -5,11 +5,15 @@ what:
 copyrights:
   - Copyright (c) 1998-2005 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 holders:
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/d1_clnt.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/d1_clnt.c.yml
@@ -5,11 +5,15 @@ what:
 copyrights:
   - Copyright (c) 1999-2007 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 holders:
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/s2_lib.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/s2_lib.c.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2007 The OpenSSL Project
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/s3_enc.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/s3_enc.c.yml
@@ -4,10 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2007 The OpenSSL Project
   - Copyright 2005 Nokia
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
   - Nokia
 holders_summary:
@@ -16,4 +18,6 @@ holders_summary:
   - value: Nokia
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/s3_lib.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/s3_lib.c.yml
@@ -4,11 +4,13 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2007 The OpenSSL Project
   - Copyright 2002 Sun Microsystems, Inc.
   - Copyright 2005 Nokia
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
   - Sun Microsystems, Inc.
   - Nokia
@@ -20,4 +22,6 @@ holders_summary:
   - value: Sun Microsystems, Inc.
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/ssl_asn1.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/ssl_asn1.c.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright 2005 Nokia
 holders:
   - Eric Young
+  - Tim Hudson
   - Nokia
 holders_summary:
   - value: Eric Young
     count: 1
   - value: Nokia
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/ssl_cert.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/ssl_cert.c.yml
@@ -4,10 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2007 The OpenSSL Project
   - Copyright 2002 Sun Microsystems, Inc.
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
@@ -16,4 +18,6 @@ holders_summary:
   - value: Sun Microsystems, Inc.
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/ssltest.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/ssltest.c.yml
@@ -4,11 +4,13 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2000 The OpenSSL Project
   - Copyright 2002 Sun Microsystems, Inc.
   - Copyright 2005 Nokia
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
   - Sun Microsystems, Inc.
   - Nokia
@@ -20,4 +22,6 @@ holders_summary:
   - value: Sun Microsystems, Inc.
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/t1_reneg.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/t1_reneg.c.yml
@@ -4,12 +4,16 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
   - Copyright (c) 1998-2009 The OpenSSL Project
 holders:
   - Eric Young
+  - Tim Hudson
   - The OpenSSL Project
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl/NOTICE.yml
+++ b/tests/cluecode/data/ics/openssl/NOTICE.yml
@@ -5,11 +5,15 @@ what:
 copyrights:
   - Copyright (c) 1998-2011 The OpenSSL Project
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 holders:
   - The OpenSSL Project
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
     count: 1
   - value: The OpenSSL Project
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl/e_os.h.yml
+++ b/tests/cluecode/data/ics/openssl/e_os.h.yml
@@ -4,8 +4,12 @@ what:
   - holders_summary
 copyrights:
   - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  - holder is Tim Hudson (tjh@cryptsoft.com)
 holders:
   - Eric Young
+  - Tim Hudson
 holders_summary:
   - value: Eric Young
+    count: 1
+  - value: Tim Hudson
     count: 1

--- a/tests/packagedcode/data/debian/copyright/debian-2019-11-15/non-free/f/firmware-nonfree/stable_firmware-qcom-media.copyright-detailed.expected.yml
+++ b/tests/packagedcode/data/debian/copyright/debian-2019-11-15/non-free/f/firmware-nonfree/stable_firmware-qcom-media.copyright-detailed.expected.yml
@@ -7,6 +7,7 @@
   Copyright (c) 2013-2017 Qualcomm Technologies, Inc.
   Copyright (c) 1998-2011 The OpenSSL Project
   Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  holder is Tim Hudson (tjh@cryptsoft.com)
   Copyright (c) 1995-2005 Jean-loup Gailly
   Copyright (c) 1995-2009 Mark Adler
   Copyright (c) 1995-2003, 2010 Mark Adler

--- a/tests/packagedcode/data/debian/copyright/debian-2019-11-15/non-free/f/firmware-nonfree/stable_firmware-qcom-media.copyright.expected.yml
+++ b/tests/packagedcode/data/debian/copyright/debian-2019-11-15/non-free/f/firmware-nonfree/stable_firmware-qcom-media.copyright.expected.yml
@@ -7,6 +7,7 @@
   Copyright (c) 2013-2017 Qualcomm Technologies, Inc.
   Copyright (c) 1998-2011 The OpenSSL Project
   Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  holder is Tim Hudson (tjh@cryptsoft.com)
   Copyright (c) 1995-2005 Jean-loup Gailly
   Copyright (c) 1995-2009 Mark Adler
   Copyright (c) 1995-2003, 2010 Mark Adler

--- a/tests/packagedcode/data/debian/copyright/debian-slim-2021-04-07/usr/share/doc/libssl1.1/copyright-detailed.expected.yml
+++ b/tests/packagedcode/data/debian/copyright/debian-slim-2021-04-07/usr/share/doc/libssl1.1/copyright-detailed.expected.yml
@@ -5,3 +5,4 @@
   Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson
   Copyright (c) 1998-2004 The OpenSSL Project
   Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  holder is Tim Hudson (tjh@cryptsoft.com)

--- a/tests/packagedcode/data/debian/copyright/debian-slim-2021-04-07/usr/share/doc/libssl1.1/copyright.expected.yml
+++ b/tests/packagedcode/data/debian/copyright/debian-slim-2021-04-07/usr/share/doc/libssl1.1/copyright.expected.yml
@@ -5,3 +5,4 @@
   Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson
   Copyright (c) 1998-2004 The OpenSSL Project
   Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
+  holder is Tim Hudson (tjh@cryptsoft.com)


### PR DESCRIPTION
This PR adds small several improvements to copyright detection and a major update to performance with the new pygmars parser library replacing NLTK.
### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>