### PR TITLE
devcontainer: Base python 3.10.2 devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        gnupg2 \
+        openssh-client \
+        php7.4 \
+    && curl -JLO 'https://apt.puppet.com/puppet-tools-release-bullseye.deb' \
+    && dpkg -i puppet-tools-release-bullseye.deb \
+    && rm puppet-tools-release-bullseye.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        pdk \
+    && rm -rf /var/lib/apt/lists/*
+
+# Run with non privileged user
+RUN groupadd --gid 1000 user \
+    && useradd --uid 1000 --gid user --shell /bin/bash --home-dir /workspace --create-home user

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,20 +1,59 @@
-FROM python:3-slim
+ARG PYTHON_VERSION="3.10"
+FROM python:${PYTHON_VERSION}-slim
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        coreutils \
         curl \
+        dialog \
+        dirmngr \
+        gcc \
         git \
         gnupg2 \
+        iproute2 \
+        libssl1.1 \
+        libxml2-dev \
+        libxslt-dev \
         openssh-client \
-        php7.4 \
-    && curl -JLO 'https://apt.puppet.com/puppet-tools-release-bullseye.deb' \
-    && dpkg -i puppet-tools-release-bullseye.deb \
-    && rm puppet-tools-release-bullseye.deb \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        pdk \
+        procps \
+        psmisc \
+        rsync \
+        sudo \
+        unzip \
+        wget \
+        zip \
+        zlib1g \
+        libz-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Install common python tools for development
+RUN pip install \
+        autopep8 \
+        black \
+        flake8 \
+        mypy \
+        poetry \
+        pre-commit \
+        pylint
+
+ARG USERNAME=vscode
+ARG USER_ID=1000
+ARG USER_GID=$USER_ID
+
 # Run with non privileged user
-RUN groupadd --gid 1000 user \
-    && useradd --uid 1000 --gid user --shell /bin/bash --home-dir /workspace --create-home user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd \
+        --uid $USER_ID \
+        --gid $USER_GID \
+        --shell /bin/bash \
+        --create-home $USERNAME
+
+# sudo support
+RUN echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+ENV CONFIGURE_SUPPORTED_PYTHON=${PYTHON_VERSION}
+
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,30 +2,30 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.112.0/containers/python-3
 {
 	"name": "ScanCode-Toolkit",
-
 	"build": {
 		"dockerfile": "Dockerfile",
 	},
-
 	"settings": {
 		"puppet.installType": "pdk",
+		"python.pythonPath": "/usr/local/bin/python",
+		"python.languageServer": "Pylance",
+		"python.linting.enabled": true,
+		"python.formatting.provider": "black",
+		"python.unitTest.pyTestEnabled": true,
+		"editor.formatOnSave": true,
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-python.python",
-        "ms-python.vscode-pylance",
-        "shardulm94.trailing-spaces",
-        "formulahendry.code-runner",
-        "aaron-bond.better-comments",
-        "eamodio.gitlens",
+		"ms-python.vscode-pylance",
+		"shardulm94.trailing-spaces",
+		"formulahendry.code-runner",
+		"aaron-bond.better-comments",
+		"eamodio.gitlens",
 		"wholroyd.jinja",
-		"xdebug.php-pack",
-		"puppet.puppet-vscode",
+		// "xdebug.php-pack",
+		// "puppet.puppet-vscode",
 	],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install poetry pylint flake8 mypy autopep8 black pre-commit",
-
-    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "user"
+	// "postCreateCommand": "./configure --dev",
+	"postStartCommand": "pip install -r requirements.txt -r requirements-dev.txt"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.112.0/containers/python-3
+{
+	"name": "ScanCode-Toolkit",
+
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
+
+	"settings": {
+		"puppet.installType": "pdk",
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+        "ms-python.vscode-pylance",
+        "shardulm94.trailing-spaces",
+        "formulahendry.code-runner",
+        "aaron-bond.better-comments",
+        "eamodio.gitlens",
+		"wholroyd.jinja",
+		"xdebug.php-pack",
+		"puppet.puppet-vscode",
+	],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pip install poetry pylint flake8 mypy autopep8 black pre-commit",
+
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "user"
+}


### PR DESCRIPTION
Use VSCode devcontainer infrastructure to allow remote or containerized
development to avoid install multiple depenencies on host machine

Installed:
- python 3.10.2 ( base official Docker image on debian Bullseye )

Signed-off-by: Helio Chissini de Castro <helio@kde.org>

