### PR TITLE
Add basic XML output plugin

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,6 +17,7 @@ The following organizations or individuals have contributed to ScanCode:
 - Ayush Jain @aj4ayushjain
 - Bruno Oliveira @nicoddemus
 - Carmen Bianca Bakker @carmenbianca
+- Chaitanya Gadgil @chaitanya710
 - Chaitya Shah @Chaitya62
 - Chin-Yeung Li @chinyeungli
 - Clement Poulain @FOSS117

--- a/setup.cfg
+++ b/setup.cfg
@@ -207,6 +207,7 @@ scancode_output =
     html = formattedcode.output_html:HtmlOutput
     html-app = formattedcode.output_html:HtmlAppOutput
     json = formattedcode.output_json:JsonCompactOutput
+    xml = formattedcode.output_xml:XmlOutput
     json-pp = formattedcode.output_json:JsonPrettyOutput
     spdx-tv = formattedcode.output_spdx:SpdxTvOutput
     spdx-rdf = formattedcode.output_spdx:SpdxRdfOutput

--- a/src/formattedcode/output_xml.py
+++ b/src/formattedcode/output_xml.py
@@ -1,0 +1,53 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# ScanCode is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/scancode-toolkit for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+from json2xml import json2xml
+from json2xml.utils import readfromjson
+from formattedcode import FileOptionType
+from formattedcode import output_json
+from commoncode.cliutils import PluggableCommandLineOption
+from commoncode.cliutils import OUTPUT_GROUP
+from plugincode.output import output_impl
+from plugincode.output import OutputPlugin
+
+"""
+Output plugin to write scan results as XML.
+"""
+
+@output_impl
+class XmlOutput(OutputPlugin):
+
+    options = [
+        PluggableCommandLineOption(('--xml', 'output_xml',),
+            type=FileOptionType(mode='w', encoding='utf-8', lazy=True),
+            metavar='FILE',
+            help='Write scan output as XML to FILE.',
+            help_group=OUTPUT_GROUP,
+            sort_order=20
+        ),
+    ]
+
+    def is_enabled(self, output_xml, **kwargs):
+        return output_xml
+
+    def process_codebase(self, codebase, output_xml, **kwargs):
+        results = output_json.get_results(codebase, as_list=True, **kwargs)
+        write_xml(results, output_file=output_xml, pretty=False)
+
+def write_xml(results, output_file, **kwargs):
+    """
+    Write `results` to the `output_file` opened file-like object.
+    """
+    data = readfromjson(results)
+   # print(json2xml.Json2xml(data).to_xml())
+    output_file.write(json2xml.Json2xml(data).to_xml())
+    output_file.write('\n')
+
+
+    

--- a/src/formattedcode/output_xml.py
+++ b/src/formattedcode/output_xml.py
@@ -6,9 +6,10 @@
 # See https://github.com/nexB/scancode-toolkit for support or download.
 # See https://aboutcode.org for more information about nexB OSS projects.
 #
+import json 
 
 from json2xml import json2xml
-from json2xml.utils import readfromjson
+from json2xml.utils import readfromstring
 from formattedcode import FileOptionType
 from formattedcode import output_json
 from commoncode.cliutils import PluggableCommandLineOption
@@ -38,14 +39,14 @@ class XmlOutput(OutputPlugin):
 
     def process_codebase(self, codebase, output_xml, **kwargs):
         results = output_json.get_results(codebase, as_list=True, **kwargs)
-        write_xml(results, output_file=output_xml, pretty=False)
+        results = json.dumps(results)
+        write_xml(results, output_file=output_xml, pretty=True)
 
 def write_xml(results, output_file, **kwargs):
     """
     Write `results` to the `output_file` opened file-like object.
     """
-    data = readfromjson(results)
-   # print(json2xml.Json2xml(data).to_xml())
+    data = readfromstring(results)
     output_file.write(json2xml.Json2xml(data).to_xml())
     output_file.write('\n')
 

--- a/tests/formattedcode/data/xml/simple-expected.xml
+++ b/tests/formattedcode/data/xml/simple-expected.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" ?>
+<all>
+        <headers type="list">
+                <item type="dict">
+                        <tool_name type="str">scancode-toolkit</tool_name>
+                        <tool_version type="str">31.0.0b1</tool_version>
+                        <options type="dict">
+                                <input type="str">&lt;path&gt;</input>
+                                <key name="--copyright" type="bool">True</key>
+                                <key name="--info" type="bool">True</key>
+                                <key name="--license" type="bool">True</key>
+                                <key name="--package" type="bool">True</key>
+                                <key name="--xml" type="str">&lt;file&gt;</key>
+                        </options>
+                        <notice type="str">Generated with ScanCode and provided on an "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+ScanCode should be considered or used as legal advice. Consult an Attorney
+for any legal advice.
+ScanCode is a free software code scanning tool from nexB Inc. and others.
+Visit https://github.com/nexB/scancode-toolkit/ for support and download.</notice>
+                        <start_timestamp type="str">2022-04-01T085345.355248</start_timestamp>
+                        <end_timestamp type="str">2022-04-01T085345.607427</end_timestamp>
+                        <output_format_version type="str">2.0.0</output_format_version>
+                        <duration type="float">0.2521989345550537</duration>
+                        <message type="null"/>
+                        <errors type="list"/>
+                        <extra_data type="dict">
+                                <spdx_license_list_version type="str">3.16</spdx_license_list_version>
+                                <files_count type="int">1</files_count>
+                        </extra_data>
+                </item>
+        </headers>
+        <dependencies type="list"/>
+        <packages type="list"/>
+        <files type="list">
+                <item type="dict">
+                        <path type="str">simple</path>
+                        <type type="str">directory</type>
+                        <name type="str">simple</name>
+                        <base_name type="str">simple</base_name>
+                        <extension type="str"/>
+                        <size type="int">0</size>
+                        <date type="null"/>
+                        <sha1 type="null"/>
+                        <md5 type="null"/>
+                        <sha256 type="null"/>
+                        <mime_type type="null"/>
+                        <file_type type="null"/>
+                        <programming_language type="null"/>
+                        <is_binary type="bool">False</is_binary>
+                        <is_text type="bool">False</is_text>
+                        <is_archive type="bool">False</is_archive>
+                        <is_media type="bool">False</is_media>
+                        <is_source type="bool">False</is_source>
+                        <is_script type="bool">False</is_script>
+                        <licenses type="list"/>
+                        <license_expressions type="list"/>
+                        <percentage_of_license_text type="int">0</percentage_of_license_text>
+                        <copyrights type="list"/>
+                        <holders type="list"/>
+                        <authors type="list"/>
+                        <package_data type="list"/>
+                        <for_packages type="list"/>
+                        <files_count type="int">1</files_count>
+                        <dirs_count type="int">0</dirs_count>
+                        <size_count type="int">55</size_count>
+                        <scan_errors type="list"/>
+                </item>
+                <item type="dict">
+                        <path type="str">simple/copyright_acme_c-c.c</path>
+                        <type type="str">file</type>
+                        <name type="str">copyright_acme_c-c.c</name>
+                        <base_name type="str">copyright_acme_c-c</base_name>
+                        <extension type="str">.c</extension>
+                        <size type="int">55</size>
+                        <date type="str">2022-03-31</date>
+                        <sha1 type="str">e2466d5b764d27fb301ceb439ffb5da22e43ab1d</sha1>
+                        <md5 type="str">bdf7c572beb4094c2059508fa73c05a4</md5>
+                        <sha256 type="str">234d690ec9a5ac134e01847f34581b0ea83dfd1f3d4c79bee046297baa5f5925</sha256>
+                        <mime_type type="str">text/plain</mime_type>
+                        <file_type type="str">UTF-8 Unicode text, with no line terminators</file_type>
+                        <programming_language type="str">C</programming_language>
+                        <is_binary type="bool">False</is_binary>
+                        <is_text type="bool">True</is_text>
+                        <is_archive type="bool">False</is_archive>
+                        <is_media type="bool">False</is_media>
+                        <is_source type="bool">True</is_source>
+                        <is_script type="bool">False</is_script>
+                        <licenses type="list"/>
+                        <license_expressions type="list"/>
+                        <percentage_of_license_text type="int">0</percentage_of_license_text>
+                        <copyrights type="list">
+                                <item type="dict">
+                                        <copyright type="str">Copyright (c) 2000 ACME, Inc.</copyright>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </copyrights>
+                        <holders type="list">
+                                <item type="dict">
+                                        <holder type="str">ACME, Inc.</holder>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </holders>
+                        <authors type="list"/>
+                        <package_data type="list"/>
+                        <for_packages type="list"/>
+                        <files_count type="int">0</files_count>
+                        <dirs_count type="int">0</dirs_count>
+                        <size_count type="int">0</size_count>
+                        <scan_errors type="list"/>
+                </item>
+        </files>
+</all>

--- a/tests/formattedcode/data/xml/simple/copyright_acme_c-c.c
+++ b/tests/formattedcode/data/xml/simple/copyright_acme_c-c.c
@@ -1,0 +1,1 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */

--- a/tests/formattedcode/data/xml/tree/expected.xml
+++ b/tests/formattedcode/data/xml/tree/expected.xml
@@ -1,0 +1,386 @@
+<?xml version="1.0" ?>
+<all>
+        <headers type="list">
+                <item type="dict">
+                        <tool_name type="str">scancode-toolkit</tool_name>
+                        <tool_version type="str">31.0.0b1</tool_version>
+                        <options type="dict">
+                                <input type="str">&lt;path&gt;</input>
+                                <key name="--copyright" type="bool">True</key>
+                                <key name="--info" type="bool">True</key>
+                                <key name="--license" type="bool">True</key>
+                                <key name="--package" type="bool">True</key>
+                                <key name="--strip-root" type="bool">True</key>
+                                <key name="--xml" type="str">&lt;file&gt;</key>
+                        </options>
+                        <notice type="str">Generated with ScanCode and provided on an &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied. No content created from
+ScanCode should be considered or used as legal advice. Consult an Attorney
+for any legal advice.
+ScanCode is a free software code scanning tool from nexB Inc. and others.
+Visit https://github.com/nexB/scancode-toolkit/ for support and download.</notice>
+                        <start_timestamp type="str">2022-04-01T104718.217774</start_timestamp>
+                        <end_timestamp type="str">2022-04-01T104718.601146</end_timestamp>
+                        <output_format_version type="str">2.0.0</output_format_version>
+                        <duration type="float">0.3833925724029541</duration>
+                        <message type="null"/>
+                        <errors type="list"/>
+                        <extra_data type="dict">
+                                <spdx_license_list_version type="str">3.16</spdx_license_list_version>
+                                <files_count type="int">7</files_count>
+                        </extra_data>
+                </item>
+        </headers>
+        <dependencies type="list"/>
+        <packages type="list"/>
+        <files type="list">
+                <item type="dict">
+                        <path type="str">copy1.c</path>
+                        <type type="str">file</type>
+                        <name type="str">copy1.c</name>
+                        <base_name type="str">copy1</base_name>
+                        <extension type="str">.c</extension>
+                        <size type="int">91</size>
+                        <date type="str">2022-03-31</date>
+                        <sha1 type="str">3922760d8492eb8f853c10a627f5a73f9eaec6ff</sha1>
+                        <md5 type="str">fc7f53659b7a9db8b6dff0638641778e</md5>
+                        <sha256 type="str">23fe3ce8ad18772ea688a435bb624d65e08fdee1d31b9f620a1ba62619c0f201</sha256>
+                        <mime_type type="str">text/plain</mime_type>
+                        <file_type type="str">UTF-8 Unicode text</file_type>
+                        <programming_language type="str">C</programming_language>
+                        <is_binary type="bool">False</is_binary>
+                        <is_text type="bool">True</is_text>
+                        <is_archive type="bool">False</is_archive>
+                        <is_media type="bool">False</is_media>
+                        <is_source type="bool">True</is_source>
+                        <is_script type="bool">False</is_script>
+                        <licenses type="list"/>
+                        <license_expressions type="list"/>
+                        <percentage_of_license_text type="int">0</percentage_of_license_text>
+                        <copyrights type="list">
+                                <item type="dict">
+                                        <copyright type="str">Copyright (c) 2000 ACME, Inc.</copyright>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </copyrights>
+                        <holders type="list">
+                                <item type="dict">
+                                        <holder type="str">ACME, Inc.</holder>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </holders>
+                        <authors type="list"/>
+                        <package_data type="list"/>
+                        <for_packages type="list"/>
+                        <files_count type="int">0</files_count>
+                        <dirs_count type="int">0</dirs_count>
+                        <size_count type="int">0</size_count>
+                        <scan_errors type="list"/>
+                </item>
+                <item type="dict">
+                        <path type="str">copy2.c</path>
+                        <type type="str">file</type>
+                        <name type="str">copy2.c</name>
+                        <base_name type="str">copy2</base_name>
+                        <extension type="str">.c</extension>
+                        <size type="int">91</size>
+                        <date type="str">2022-03-31</date>
+                        <sha1 type="str">3922760d8492eb8f853c10a627f5a73f9eaec6ff</sha1>
+                        <md5 type="str">fc7f53659b7a9db8b6dff0638641778e</md5>
+                        <sha256 type="str">23fe3ce8ad18772ea688a435bb624d65e08fdee1d31b9f620a1ba62619c0f201</sha256>
+                        <mime_type type="str">text/plain</mime_type>
+                        <file_type type="str">UTF-8 Unicode text</file_type>
+                        <programming_language type="str">C</programming_language>
+                        <is_binary type="bool">False</is_binary>
+                        <is_text type="bool">True</is_text>
+                        <is_archive type="bool">False</is_archive>
+                        <is_media type="bool">False</is_media>
+                        <is_source type="bool">True</is_source>
+                        <is_script type="bool">False</is_script>
+                        <licenses type="list"/>
+                        <license_expressions type="list"/>
+                        <percentage_of_license_text type="int">0</percentage_of_license_text>
+                        <copyrights type="list">
+                                <item type="dict">
+                                        <copyright type="str">Copyright (c) 2000 ACME, Inc.</copyright>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </copyrights>
+                        <holders type="list">
+                                <item type="dict">
+                                        <holder type="str">ACME, Inc.</holder>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </holders>
+                        <authors type="list"/>
+                        <package_data type="list"/>
+                        <for_packages type="list"/>
+                        <files_count type="int">0</files_count>
+                        <dirs_count type="int">0</dirs_count>
+                        <size_count type="int">0</size_count>
+                        <scan_errors type="list"/>
+                </item>
+                <item type="dict">
+                        <path type="str">copy3.c</path>
+                        <type type="str">file</type>
+                        <name type="str">copy3.c</name>
+                        <base_name type="str">copy3</base_name>
+                        <extension type="str">.c</extension>
+                        <size type="int">91</size>
+                        <date type="str">2022-03-31</date>
+                        <sha1 type="str">c91811eb5fdc7ab440355f9f8d1580e1518b0c2f</sha1>
+                        <md5 type="str">e999e21c9d7de4d0f943aefbb6f21b99</md5>
+                        <sha256 type="str">abd984f8715001bb54d5a2ef293b2c559861756b17c4461cde3ac08e9b61ec78</sha256>
+                        <mime_type type="str">text/plain</mime_type>
+                        <file_type type="str">UTF-8 Unicode text</file_type>
+                        <programming_language type="str">C</programming_language>
+                        <is_binary type="bool">False</is_binary>
+                        <is_text type="bool">True</is_text>
+                        <is_archive type="bool">False</is_archive>
+                        <is_media type="bool">False</is_media>
+                        <is_source type="bool">True</is_source>
+                        <is_script type="bool">False</is_script>
+                        <licenses type="list"/>
+                        <license_expressions type="list"/>
+                        <percentage_of_license_text type="int">0</percentage_of_license_text>
+                        <copyrights type="list">
+                                <item type="dict">
+                                        <copyright type="str">Copyright (c) 2000 ACME, Inc.</copyright>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </copyrights>
+                        <holders type="list">
+                                <item type="dict">
+                                        <holder type="str">ACME, Inc.</holder>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </holders>
+                        <authors type="list"/>
+                        <package_data type="list"/>
+                        <for_packages type="list"/>
+                        <files_count type="int">0</files_count>
+                        <dirs_count type="int">0</dirs_count>
+                        <size_count type="int">0</size_count>
+                        <scan_errors type="list"/>
+                </item>
+                <item type="dict">
+                        <path type="str">subdir</path>
+                        <type type="str">directory</type>
+                        <name type="str">subdir</name>
+                        <base_name type="str">subdir</base_name>
+                        <extension type="str"/>
+                        <size type="int">0</size>
+                        <date type="null"/>
+                        <sha1 type="null"/>
+                        <md5 type="null"/>
+                        <sha256 type="null"/>
+                        <mime_type type="null"/>
+                        <file_type type="null"/>
+                        <programming_language type="null"/>
+                        <is_binary type="bool">False</is_binary>
+                        <is_text type="bool">False</is_text>
+                        <is_archive type="bool">False</is_archive>
+                        <is_media type="bool">False</is_media>
+                        <is_source type="bool">False</is_source>
+                        <is_script type="bool">False</is_script>
+                        <licenses type="list"/>
+                        <license_expressions type="list"/>
+                        <percentage_of_license_text type="int">0</percentage_of_license_text>
+                        <copyrights type="list"/>
+                        <holders type="list"/>
+                        <authors type="list"/>
+                        <package_data type="list"/>
+                        <for_packages type="list"/>
+                        <files_count type="int">4</files_count>
+                        <dirs_count type="int">0</dirs_count>
+                        <size_count type="int">361</size_count>
+                        <scan_errors type="list"/>
+                </item>
+                <item type="dict">
+                        <path type="str">subdir/copy1.c</path>
+                        <type type="str">file</type>
+                        <name type="str">copy1.c</name>
+                        <base_name type="str">copy1</base_name>
+                        <extension type="str">.c</extension>
+                        <size type="int">91</size>
+                        <date type="str">2022-03-31</date>
+                        <sha1 type="str">3922760d8492eb8f853c10a627f5a73f9eaec6ff</sha1>
+                        <md5 type="str">fc7f53659b7a9db8b6dff0638641778e</md5>
+                        <sha256 type="str">23fe3ce8ad18772ea688a435bb624d65e08fdee1d31b9f620a1ba62619c0f201</sha256>
+                        <mime_type type="str">text/plain</mime_type>
+                        <file_type type="str">UTF-8 Unicode text</file_type>
+                        <programming_language type="str">C</programming_language>
+                        <is_binary type="bool">False</is_binary>
+                        <is_text type="bool">True</is_text>
+                        <is_archive type="bool">False</is_archive>
+                        <is_media type="bool">False</is_media>
+                        <is_source type="bool">True</is_source>
+                        <is_script type="bool">False</is_script>
+                        <licenses type="list"/>
+                        <license_expressions type="list"/>
+                        <percentage_of_license_text type="int">0</percentage_of_license_text>
+                        <copyrights type="list">
+                                <item type="dict">
+                                        <copyright type="str">Copyright (c) 2000 ACME, Inc.</copyright>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </copyrights>
+                        <holders type="list">
+                                <item type="dict">
+                                        <holder type="str">ACME, Inc.</holder>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </holders>
+                        <authors type="list"/>
+                        <package_data type="list"/>
+                        <for_packages type="list"/>
+                        <files_count type="int">0</files_count>
+                        <dirs_count type="int">0</dirs_count>
+                        <size_count type="int">0</size_count>
+                        <scan_errors type="list"/>
+                </item>
+                <item type="dict">
+                        <path type="str">subdir/copy2.c</path>
+                        <type type="str">file</type>
+                        <name type="str">copy2.c</name>
+                        <base_name type="str">copy2</base_name>
+                        <extension type="str">.c</extension>
+                        <size type="int">91</size>
+                        <date type="str">2022-03-31</date>
+                        <sha1 type="str">3922760d8492eb8f853c10a627f5a73f9eaec6ff</sha1>
+                        <md5 type="str">fc7f53659b7a9db8b6dff0638641778e</md5>
+                        <sha256 type="str">23fe3ce8ad18772ea688a435bb624d65e08fdee1d31b9f620a1ba62619c0f201</sha256>
+                        <mime_type type="str">text/plain</mime_type>
+                        <file_type type="str">UTF-8 Unicode text</file_type>
+                        <programming_language type="str">C</programming_language>
+                        <is_binary type="bool">False</is_binary>
+                        <is_text type="bool">True</is_text>
+                        <is_archive type="bool">False</is_archive>
+                        <is_media type="bool">False</is_media>
+                        <is_source type="bool">True</is_source>
+                        <is_script type="bool">False</is_script>
+                        <licenses type="list"/>
+                        <license_expressions type="list"/>
+                        <percentage_of_license_text type="int">0</percentage_of_license_text>
+                        <copyrights type="list">
+                                <item type="dict">
+                                        <copyright type="str">Copyright (c) 2000 ACME, Inc.</copyright>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </copyrights>
+                        <holders type="list">
+                                <item type="dict">
+                                        <holder type="str">ACME, Inc.</holder>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </holders>
+                        <authors type="list"/>
+                        <package_data type="list"/>
+                        <for_packages type="list"/>
+                        <files_count type="int">0</files_count>
+                        <dirs_count type="int">0</dirs_count>
+                        <size_count type="int">0</size_count>
+                        <scan_errors type="list"/>
+                </item>
+                <item type="dict">
+                        <path type="str">subdir/copy3.c</path>
+                        <type type="str">file</type>
+                        <name type="str">copy3.c</name>
+                        <base_name type="str">copy3</base_name>
+                        <extension type="str">.c</extension>
+                        <size type="int">84</size>
+                        <date type="str">2022-03-31</date>
+                        <sha1 type="str">389af7e629a9853056e42b262d5e30bf4579a74f</sha1>
+                        <md5 type="str">290627a1387288ef77ae7e07946f3ecf</md5>
+                        <sha256 type="str">271a9f4402a59c923ee04fd9bd3f2aa188d2b9e4741cef1b756ec7116f9d83ef</sha256>
+                        <mime_type type="str">text/plain</mime_type>
+                        <file_type type="str">UTF-8 Unicode text</file_type>
+                        <programming_language type="str">C</programming_language>
+                        <is_binary type="bool">False</is_binary>
+                        <is_text type="bool">True</is_text>
+                        <is_archive type="bool">False</is_archive>
+                        <is_media type="bool">False</is_media>
+                        <is_source type="bool">True</is_source>
+                        <is_script type="bool">False</is_script>
+                        <licenses type="list"/>
+                        <license_expressions type="list"/>
+                        <percentage_of_license_text type="int">0</percentage_of_license_text>
+                        <copyrights type="list">
+                                <item type="dict">
+                                        <copyright type="str">Copyright (c) 2000 ACME, Inc.</copyright>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </copyrights>
+                        <holders type="list">
+                                <item type="dict">
+                                        <holder type="str">ACME, Inc.</holder>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </holders>
+                        <authors type="list"/>
+                        <package_data type="list"/>
+                        <for_packages type="list"/>
+                        <files_count type="int">0</files_count>
+                        <dirs_count type="int">0</dirs_count>
+                        <size_count type="int">0</size_count>
+                        <scan_errors type="list"/>
+                </item>
+                <item type="dict">
+                        <path type="str">subdir/copy4.c</path>
+                        <type type="str">file</type>
+                        <name type="str">copy4.c</name>
+                        <base_name type="str">copy4</base_name>
+                        <extension type="str">.c</extension>
+                        <size type="int">95</size>
+                        <date type="str">2022-03-31</date>
+                        <sha1 type="str">58748872d25374160692f1ed7075d0fe80a544b1</sha1>
+                        <md5 type="str">88e46475db9b1a68f415f6a3544eeb16</md5>
+                        <sha256 type="str">f6810dc076ffe08dad2812318e414ac4123de9a612faabc35121206a4fa48ce4</sha256>
+                        <mime_type type="str">text/plain</mime_type>
+                        <file_type type="str">UTF-8 Unicode text</file_type>
+                        <programming_language type="str">C</programming_language>
+                        <is_binary type="bool">False</is_binary>
+                        <is_text type="bool">True</is_text>
+                        <is_archive type="bool">False</is_archive>
+                        <is_media type="bool">False</is_media>
+                        <is_source type="bool">True</is_source>
+                        <is_script type="bool">False</is_script>
+                        <licenses type="list"/>
+                        <license_expressions type="list"/>
+                        <percentage_of_license_text type="int">0</percentage_of_license_text>
+                        <copyrights type="list">
+                                <item type="dict">
+                                        <copyright type="str">Copyright (c) 2000 ACME, Inc.</copyright>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </copyrights>
+                        <holders type="list">
+                                <item type="dict">
+                                        <holder type="str">ACME, Inc.</holder>
+                                        <start_line type="int">1</start_line>
+                                        <end_line type="int">1</end_line>
+                                </item>
+                        </holders>
+                        <authors type="list"/>
+                        <package_data type="list"/>
+                        <for_packages type="list"/>
+                        <files_count type="int">0</files_count>
+                        <dirs_count type="int">0</dirs_count>
+                        <size_count type="int">0</size_count>
+                        <scan_errors type="list"/>
+                </item>
+        </files>
+</all>

--- a/tests/formattedcode/data/xml/tree/scan/copy1.c
+++ b/tests/formattedcode/data/xml/tree/scan/copy1.c
@@ -1,0 +1,11 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+adasd
+ad
+asd
+as
+das
+da
+da
+dasd
+asd

--- a/tests/formattedcode/data/xml/tree/scan/copy2.c
+++ b/tests/formattedcode/data/xml/tree/scan/copy2.c
@@ -1,0 +1,11 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+adasd
+ad
+asd
+as
+das
+da
+da
+dasd
+asd

--- a/tests/formattedcode/data/xml/tree/scan/copy3.c
+++ b/tests/formattedcode/data/xml/tree/scan/copy3.c
@@ -1,0 +1,10 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+adasd
+ad
+asd
+as
+da
+dasdas
+dasd
+asd

--- a/tests/formattedcode/data/xml/tree/scan/subdir/copy1.c
+++ b/tests/formattedcode/data/xml/tree/scan/subdir/copy1.c
@@ -1,0 +1,11 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+adasd
+ad
+asd
+as
+das
+da
+da
+dasd
+asd

--- a/tests/formattedcode/data/xml/tree/scan/subdir/copy2.c
+++ b/tests/formattedcode/data/xml/tree/scan/subdir/copy2.c
@@ -1,0 +1,11 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+adasd
+ad
+asd
+as
+das
+da
+da
+dasd
+asd

--- a/tests/formattedcode/data/xml/tree/scan/subdir/copy3.c
+++ b/tests/formattedcode/data/xml/tree/scan/subdir/copy3.c
@@ -1,0 +1,9 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+
+adasd
+ad
+asd
+as
+da
+dasd
+asd

--- a/tests/formattedcode/data/xml/tree/scan/subdir/copy4.c
+++ b/tests/formattedcode/data/xml/tree/scan/subdir/copy4.c
@@ -1,0 +1,11 @@
+/* Copyright © 2000 ACME, Inc., All Rights Reserved */
+fafsdfsdf
+
+
+adasd
+ad
+asd
+as
+da
+dasd
+asd

--- a/tests/formattedcode/test_output_xml.py
+++ b/tests/formattedcode/test_output_xml.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# ScanCode is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/scancode-toolkit for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+import xmltodict
+import os
+import json
+import pytest
+import xml.etree.ElementTree as ET
+
+from commoncode.testcase import FileDrivenTesting
+from scancode.cli_test_utils import run_scan_click
+from scancode_config import REGEN_TEST_FIXTURES
+
+
+test_env = FileDrivenTesting()
+test_env.test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
+
+def test_xml():
+    test_dir = test_env.get_test_loc('xml/simple')
+    result_file = test_env.get_temp_file('xml')
+    run_scan_click(['-clip', test_dir, '--xml', result_file])
+    expected = test_env.get_test_loc('xml/simple-expected.xml')
+    check_xml_scan(expected, result_file, regen=REGEN_TEST_FIXTURES)
+
+@pytest.mark.scanslow
+def test_scan_output_does_not_truncate_copyright_xml():
+    test_dir = test_env.get_test_loc('xml/tree/scan/')
+    result_file = test_env.get_temp_file('test.xml')
+    run_scan_click(['-clip', '--strip-root', test_dir, '--xml', result_file])
+    expected = test_env.get_test_loc('xml/tree/expected.xml')
+    check_xml_scan(expected, result_file, regen=REGEN_TEST_FIXTURES)
+
+
+@pytest.mark.scanslow
+def test_scan_output_for_timestamp():
+    test_dir = test_env.get_test_loc('xml/simple')
+    result_file = test_env.get_temp_file('xml')
+    run_scan_click(['-clip', test_dir, '--xml', result_file])
+    result_xml = json.loads(json.dumps((xmltodict.parse(open(result_file).read()))))
+    header = result_xml['all']['headers']['item']
+    assert 'start_timestamp' in header
+    assert 'end_timestamp' in header
+
+
+def check_xml_scan(expected_file, result_file, regen=REGEN_TEST_FIXTURES):
+    """
+    Check the scan `result_file` xml results against the `expected_file`
+    expected xml results.
+
+    If `regen` is True the expected_file WILL BE overwritten with the new scan
+    results from `results_file`. This is convenient for updating tests
+    expectations. But use with caution.
+    """
+    results = load_xml_results(result_file) or {}
+    if regen:
+        with open(expected_file, 'w') as reg:
+            reg.write(ET.dump(results))
+
+    expected = load_xml_results(expected_file)
+
+    results.pop('headers', None)
+    expected.pop('headers', None)
+
+    # NOTE we redump this as a string for a more efficient display of the
+    # failures comparison/diff
+    expected = json.dumps(expected)
+    results = json.dumps(results)
+    assert results == expected
+
+def load_xml_results(location):
+    """
+    Load the xml scan results file at `location`.
+    To help with test resilience against small changes some attributes are
+    removed or streamlined such as the  "tool_version" and scan "errors".
+    Also date attributes from "files" and "headers" entries are removed.
+    """
+    with open(location, encoding='utf-8') as res:
+        scan_results = convert_xml_to_dict(res)
+    return cleanup_scan(scan_results, remove_file_date=True)
+
+
+def cleanup_scan(scan_results, remove_file_date=False):
+    """
+    Cleanup in place the ``scan_results`` mapping for dates, headers and
+    other variable data that break tests otherwise.
+    """
+    # clean new headers attributes
+    streamline_headers(scan_results)
+    # clean file_level attributes
+    for scanned_file in scan_results['all']['files']['item'][0]['scan_errors']:
+        streamline_scanned_file(scanned_file, remove_file_date)
+    return scan_results
+
+
+def streamline_errors(errors):
+    """
+    Modify the `errors` list in place to make it easier to test
+    """
+    for i, error in enumerate(errors[:]):
+        error_lines = error.splitlines(True)
+        if len(error_lines) <= 1:
+            continue
+        # keep only first and last line
+        cleaned_error = ''.join([error_lines[0] + error_lines[-1]])
+        errors[i] = cleaned_error
+
+
+def streamline_headers(scan_results):
+    """
+    Modify the `headers` list of mappings in place to make it easier to test.
+    """
+    del scan_results['all']['headers']['item']['start_timestamp']
+    del scan_results['all']['headers']['item']['end_timestamp']
+    del scan_results['all']['headers']['item']['duration']
+    del scan_results['all']['headers']['item']['options']
+
+
+def streamline_scanned_file(scanned_file, remove_file_date=False):
+    """
+    Modify the `scanned_file` mapping for a file in scan results in place to
+    make it easier to test.
+    """
+    streamline_errors(scanned_file)
+
+def convert_xml_to_dict(xml_file):
+    tree = ET.parse(xml_file)
+    xml_data = tree.getroot()
+    xmlstr = ET.tostring(xml_data, encoding='utf-8', method='xml')
+    return dict(xmltodict.parse(xmlstr))

--- a/tests/scancode/data/help/help.txt
+++ b/tests/scancode/data/help/help.txt
@@ -43,6 +43,7 @@ Options:
     --json-pp FILE          Write scan output as pretty-printed JSON to FILE.
     --json-lines FILE       Write scan output as JSON Lines to FILE.
     --yaml FILE             Write scan output as YAML to FILE.
+    --xml FILE              Write scan output as XML to FILE.
     --csv FILE              Write scan output as CSV to FILE.
     --html FILE             Write scan output as HTML to FILE.
     --custom-output FILE    Write scan output to FILE formatted with the custom

--- a/tests/scancode/data/help/help.txt
+++ b/tests/scancode/data/help/help.txt
@@ -42,8 +42,8 @@ Options:
     --json FILE             Write scan output as compact JSON to FILE.
     --json-pp FILE          Write scan output as pretty-printed JSON to FILE.
     --json-lines FILE       Write scan output as JSON Lines to FILE.
-    --yaml FILE             Write scan output as YAML to FILE.
     --xml FILE              Write scan output as XML to FILE.
+    --yaml FILE             Write scan output as YAML to FILE.
     --csv FILE              Write scan output as CSV to FILE.
     --html FILE             Write scan output as HTML to FILE.
     --custom-output FILE    Write scan output to FILE formatted with the custom


### PR DESCRIPTION
Added XML output plugin that gets report in an XML file.

Fixes #2801

Signed-off-by: Chaitanya Gadgil [chaitanyagadgil0170@gmail.com](mailto:chaitanyagadgil0170@gmail.com)

### Tasks

* [X] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [X] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [X] Commits are in uniquely-named feature branch and has no merge conflicts 📁

