### PR TITLE
Detect SPDX-FileContributor tags as authors

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -639,6 +639,9 @@ patterns = [
     # SPDX-FileCopyrightText as defined by the FSFE Reuse project
     (r'^[Ss][Pp][Dd][Xx]-[Ff]ile[Cc]opyright[Tt]ext', 'COPY'),
 
+    # SPDX-FileContributor as defined in SPDX and seen used in KDE
+    (r'^[Ss][Pp][Dd][Xx]-[Ff]ile[Cc]ontributor', 'SPDX-CONTRIB'),
+
     ############################################################################
     # ALL Rights Reserved.
     ############################################################################
@@ -2566,6 +2569,9 @@ grammar = """
 # Authors
 #######################################
 
+    # SPDX-FileContributor special case
+    AUTHOR: {<SPDX-CONTRIB> <CCOMPANY|NAME|NAME-EMAIL|NAME-YEAR|EMAIL> <COMPANY|NAME|NAME-EMAIL|NAME-YEAR|EMAIL|NN>? }        #264000
+
     # developed by Project Mayo.
     AUTHOR: {<AUTH2>+ <BY> <COMPANY> <NNP>}        #2645-1
 
@@ -2923,6 +2929,7 @@ AUTHORS_PREFIXES = frozenset(set.union(
         'authors,',
         'authorship',
         'or',
+        'spdx-filecontributor',
     ])
 ))
 

--- a/src/cluecode/copyrights_hint.py
+++ b/src/cluecode/copyrights_hint.py
@@ -61,7 +61,7 @@ statement_markers = (
     'right',
     'reserv',
     'auth',
-    'contributor',
+    'filecontributor',
     'devel',
     '<s>',
     '</s>',

--- a/src/cluecode/copyrights_hint.py
+++ b/src/cluecode/copyrights_hint.py
@@ -61,6 +61,7 @@ statement_markers = (
     'right',
     'reserv',
     'auth',
+    'contributor',
     'devel',
     '<s>',
     '</s>',

--- a/tests/cluecode/data/copyrights/spdx-copy-contrib.txt
+++ b/tests/cluecode/data/copyrights/spdx-copy-contrib.txt
@@ -1,0 +1,4 @@
+ * SPDX-FileCopyrightText: 2008 Red Hat Inc.
+ * SPDX-FileContributor: Adam Jackson <ajax@redhat.com>
+ * SPDX-FileContributor: Bill Nottingham <notting@redhat.com>
+ * SPDX-FileContributor: Ray Strode <rstrode@redhat.com>

--- a/tests/cluecode/data/copyrights/spdx-copy-contrib.txt.yml
+++ b/tests/cluecode/data/copyrights/spdx-copy-contrib.txt.yml
@@ -1,0 +1,14 @@
+what:
+  - copyrights
+  - holders
+  - authors
+
+copyrights:
+    - Copyright 2008 Red Hat Inc.
+holders:
+    - Red Hat Inc.
+authors:
+    - Adam Jackson <ajax@redhat.com>
+    - Bill Nottingham <notting@redhat.com>
+    - Ray Strode <rstrode@redhat.com>
+


### PR DESCRIPTION
This is SPDX but not reuse compliant
but frequent enough per:
https://github.com/search?q="SPDX-FileContributor"&type=code

See https://github.com/nexB/scancode-toolkit/issues/1816

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
