### PR TITLE
Bump regipy version to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,10 +31,8 @@ isodate==0.6.0
 jaraco.functools==3.3.0
 javaproperties==0.8.0
 Jinja2==3.0.1
-jsonlines==2.0.0
 jsonstreams==0.6.0
 license-expression==21.6.14
-Logbook==1.5.3
 lxml==4.6.3
 MarkupSafe==2.0.1
 more-itertools==8.8.0
@@ -61,7 +59,7 @@ pyparsing==2.4.7
 pytz==2021.1
 PyYAML==5.4.1
 rdflib==5.0.0
-regipy==1.9.3
+regipy==2.0.0
 requests==2.25.1
 rpm-inspector-rpm==4.16.1.3.210404
 saneyaml==0.5.2
@@ -69,10 +67,8 @@ six==1.16.0
 sortedcontainers==2.4.0
 soupsieve==2.2.1
 spdx-tools==0.6.1
-tabulate==0.8.9
 text-unidecode==1.3
 toml==0.10.2
-tqdm==4.61.2
 typecode==21.6.1
 typecode-libmagic==5.39.210531
 typing==3.6.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,7 +115,7 @@ full =
 # linux-only package handling
 packages =
     rpm_inspector_rpm >= 4.16.1.3; platform_system == 'Linux'
-    regipy >= 1.9.3; platform_system == 'Linux'
+    regipy >= 2.0.0; platform_system == 'Linux'
     packagedcode_msitools >= 0.101.210706; platform_system == 'Linux'
 
 dev =


### PR DESCRIPTION
This PR bumps the required version of regipy as well as some of its dependencies in base.txt