### PR TITLE
Fix bug recognizing license as license_notice instead of license_text

### DIFF
--- a/src/licensedcode/data/rules/cc-by-4.0.SPDX.yml
+++ b/src/licensedcode/data/rules/cc-by-4.0.SPDX.yml
@@ -1,4 +1,4 @@
 license_expression: cc-by-4.0
-is_license_notice: yes
+is_license_text: yes
 minimum_coverage: 10
 notes: license text as published by SPDX


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #2807 

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->