### PR TITLE
Make --version output valid YAML for parsing #2856

### DIFF
--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -93,9 +93,9 @@ def print_examples(ctx, param, value):
 def print_version(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    click.echo('ScanCode version ' + scancode_config.__version__)
-    click.echo('ScanCode Output Format version ' + scancode_config.__output_format_version__)
-    click.echo('SPDX License list version ' + scancode_config.spdx_license_list_version)
+    click.echo(f'ScanCode version: {scancode_config.__version__}')
+    click.echo(f'ScanCode Output Format version: {scancode_config.__output_format_version__}')
+    click.echo(f'SPDX License list version: {scancode_config.spdx_license_list_version}')
     ctx.exit()
 
 

--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -929,3 +929,14 @@ def test_VirtualCodebase_output_with_from_json_is_same_as_original():
 
     assert json.dumps(results , indent=2) == json.dumps(expected, indent=2)
     assert len(results_headers) == len(expected_headers) + 1
+
+def test_getting_version_returns_valid_yaml():
+    import saneyaml
+    import scancode_config
+    args = ['--version']
+    result = run_scan_click(args)
+    assert saneyaml.load(result.output) == {
+        'ScanCode version': f'{scancode_config.__version__}',
+        'ScanCode Output Format version': f'{scancode_config.__output_format_version__}',
+        'SPDX License list version': f'{scancode_config.spdx_license_list_version}'
+    }


### PR DESCRIPTION
This commit adds a colon so instead of getting

```
$ ./scancode --version
ScanCode version 30.1.0
ScanCode Output Format version 2.0.0
SPDX License list version 3.15
```
we get
```
$ ./scancode --version
ScanCode version: 30.1.0
ScanCode Output Format version: 2.0.0
SPDX License list version: 3.15
```

This will make the output easier to parse since it is valid YAML now. Fixes #2856 
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->


<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
