### PR TITLE
Fixed inconsistency in --html-app FILE in cli-reference

### DIFF
--- a/docs/source/cli-reference/output-format.rst
+++ b/docs/source/cli-reference/output-format.rst
@@ -465,7 +465,7 @@ Comparing Different ``json`` Output Formats
     The following code performs a scan on the samples directory, and publishes the results in
     ``html-app`` format::
 
-        scancode -clpieu --csv output.html samples
+        scancode -clpieu --html-app output.html samples
 
     The Files scanned are shown in the left sidebar, and the section on the right contains separate
     tabs for the following:


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #2789

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Before
```scancode -clpieu --csv output.html samples```

### After
```scancode -clpieu --html-app output.html samples```

### Tasks


* [X] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [ ] Commits are in uniquely-named feature branch and has no merge conflicts 📁
It is a small documentation change, therefore I pushed it to the develop branch itself.
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
