### PR TITLE
Detect only mit license, not boost #2675

### DIFF
--- a/src/licensedcode/data/rules/mit_1056.RULE
+++ b/src/licensedcode/data/rules/mit_1056.RULE
@@ -1,0 +1,1 @@
+Distributed under the MIT License (MIT)

--- a/src/licensedcode/data/rules/mit_1056.yml
+++ b/src/licensedcode/data/rules/mit_1056.yml
@@ -1,0 +1,4 @@
+license_expression: mit
+is_license_notice: yes
+relevance: 100
+notes: https://github.com/nexB/scancode-toolkit/issues/2675

--- a/src/licensedcode/data/rules/mit_1057.RULE
+++ b/src/licensedcode/data/rules/mit_1057.RULE
@@ -1,0 +1,2 @@
+Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+or copy at http://opensource.org/licenses/MIT)

--- a/src/licensedcode/data/rules/mit_1057.yml
+++ b/src/licensedcode/data/rules/mit_1057.yml
@@ -1,0 +1,9 @@
+license_expression: mit
+is_license_notice: yes
+relevance: 100
+referenced_filenames:
+    - LICENSE.txt
+notes: https://github.com/nexB/scancode-toolkit/issues/2675
+ignorable_urls:
+  - http://opensource.org/licenses/MIT
+

--- a/tests/licensedcode/data/datadriven/lic4/2675-sqlite.cpp
+++ b/tests/licensedcode/data/datadriven/lic4/2675-sqlite.cpp
@@ -1,0 +1,11 @@
+/**
+ * @file    Exception.cpp
+ * @ingroup SQLiteCpp
+ * @brief   Encapsulation of the error message from SQLite3 on a std::runtime_error.
+ *
+ * Copyright (c) 2012-2020 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+ * or copy at http://opensource.org/licenses/MIT)
+ */
+#include <SQLiteCpp/Exception.h>

--- a/tests/licensedcode/data/datadriven/lic4/2675-sqlite.cpp.yml
+++ b/tests/licensedcode/data/datadriven/lic4/2675-sqlite.cpp.yml
@@ -1,0 +1,3 @@
+license_expressions:
+    - mit
+


### PR DESCRIPTION
This PR corrects #2675

Reported-by: Henrik Sandklef @hesa
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>