### PR TITLE
Update debian package getter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,10 +31,8 @@ isodate==0.6.0
 jaraco.functools==3.3.0
 javaproperties==0.8.0
 Jinja2==3.0.1
-jsonlines==2.0.0
 jsonstreams==0.6.0
 license-expression==21.6.14
-Logbook==1.5.3
 lxml==4.6.3
 MarkupSafe==2.0.1
 more-itertools==8.8.0
@@ -61,7 +59,7 @@ pyparsing==2.4.7
 pytz==2021.1
 PyYAML==5.4.1
 rdflib==5.0.0
-regipy==1.9.3
+regipy==2.0.0
 requests==2.25.1
 rpm-inspector-rpm==4.16.1.3.210404
 saneyaml==0.5.2
@@ -69,10 +67,8 @@ six==1.16.0
 sortedcontainers==2.4.0
 soupsieve==2.2.1
 spdx-tools==0.6.1
-tabulate==0.8.9
 text-unidecode==1.3
 toml==0.10.2
-tqdm==4.61.2
 typecode==21.6.1
 typecode-libmagic==5.39.210531
 typing==3.6.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,7 +115,7 @@ full =
 # linux-only package handling
 packages =
     rpm_inspector_rpm >= 4.16.1.3; platform_system == 'Linux'
-    regipy >= 1.9.3; platform_system == 'Linux'
+    regipy >= 2.0.0; platform_system == 'Linux'
     packagedcode_msitools >= 0.101.210706; platform_system == 'Linux'
 
 dev =

--- a/src/packagedcode/debian.py
+++ b/src/packagedcode/debian.py
@@ -163,38 +163,44 @@ def get_installed_packages(root_dir, distro='debian', detect_licenses=False, **k
     """
 
     base_status_file_loc = os.path.join(root_dir, 'var/lib/dpkg/status')
-    if not os.path.exists(base_status_file_loc):
-        return
+    base_statusd_loc = os.path.join(root_dir, 'var/lib/dpkg/status.d/')
 
-    var_lib_dpkg_info_dir = os.path.join(root_dir, 'var/lib/dpkg/info/')
+    if os.path.exists(base_status_file_loc):
+        var_lib_dpkg_info_dir = os.path.join(root_dir, 'var/lib/dpkg/info/')
 
-    # guard from recursive import
-    from packagedcode import debian_copyright
+        # guard from recursive import
+        from packagedcode import debian_copyright
 
-    for package in parse_status_file(base_status_file_loc, distro=distro):
-        package.populate_installed_files(var_lib_dpkg_info_dir)
-        if detect_licenses:
-            copyright_location = package.get_copyright_file_path(root_dir)
-            dc = debian_copyright.parse_copyright_file(copyright_location)
-            if dc:
-                package.declared_license = dc.get_declared_license(
-                    filter_duplicates=True,
-                    skip_debian_packaging=True,
-                )
-                package.license_expression = dc.get_license_expression(
-                    skip_debian_packaging=True,
-                    simplify_licenses=True,
-                )
-                package.copyright = dc.get_copyright(
-                    skip_debian_packaging=True,
-                    unique_copyrights=True,
-                )
+        for package in parse_status_file(base_status_file_loc, distro=distro):
+            package.populate_installed_files(var_lib_dpkg_info_dir)
+            if detect_licenses:
+                copyright_location = package.get_copyright_file_path(root_dir)
+                dc = debian_copyright.parse_copyright_file(copyright_location)
+                if dc:
+                    package.declared_license = dc.get_declared_license(
+                        filter_duplicates=True,
+                        skip_debian_packaging=True,
+                    )
+                    package.license_expression = dc.get_license_expression(
+                        skip_debian_packaging=True,
+                        simplify_licenses=True,
+                    )
+                    package.copyright = dc.get_copyright(
+                        skip_debian_packaging=True,
+                        unique_copyrights=True,
+                    )
+            yield package
 
-        yield package
+    elif os.path.exists(base_statusd_loc):
+        for root, dirs, files in os.walk(base_statusd_loc):
+            for f in files:
+                status_file_loc = os.path.join(root, f)
+                for package in parse_status_file(status_file_loc, distro=distro):
+                    yield package
 
 
 def is_debian_status_file(location):
-    return filetype.is_file(location) and location.endswith('/status')
+    return filetype.is_file(location) #and location.endswith('/status')
 
 
 def parse_status_file(location, distro='debian'):

--- a/src/packagedcode/debian.py
+++ b/src/packagedcode/debian.py
@@ -199,19 +199,14 @@ def get_installed_packages(root_dir, distro='debian', detect_licenses=False, **k
                     yield package
 
 
-def is_debian_status_file(location):
-    return filetype.is_file(location) #and location.endswith('/status')
-
-
 def parse_status_file(location, distro='debian'):
     """
     Yield Debian Package objects from a dpkg `status` file or None.
     """
     if not os.path.exists(location):
         raise FileNotFoundError('[Errno 2] No such file or directory: {}'.format(repr(location)))
-    if not is_debian_status_file(location):
-        return
-
+    if not filetype.is_file(location):
+        raise Exception(f'Location is not a file: {location}')
     for debian_pkg_data in debcon.get_paragraphs_data_from_file(location):
         yield build_package(debian_pkg_data, distro)
 


### PR DESCRIPTION
The Debian package getter has been updated to report detected packages from individual Debian status files in the `/var/lib/dpkg/status.d/` directory if `/var/lib/dpkg/status` does not exist. This helps in the case of some distroless images, where `/var/lib/dpkg/status` does not exist, but there are individual status files for packages in the `/var/lib/dpkg/status.d/` directory.