### PR TITLE
Fixing OSI identifier for BSD-3-Clause; see also SPDX license metadata

### DIFF
--- a/src/licensedcode/data/licenses/bsd-new.yml
+++ b/src/licensedcode/data/licenses/bsd-new.yml
@@ -12,4 +12,4 @@ osi_url: http://www.opensource.org/licenses/BSD-3-Clause
 other_urls:
     - http://framework.zend.com/license/new-bsd
     - https://opensource.org/licenses/BSD-3-Clause
-osi_license_key: BSD-3
+osi_license_key: BSD-3-Clause


### PR DESCRIPTION
Just something rather minor. Perhaps a good example to learn how to contribute to Scancode-Toolkit. We found that linking to OSI using the BSD-3 as identifier does not work. The "official id" is BSD-3-Clause.

You may want to check out: 
https://opensource.org/licenses/BSD-3
https://opensource.org/licenses/BSD-3-Clause

Regards,
Karsten