### PR TITLE
Also include setuptool_scm in dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,7 @@ requests==2.25.1
 rpm-inspector-rpm==4.16.1.3.210404
 saneyaml==0.5.2
 setuptools==57.0.0
+setuptools_scm==6.0.1
 six==1.16.0
 sortedcontainers==2.4.0
 soupsieve==2.2.1


### PR DESCRIPTION
Otherwise its is missing when building in some cases.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
