### PR TITLE
Fixed Typo in Documentation

### DIFF
--- a/docs/source/getting-started/newcomer.rst
+++ b/docs/source/getting-started/newcomer.rst
@@ -101,7 +101,7 @@ Before you start using Scancode
 
 .. note::
 
-    For Windows, Refer to :ref:`_windows_app_install` for installing easily using Releases.
+    For Windows, Refer to :ref:`windows_app_install` for installing easily using Releases.
 
 .. _newcomer_scan_codebase:
 


### PR DESCRIPTION
Signed-off-by: OsmiumOP <harshbansal.contact@gmail.com>

Fixes a little typo in the Documentation. A separate issue wasn't opened as it was pretty much straight forward. 

Problem at Page - https://scancode-toolkit.readthedocs.io/en/latest/getting-started/newcomer.html#before-you-start-using-scancode

![image](https://user-images.githubusercontent.com/71386574/153474783-2ad9cc92-333d-4eec-85d5-b06e577051b6.png)

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!-- Don't forget to Signoff -->
