### PR TITLE
rules with "unqualified" license names are references, not notices

### DIFF
--- a/src/licensedcode/data/rules/agpl-3.0-plus_105.yml
+++ b/src/licensedcode/data/rules/agpl-3.0-plus_105.yml
@@ -1,3 +1,3 @@
 license_expression: agpl-3.0-plus
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/apache-2.0_136.yml
+++ b/src/licensedcode/data/rules/apache-2.0_136.yml
@@ -1,5 +1,5 @@
 license_expression: apache-2.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - http://www.apache.org/licenses/LICENSE-2.0.txt
+  - http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/src/licensedcode/data/rules/apache-2.0_170.yml
+++ b/src/licensedcode/data/rules/apache-2.0_170.yml
@@ -1,5 +1,5 @@
 license_expression: apache-2.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - http://www.apache.org/licenses/
+  - http://www.apache.org/licenses/

--- a/src/licensedcode/data/rules/apache-2.0_175.yml
+++ b/src/licensedcode/data/rules/apache-2.0_175.yml
@@ -1,3 +1,3 @@
 license_expression: apache-2.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/apache-2.0_176.yml
+++ b/src/licensedcode/data/rules/apache-2.0_176.yml
@@ -1,3 +1,3 @@
 license_expression: apache-2.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/apache-2.0_417.yml
+++ b/src/licensedcode/data/rules/apache-2.0_417.yml
@@ -1,3 +1,3 @@
 license_expression: apache-2.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 90

--- a/src/licensedcode/data/rules/apache-2.0_767.yml
+++ b/src/licensedcode/data/rules/apache-2.0_767.yml
@@ -1,5 +1,5 @@
 license_expression: apache-2.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - https://www.apache.org/licenses/
+  - https://www.apache.org/licenses/

--- a/src/licensedcode/data/rules/apache-2.0_893.yml
+++ b/src/licensedcode/data/rules/apache-2.0_893.yml
@@ -1,5 +1,5 @@
 license_expression: apache-2.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - https://www.apache.org/licenses/LICENSE-2.0.txt
+  - https://www.apache.org/licenses/LICENSE-2.0.txt

--- a/src/licensedcode/data/rules/bitstream_3.yml
+++ b/src/licensedcode/data/rules/bitstream_3.yml
@@ -1,3 +1,3 @@
 license_expression: bitstream
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/bitstream_4.yml
+++ b/src/licensedcode/data/rules/bitstream_4.yml
@@ -1,3 +1,3 @@
 license_expression: bitstream
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/bitstream_5.yml
+++ b/src/licensedcode/data/rules/bitstream_5.yml
@@ -1,3 +1,3 @@
 license_expression: bitstream
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/bsd-2-clause-views_32.yml
+++ b/src/licensedcode/data/rules/bsd-2-clause-views_32.yml
@@ -1,5 +1,5 @@
 license_expression: bsd-2-clause-views
-is_license_notice: yes
+is_license_reference: yes
 relevance: 95
 ignorable_urls:
-    - http://www.freebsd.org/copyright/freebsd-license.html
+  - http://www.freebsd.org/copyright/freebsd-license.html

--- a/src/licensedcode/data/rules/bsd-2-clause-views_51.yml
+++ b/src/licensedcode/data/rules/bsd-2-clause-views_51.yml
@@ -1,5 +1,5 @@
 license_expression: bsd-2-clause-views
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - http://www.freebsd.org/copyright/freebsd-license.html
+  - http://www.freebsd.org/copyright/freebsd-license.html

--- a/src/licensedcode/data/rules/bsd-new_393.yml
+++ b/src/licensedcode/data/rules/bsd-new_393.yml
@@ -1,4 +1,4 @@
 license_expression: bsd-new
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 minimum_coverage: 100

--- a/src/licensedcode/data/rules/bsd-new_394.yml
+++ b/src/licensedcode/data/rules/bsd-new_394.yml
@@ -1,4 +1,4 @@
 license_expression: bsd-new
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 minimum_coverage: 100

--- a/src/licensedcode/data/rules/bsd-simplified_161.yml
+++ b/src/licensedcode/data/rules/bsd-simplified_161.yml
@@ -1,3 +1,3 @@
 license_expression: bsd-simplified
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/bsd-simplified_194.yml
+++ b/src/licensedcode/data/rules/bsd-simplified_194.yml
@@ -1,5 +1,5 @@
 license_expression: bsd-simplified
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - https://www.opensource.org/licenses/bsd-license.php
+  - https://www.opensource.org/licenses/bsd-license.php

--- a/src/licensedcode/data/rules/bsd-simplified_195.yml
+++ b/src/licensedcode/data/rules/bsd-simplified_195.yml
@@ -1,5 +1,5 @@
 license_expression: bsd-simplified
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - http://opensource.org/licenses/bsd-license.php
+  - http://opensource.org/licenses/bsd-license.php

--- a/src/licensedcode/data/rules/bsd-simplified_196.yml
+++ b/src/licensedcode/data/rules/bsd-simplified_196.yml
@@ -1,5 +1,5 @@
 license_expression: bsd-simplified
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - https://opensource.org/licenses/bsd-license.php
+  - https://opensource.org/licenses/bsd-license.php

--- a/src/licensedcode/data/rules/cc-by-nc-nd-3.0_licensebutton.yml
+++ b/src/licensedcode/data/rules/cc-by-nc-nd-3.0_licensebutton.yml
@@ -1,5 +1,5 @@
 license_expression: cc-by-nc-nd-3.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - https://licensebuttons.net/l/by-nc-nd/3.0
+  - https://licensebuttons.net/l/by-nc-nd/3.0

--- a/src/licensedcode/data/rules/cc-by-nc-nd-4.0_3.yml
+++ b/src/licensedcode/data/rules/cc-by-nc-nd-4.0_3.yml
@@ -1,3 +1,3 @@
 license_expression: cc-by-nc-nd-4.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/cc-by-nc-sa-3.0_licensebutton.yml
+++ b/src/licensedcode/data/rules/cc-by-nc-sa-3.0_licensebutton.yml
@@ -1,5 +1,5 @@
 license_expression: cc-by-nc-sa-3.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - https://licensebuttons.net/l/by-nc-sa/3.0
+  - https://licensebuttons.net/l/by-nc-sa/3.0

--- a/src/licensedcode/data/rules/cc-by-nc-sa-4.0_licensebutton.yml
+++ b/src/licensedcode/data/rules/cc-by-nc-sa-4.0_licensebutton.yml
@@ -1,5 +1,5 @@
 license_expression: cc-by-nc-sa-4.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - https://licensebuttons.net/l/by-nc-sa/4.0
+  - https://licensebuttons.net/l/by-nc-sa/4.0

--- a/src/licensedcode/data/rules/cc-by-sa-4.0_18.yml
+++ b/src/licensedcode/data/rules/cc-by-sa-4.0_18.yml
@@ -1,5 +1,5 @@
 license_expression: cc-by-sa-4.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - https://creativecommons.org/licenses/by-sa/4.0
+  - https://creativecommons.org/licenses/by-sa/4.0

--- a/src/licensedcode/data/rules/cc-by-sa-4.0_19.yml
+++ b/src/licensedcode/data/rules/cc-by-sa-4.0_19.yml
@@ -1,3 +1,3 @@
 license_expression: cc-by-sa-4.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/cc-by-sa-4.0_20.yml
+++ b/src/licensedcode/data/rules/cc-by-sa-4.0_20.yml
@@ -1,5 +1,5 @@
 license_expression: cc-by-sa-4.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - https://creativecommons.org/licenses/by-sa/4.0
+  - https://creativecommons.org/licenses/by-sa/4.0

--- a/src/licensedcode/data/rules/cmu-uc_7.yml
+++ b/src/licensedcode/data/rules/cmu-uc_7.yml
@@ -1,4 +1,4 @@
 license_expression: secret-labs-2011
-is_license_notice: yes
+is_license_reference: yes
 relevance: 99
 minimum_coverage: 90

--- a/src/licensedcode/data/rules/ecosrh-1.1_2.yml
+++ b/src/licensedcode/data/rules/ecosrh-1.1_2.yml
@@ -1,3 +1,3 @@
 license_expression: ecosrh-1.1
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/elastic-license-2018_4.yml
+++ b/src/licensedcode/data/rules/elastic-license-2018_4.yml
@@ -3,6 +3,4 @@ is_license_notice: yes
 relevance: 99
 notes: this could refer to the older elastic-license-2018
 referenced_filenames:
-    - ELASTIC-LICENSE.txt
-
-
+  - ELASTIC-LICENSE.txt

--- a/src/licensedcode/data/rules/gpl-2.0-plus_20.yml
+++ b/src/licensedcode/data/rules/gpl-2.0-plus_20.yml
@@ -1,3 +1,3 @@
 license_expression: gpl-2.0-plus
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/gpl-2.0_617_1.yml
+++ b/src/licensedcode/data/rules/gpl-2.0_617_1.yml
@@ -1,8 +1,9 @@
 license_expression: gpl-2.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 minimum_coverage: 100
-notes: At https://web.archive.org/web/20020809115410/ftp://prep.ai.mit.edu/pub/gnu/GPL the text
-    is a GPL 2.0 license text
+notes:
+  At https://web.archive.org/web/20020809115410/ftp://prep.ai.mit.edu/pub/gnu/GPL the text
+  is a GPL 2.0 license text
 ignorable_urls:
-    - ftp://prep.ai.mit.edu/pub/gnu/GPL
+  - ftp://prep.ai.mit.edu/pub/gnu/GPL

--- a/src/licensedcode/data/rules/gpl-2.0_666.yml
+++ b/src/licensedcode/data/rules/gpl-2.0_666.yml
@@ -1,3 +1,3 @@
 license_expression: gpl-2.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/gpl-3.0-plus_309.yml
+++ b/src/licensedcode/data/rules/gpl-3.0-plus_309.yml
@@ -1,3 +1,3 @@
 license_expression: gpl-3.0-plus
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/gpl-3.0-plus_77.yml
+++ b/src/licensedcode/data/rules/gpl-3.0-plus_77.yml
@@ -1,3 +1,3 @@
 license_expression: gpl-3.0-plus
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/gpl_234.yml
+++ b/src/licensedcode/data/rules/gpl_234.yml
@@ -1,3 +1,3 @@
 license_expression: gpl-1.0-plus
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/lgpl-2.0-plus_454.yml
+++ b/src/licensedcode/data/rules/lgpl-2.0-plus_454.yml
@@ -1,3 +1,3 @@
 license_expression: lgpl-2.0-plus
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/lgpl-2.0_71.yml
+++ b/src/licensedcode/data/rules/lgpl-2.0_71.yml
@@ -1,3 +1,3 @@
 license_expression: lgpl-2.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/lgpl-2.1-plus_162.yml
+++ b/src/licensedcode/data/rules/lgpl-2.1-plus_162.yml
@@ -1,3 +1,3 @@
 license_expression: lgpl-2.1-plus
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/lgpl-2.1-plus_286.yml
+++ b/src/licensedcode/data/rules/lgpl-2.1-plus_286.yml
@@ -1,4 +1,4 @@
 license_expression: lgpl-2.1-plus
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 notes: Seen in pacemaker HTML doc

--- a/src/licensedcode/data/rules/lgpl-2.1_162.yml
+++ b/src/licensedcode/data/rules/lgpl-2.1_162.yml
@@ -1,3 +1,3 @@
 license_expression: lgpl-2.1
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/lgpl-3.0-plus_186.yml
+++ b/src/licensedcode/data/rules/lgpl-3.0-plus_186.yml
@@ -1,3 +1,3 @@
 license_expression: lgpl-3.0-plus
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/lgpl-3.0_98.yml
+++ b/src/licensedcode/data/rules/lgpl-3.0_98.yml
@@ -1,3 +1,3 @@
 license_expression: lgpl-3.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/lgpl-3.0_99.yml
+++ b/src/licensedcode/data/rules/lgpl-3.0_99.yml
@@ -1,3 +1,3 @@
 license_expression: lgpl-3.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/mit_428.yml
+++ b/src/licensedcode/data/rules/mit_428.yml
@@ -1,5 +1,5 @@
 license_expression: mit
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - http://www.opensource.org/licenses/mit-license.php
+  - http://www.opensource.org/licenses/mit-license.php

--- a/src/licensedcode/data/rules/mit_429.yml
+++ b/src/licensedcode/data/rules/mit_429.yml
@@ -1,5 +1,5 @@
 license_expression: mit
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - https://www.opensource.org/licenses/mit-license.php
+  - https://www.opensource.org/licenses/mit-license.php

--- a/src/licensedcode/data/rules/mit_434.yml
+++ b/src/licensedcode/data/rules/mit_434.yml
@@ -1,5 +1,5 @@
 license_expression: mit
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - http://opensource.org/licenses/MIT
+  - http://opensource.org/licenses/MIT

--- a/src/licensedcode/data/rules/odbl-1.0_1.yml
+++ b/src/licensedcode/data/rules/odbl-1.0_1.yml
@@ -1,5 +1,5 @@
 license_expression: odbl-1.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - http://www.opendatacommons.org/licenses/odbl/
+  - http://www.opendatacommons.org/licenses/odbl/

--- a/src/licensedcode/data/rules/proprietary_greensock_3.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_3.yml
@@ -1,5 +1,5 @@
 license_expression: proprietary-license
-is_license_notice: yes
+is_license_reference: yes
 relevance: 90
 ignorable_urls:
-    - http://greensock.com/standard-license
+  - http://greensock.com/standard-license

--- a/src/licensedcode/data/rules/proprietary_greensock_8.yml
+++ b/src/licensedcode/data/rules/proprietary_greensock_8.yml
@@ -1,5 +1,5 @@
 license_expression: proprietary-license
-is_license_notice: yes
+is_license_reference: yes
 relevance: 90
 ignorable_urls:
-    - http://www.greensock.com/
+  - http://www.greensock.com/

--- a/src/licensedcode/data/rules/public-domain_or_apache-2.0_1.yml
+++ b/src/licensedcode/data/rules/public-domain_or_apache-2.0_1.yml
@@ -1,3 +1,3 @@
 license_expression: public-domain OR apache-2.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/redis-source-available-1.0_5.yml
+++ b/src/licensedcode/data/rules/redis-source-available-1.0_5.yml
@@ -1,3 +1,3 @@
 license_expression: redis-source-available-1.0
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100

--- a/src/licensedcode/data/rules/unlicense_25.yml
+++ b/src/licensedcode/data/rules/unlicense_25.yml
@@ -1,5 +1,5 @@
 license_expression: unlicense
-is_license_notice: yes
+is_license_reference: yes
 relevance: 100
 ignorable_urls:
-    - http://unlicense.org/
+  - http://unlicense.org/

--- a/tests/packagedcode/data/debian/copyright/debian-2019-11-15/main/g/glib2.0/stable_copyright-detailed.expected.yml
+++ b/tests/packagedcode/data/debian/copyright/debian-2019-11-15/main/g/glib2.0/stable_copyright-detailed.expected.yml
@@ -132,8 +132,8 @@ matches:
     identifier: apache-2.0_417.RULE
     license_expression: apache-2.0
     is_license_text: no
-    is_license_notice: yes
-    is_license_reference: no
+    is_license_notice: no
+    is_license_reference: yes
     is_license_tag: no
     is_license_intro: no
     matched_text: the Apache license
@@ -148,8 +148,8 @@ matches:
     identifier: apache-2.0_176.RULE
     license_expression: apache-2.0
     is_license_text: no
-    is_license_notice: yes
-    is_license_reference: no
+    is_license_notice: no
+    is_license_reference: yes
     is_license_tag: no
     is_license_intro: no
     matched_text: |

--- a/tests/packagedcode/test_debian_copyright.py
+++ b/tests/packagedcode/test_debian_copyright.py
@@ -26,7 +26,7 @@ from debian_inspector.copyright import CopyrightFilesParagraph
 def check_expected_parse_copyright_file(
     test_loc,
     expected_loc,
-    regen=False,
+    regen=True,
     simplified=False,
     _licensing=Licensing(),
 ):
@@ -156,7 +156,7 @@ def create_test_function(
     expected_loc,
     test_name,
     simplified=False,
-    regen=False,
+    regen=True,
 ):
     '''
     Return a test function closed on test arguments.
@@ -179,7 +179,7 @@ def create_test_function(
     return test_func
 
 
-def build_tests(test_dir, clazz, prefix='test_', regen=False):
+def build_tests(test_dir, clazz, prefix='test_', regen=True):
     '''
     Dynamically build test methods for each copyright file in `test_dir` and
     attach the test method to the `clazz` class.
@@ -211,7 +211,7 @@ build_tests(
     test_dir='debian/copyright/debian-2019-11-15',
     prefix='test_debian_parse_copyright_file_',
     clazz=TestDebianCopyrightLicenseDetection,
-    regen=False,
+    regen=True,
 )
 
 
@@ -224,7 +224,7 @@ build_tests(
     test_dir='debian/copyright/debian-slim-2021-04-07',
     prefix='test_debian_slim_parse_copyright_file_',
     clazz=TestDebianSlimCopyrightLicenseDetection,
-    regen=False,
+    regen=True,
 )
 
 
@@ -237,7 +237,7 @@ build_tests(
     test_dir='debian/copyright/debian-misc',
     prefix='test_debian_misc_parse_copyright_file_',
     clazz=TestDebianMiscCopyrightLicenseDetection,
-    regen=False,
+    regen=True,
 )
 
 
@@ -262,7 +262,7 @@ class TestEnhancedDebianCopyright(FileBasedTesting):
             test_loc=test_loc,
             expected_loc=expected_loc,
             simplified=True,
-            regen=False,
+            regen=True,
         )
 
     def test_is_paragraph_debian_packaging(self):

--- a/tests/packagedcode/test_debian_copyright.py
+++ b/tests/packagedcode/test_debian_copyright.py
@@ -26,7 +26,7 @@ from debian_inspector.copyright import CopyrightFilesParagraph
 def check_expected_parse_copyright_file(
     test_loc,
     expected_loc,
-    regen=True,
+    regen=False,
     simplified=False,
     _licensing=Licensing(),
 ):
@@ -156,7 +156,7 @@ def create_test_function(
     expected_loc,
     test_name,
     simplified=False,
-    regen=True,
+    regen=False,
 ):
     '''
     Return a test function closed on test arguments.
@@ -179,7 +179,7 @@ def create_test_function(
     return test_func
 
 
-def build_tests(test_dir, clazz, prefix='test_', regen=True):
+def build_tests(test_dir, clazz, prefix='test_', regen=False):
     '''
     Dynamically build test methods for each copyright file in `test_dir` and
     attach the test method to the `clazz` class.
@@ -211,7 +211,7 @@ build_tests(
     test_dir='debian/copyright/debian-2019-11-15',
     prefix='test_debian_parse_copyright_file_',
     clazz=TestDebianCopyrightLicenseDetection,
-    regen=True,
+    regen=False,
 )
 
 
@@ -224,7 +224,7 @@ build_tests(
     test_dir='debian/copyright/debian-slim-2021-04-07',
     prefix='test_debian_slim_parse_copyright_file_',
     clazz=TestDebianSlimCopyrightLicenseDetection,
-    regen=True,
+    regen=False,
 )
 
 
@@ -237,7 +237,7 @@ build_tests(
     test_dir='debian/copyright/debian-misc',
     prefix='test_debian_misc_parse_copyright_file_',
     clazz=TestDebianMiscCopyrightLicenseDetection,
-    regen=True,
+    regen=False,
 )
 
 
@@ -262,7 +262,7 @@ class TestEnhancedDebianCopyright(FileBasedTesting):
             test_loc=test_loc,
             expected_loc=expected_loc,
             simplified=True,
-            regen=True,
+            regen=False,
         )
 
     def test_is_paragraph_debian_packaging(self):

--- a/tests/summarycode/data/score/spdx_licenses-expected.json
+++ b/tests/summarycode/data/score/spdx_licenses-expected.json
@@ -12,7 +12,7 @@
         "--license-clarity-score": true
       },
       "notice": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.",
-      "output_format_version": "1.0.0",
+      "output_format_version": "2.0.0",
       "message": null,
       "errors": [],
       "extra_data": {
@@ -339,8 +339,8 @@
             ],
             "referenced_filenames": [],
             "is_license_text": false,
-            "is_license_notice": true,
-            "is_license_reference": false,
+            "is_license_notice": false,
+            "is_license_reference": true,
             "is_license_tag": false,
             "is_license_intro": false,
             "has_unknown": false,

--- a/tests/summarycode/test_score.py
+++ b/tests/summarycode/test_score.py
@@ -31,7 +31,7 @@ test_env = FileDrivenTesting()
 test_env.test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
 
-def make_test_function(test_name, test_dir, expected_file, regen=True):
+def make_test_function(test_name, test_dir, expected_file, regen=False):
     """
     Build and return a test function closing on tests arguments and the function
     name. Create only a single function for multiple tests (e.g. copyrights and
@@ -65,7 +65,7 @@ def make_test_function(test_name, test_dir, expected_file, regen=True):
     return closure_test_function, test_name
 
 
-def build_tests(test_base_dir, clazz, regen=True):
+def build_tests(test_base_dir, clazz, regen=False):
     """
     Dynamically build test methods from a sequence of CopyrightTest and attach
     these method to the clazz test class.
@@ -96,4 +96,4 @@ class TestLicenseScore(FileDrivenTesting):
     pass
 
 
-build_tests(test_base_dir='score', clazz=TestLicenseScore, regen=True)
+build_tests(test_base_dir='score', clazz=TestLicenseScore, regen=False)

--- a/tests/summarycode/test_score.py
+++ b/tests/summarycode/test_score.py
@@ -31,7 +31,7 @@ test_env = FileDrivenTesting()
 test_env.test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
 
-def make_test_function(test_name, test_dir, expected_file, regen=False):
+def make_test_function(test_name, test_dir, expected_file, regen=True):
     """
     Build and return a test function closing on tests arguments and the function
     name. Create only a single function for multiple tests (e.g. copyrights and
@@ -65,7 +65,7 @@ def make_test_function(test_name, test_dir, expected_file, regen=False):
     return closure_test_function, test_name
 
 
-def build_tests(test_base_dir, clazz, regen=False):
+def build_tests(test_base_dir, clazz, regen=True):
     """
     Dynamically build test methods from a sequence of CopyrightTest and attach
     these method to the clazz test class.
@@ -96,4 +96,4 @@ class TestLicenseScore(FileDrivenTesting):
     pass
 
 
-build_tests(test_base_dir='score', clazz=TestLicenseScore, regen=False)
+build_tests(test_base_dir='score', clazz=TestLicenseScore, regen=True)


### PR DESCRIPTION
This PR changes a number of rules with unqualified license names (such as `Apache 2.0 License`) to be classified as (the weaker) `reference` rather than (the stronger) `notice`.

To be precise, this PR changes the `is_license_notice` property to an `is_license_reference` property for the aforementioned rules.

I'm sure there are more occurrences like these. I just picked a few that I found. Also, I'm not entirely sure if this is the correct classification (please let know if you disagree). I am also not entirely sure if this will have any real impact (besides a more strict adherence to the nomenclature as described [here](https://github.com/nexB/scancode-toolkit/blob/98b579564b8afd789569e8bd3a64092311673143/src/licensedcode/models.py#L741-L763))

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->



<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
