### PR TITLE
Add referenced_filenames as a resource attribute

### DIFF
--- a/src/licensedcode/plugin_license.py
+++ b/src/licensedcode/plugin_license.py
@@ -43,6 +43,7 @@ class LicenseScanner(ScanPlugin):
         ('licenses', attr.ib(default=attr.Factory(list))),
         ('license_expressions', attr.ib(default=attr.Factory(list))),
         ('percentage_of_license_text', attr.ib(default=0)),
+        ('referenced_filenames', attr.ib(default=attr.Factory(list))),
     ])
 
     sort_order = 2

--- a/src/scancode/api.py
+++ b/src/scancode/api.py
@@ -171,6 +171,7 @@ def get_licenses(location, min_score=0,
 
     detected_licenses = []
     detected_expressions = []
+    ref_filenames=[]
 
     matches = idx.match(
         location=location, min_score=min_score, deadline=deadline, **kwargs
@@ -180,6 +181,10 @@ def get_licenses(location, min_score=0,
     match = None
     for match in matches:
         qspans.append(match.qspan)
+
+        ref_files = match.rule.referenced_filenames
+        if len(ref_files)!=0:
+            ref_filenames.extend(ref_files)
 
         detected_expressions.append(match.rule.license_expression)
 
@@ -204,6 +209,7 @@ def get_licenses(location, min_score=0,
         ('license_expressions', detected_expressions),
         ('spdx_license_expressions', detected_spdx_expressions),
         ('percentage_of_license_text', percentage_of_license_text),
+        ('referenced_filenames', ref_filenames),
     ])
 
 


### PR DESCRIPTION
Signed-off-by: akugarg <akanksha.garg2k@gmail.com>
This PR adds on an extra resource attribute "referenced_filenames" which should be returned by API function
See more at https://github.com/nexB/scancode-toolkit/pull/2616#discussion_r684384317

Fixes #0000

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
