### PR TITLE
2594 report proper bazel rules

### DIFF
--- a/src/packagedcode/build.py
+++ b/src/packagedcode/build.py
@@ -83,6 +83,18 @@ starlark_rule_types = [
 ]
 
 
+def check_rule_name_ending(rule_name):
+    """
+    Return True if `rule_name` ends with a rule type from `starlark_rule_types`
+
+    Return False otherwise
+    """
+    for rule_type in starlark_rule_types:
+        if rule_name.endswith(rule_type):
+            return True
+    return False
+
+
 @attr.s()
 class StarlarkManifestPackage(BaseBuildManifestPackage):
     @classmethod
@@ -103,9 +115,12 @@ class StarlarkManifestPackage(BaseBuildManifestPackage):
                     or isinstance(statement, ast.Call)
                     or isinstance(statement, ast.Assign)
                     and isinstance(statement.value, ast.Call)
-                    and isinstance(statement.value.func, ast.Name)
-                    and statement.value.func.id.endswith(starlark_rule_types)):
+                    and isinstance(statement.value.func, ast.Name)):
                 rule_name = statement.value.func.id
+                # Ensure that we are only creating packages from the proper
+                # build rules
+                if not check_rule_name_ending(rule_name):
+                    continue
                 # Process the rule arguments
                 args = {}
                 for kw in statement.value.keywords:

--- a/tests/packagedcode/data/build/bazel/parse/BUILD
+++ b/tests/packagedcode/data/build/bazel/parse/BUILD
@@ -14,3 +14,10 @@ cc_binary(
         "//lib:hello-time",
     ],
 )
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)

--- a/tests/packagedcode/data/plugin/help.txt
+++ b/tests/packagedcode/data/plugin/help.txt
@@ -225,8 +225,8 @@ Package: pods
 --------------------------------------------
 Package: pubspec
   class: packagedcode.pubspec:PubspecPackage
-  metafiles: pubspec.yaml
-  extensions: .yaml
+  metafiles: pubspec.yaml, pubspec.lock
+  extensions: .yaml, .lock
 
 --------------------------------------------
 Package: pypi

--- a/tests/packagedcode/data/plugin/pubspec-lock-expected.json
+++ b/tests/packagedcode/data/plugin/pubspec-lock-expected.json
@@ -1,0 +1,28 @@
+{
+  "headers": [
+    {
+      "tool_name": "scancode-toolkit",
+      "options": {
+        "input": "<path>",
+        "--json": "<file>",
+        "--package": true,
+        "--processes": "-1",
+        "--strip-root": true
+      },
+      "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
+      "message": null,
+      "errors": [],
+      "extra_data": {
+        "files_count": 1
+      }
+    }
+  ],
+  "files": [
+    {
+      "path": "dart-pubspec.lock",
+      "type": "file",
+      "packages": [],
+      "scan_errors": []
+    }
+  ]
+}

--- a/tests/packagedcode/test_plugin.py
+++ b/tests/packagedcode/test_plugin.py
@@ -19,7 +19,7 @@ from scancode.cli_test_utils import run_scan_click
 class TestPlugins(PackageTester):
     test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
-    def test_package_list_command(self, regen=True):
+    def test_package_list_command(self, regen=False):
         expected_file = self.get_test_loc('plugin/help.txt')
         result = run_scan_click(['--list-packages'])
         if regen:
@@ -145,11 +145,11 @@ class TestPlugins(PackageTester):
         result_file = self.get_temp_file('json')
         expected_file = self.get_test_loc('plugin/pubspec-expected.json', must_exist=False)
         run_scan_click(['--package', '--strip-root', '--processes', '-1', test_dir, '--json', result_file])
-        check_json_scan(expected_file, result_file, regen=True)
+        check_json_scan(expected_file, result_file, regen=False)
 
     def test_package_command_scan_pubspec_lock_package(self):
         test_dir = self.get_test_loc('pubspec/locks/dart-pubspec.lock')
         result_file = self.get_temp_file('json')
         expected_file = self.get_test_loc('plugin/pubspec-lock-expected.json', must_exist=False)
         run_scan_click(['--package', '--strip-root', '--processes', '-1', test_dir, '--json', result_file])
-        check_json_scan(expected_file, result_file, regen=True)
+        check_json_scan(expected_file, result_file, regen=False)


### PR DESCRIPTION
This PR introduces a fix that prevents the bazel/buck parser from reporting all build rules, only limiting reporting to build rules that end with `binary` or `library`.

I've also set `regen=False` to the package cli tests as some of them were set to True.