### PR TITLE
Add key phrase tags to GPL detection rule

### DIFF
--- a/src/licensedcode/data/rules/gpl-2.0-plus_365.RULE
+++ b/src/licensedcode/data/rules/gpl-2.0-plus_365.RULE
@@ -1,7 +1,7 @@
 This program is free software; you can redistribute  it and/or modify it
 under  the terms of  the {{GNU General  Public License}} as published by the
 Free Software Foundation;  either {{version 2}} of the  License, or (at your
-option) {{any later version{{.
+option) {{any later version}}.
 
 THIS  SOFTWARE  IS PROVIDED   ``AS  IS'' AND   ANY  EXPRESS OR IMPLIED
 WARRANTIES,   INCLUDING, BUT NOT  LIMITED  TO, THE IMPLIED WARRANTIES OF

--- a/src/licensedcode/data/rules/gpl-2.0-plus_365.RULE
+++ b/src/licensedcode/data/rules/gpl-2.0-plus_365.RULE
@@ -1,7 +1,7 @@
 This program is free software; you can redistribute  it and/or modify it
-under  the terms of  the GNU General  Public License as published by the
-Free Software Foundation;  either version 2 of the  License, or (at your
-option) any later version.
+under  the terms of  the {{GNU General  Public License}} as published by the
+Free Software Foundation;  either {{version 2}} of the  License, or (at your
+option) {{any later version{{.
 
 THIS  SOFTWARE  IS PROVIDED   ``AS  IS'' AND   ANY  EXPRESS OR IMPLIED
 WARRANTIES,   INCLUDING, BUT NOT  LIMITED  TO, THE IMPLIED WARRANTIES OF


### PR DESCRIPTION
This was otherwise detected in a BSD-like license
because this rule warranty disclaimer is not the 
standard one seen in a typical GPL notice

Reference: https://github.com/nexB/scancode-toolkit/issues/2820
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>
