### PR TITLE
Add "--no-check-version" CLI option to scancode

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -92,3 +92,4 @@ The following organizations or individuals have contributed to ScanCode:
 - Yash D. Saraf @yashdsaraf
 - Yash Nisar @yash-nisar
 - Yash Sharma @yasharmaster
+- Yunus Rahbar @yns88

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -326,6 +326,14 @@ def validate_depth(ctx, param, value):
          'are stored. (By default temporary files are deleted when a scan is '
          'completed.)',
     help_group=cliutils.MISC_GROUP, sort_order=1000, cls=PluggableCommandLineOption)
+
+@click.option(
+    "--check-version/--no-check-version",
+    help="Whether to check for new versions. Defaults to true.",
+    default=True,
+    # not yet supported in Click 6.7 but added in PluggableCommandLineOption
+    hidden=True,
+    help_group=cliutils.MISC_GROUP, sort_order=1000, cls=PluggableCommandLineOption)
 def scancode(
     ctx,
     input,  # NOQA
@@ -343,6 +351,7 @@ def scancode(
     test_slow_mode,
     test_error_mode,
     keep_temp_files,
+    check_version,
     echo_func=echo_stderr,
     *args,
     **kwargs,
@@ -454,10 +463,11 @@ def scancode(
         )
 
         # check for updates
-        from scancode.outdated import check_scancode_version
-        outdated = check_scancode_version()
-        if not quiet and outdated:
-            echo_stderr(outdated, fg='yellow')
+        if check_version:
+            from scancode.outdated import check_scancode_version
+            outdated = check_scancode_version()
+            if not quiet and outdated:
+                echo_stderr(outdated, fg='yellow')
 
     except click.UsageError as e:
         # this will exit


### PR DESCRIPTION
This version check causes problems when running in a firewalled environment (in my case, hanging for 30 seconds before timing out). This just adds a CLI option to skip it entirely.

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
