### PR TITLE
Remove deprecation warnings

### DIFF
--- a/src/formattedcode/output_debian.py
+++ b/src/formattedcode/output_debian.py
@@ -6,9 +6,9 @@
 # See https://github.com/nexB/scancode-toolkit for support or download.
 # See https://aboutcode.org for more information about nexB OSS projects.
 
-from debut.copyright import CopyrightFilesParagraph
-from debut.copyright import CopyrightHeaderParagraph
-from debut.copyright import DebianCopyright
+from debian_inspector.copyright import CopyrightFilesParagraph
+from debian_inspector.copyright import CopyrightHeaderParagraph
+from debian_inspector.copyright import DebianCopyright
 from license_expression import Licensing
 
 from commoncode.cliutils import PluggableCommandLineOption

--- a/src/formattedcode/output_json.py
+++ b/src/formattedcode/output_json.py
@@ -99,7 +99,7 @@ def write_results(codebase, output_file, pretty=False, **kwargs):
 
     # Begin wri'w' JSON to `output_file`
     with jsonstreams.Stream(
-        jsonstreams.Type.object,
+        jsonstreams.Type.OBJECT,
         fd=output_file,
         close_fd=close_fd,
         **jsonstreams_kwargs

--- a/src/scancode/cli_test_utils.py
+++ b/src/scancode/cli_test_utils.py
@@ -27,7 +27,8 @@ def run_scan_plain(
     """
     Run a scan as a plain subprocess. Return rc, stdout, stderr.
     """
-    from commoncode.command import execute2
+
+    from commoncode.command import execute
 
     options = add_windows_extra_timeout(options)
 
@@ -39,7 +40,7 @@ def run_scan_plain(
 
     scmd = u'scancode'
     scan_cmd = os.path.join(scancode_root_dir, scmd)
-    rc, stdout, stderr = execute2(
+    rc, stdout, stderr = execute(
         cmd_loc=scan_cmd,
         args=options,
         cwd=cwd,
@@ -51,7 +52,7 @@ def run_scan_plain(
         time.sleep(1)
         if '--verbose' not in options:
             options.append('--verbose')
-        result = rc, stdout, stderr = execute2(
+        result = rc, stdout, stderr = execute(
             cmd_loc=scan_cmd,
             args=options,
             cwd=cwd,


### PR DESCRIPTION
This PR removes references to a few deprecated APIs
to avoid the corresponding deprecation warnings,
### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
