### PR TITLE
Fix azure pipeline vmimage deprecations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,9 +93,9 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: mac1014
-          image_name: macos-10.14
-          python_versions: ['3.6', '3.7', '3.8', '3.9']
+          job_name: mac11
+          image_name: macOS-11
+          python_versions: ['3.7', '3.8', '3.9']
           python_architecture: x64
           test_suites:
               all: bin/pytest -n 2 -vvs tests/scancode/test_cli.py
@@ -123,9 +123,9 @@ jobs:
 
     - template: etc/ci/azure-win.yml
       parameters:
-          job_name: win2016
-          image_name: vs2017-win2016
-          python_versions: ['3.6', '3.7', '3.8', '3.9']
+          job_name: win2022
+          image_name: windows-2022
+          python_versions: ['3.7', '3.8', '3.9']
           python_architecture: x64
           test_suites:
               all: Scripts\pytest -n 2 -vvs tests\scancode\test_cli.py


### PR DESCRIPTION
`macos-10.14` and `vs2017-win2016` vm images are deprecated and
this replaces them with newer images.

See https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/

`macos-10.14` would be deprecated on December 10, 2021
`vs2017-win2016` would be deprecated on March 15, 2022

Signed-off-by: Ayan Sinha Mahapatra <ayansmahapatra@gmail.com>


### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

