### PR TITLE
Remove usage of get_terminal_size in click

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ chardet==4.0.0
 charset-normalizer==2.0.12
 click==8.0.4
 colorama==0.4.4
-commoncode==30.0.0
+commoncode==30.1.1
 construct==2.10.68
 cryptography==36.0.1
 debian-inspector==30.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ install_requires =
     chardet >= 3.0.0
     click >= 6.7, !=7.0
     colorama >= 0.3.9
-    commoncode >= 30.0.0
+    commoncode >= 30.1.1
     debian-inspector >= 30.0.0
     dparse2 >= 0.6.0
     fasteners

--- a/src/scancode/cli_test_utils.py
+++ b/src/scancode/cli_test_utils.py
@@ -94,6 +94,7 @@ def run_scan_click(
     If retry is True, wait 10 seconds after a failure and retry once
     """
     import click
+    import shutil
     from click.testing import CliRunner
     from scancode import cli
 
@@ -104,7 +105,7 @@ def run_scan_click(
 
     if monkeypatch:
         monkeypatch.setattr(click._termui_impl, 'isatty', lambda _: True)
-        monkeypatch.setattr(click , 'get_terminal_size', lambda : (80, 43,))
+        monkeypatch.setattr(shutil , 'get_terminal_size', lambda : (80, 43,))
 
     if not env:
         env = dict(os.environ)


### PR DESCRIPTION
Signed-off-by: Ayan Sinha Mahapatra <ayansmahapatra@gmail.com>

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->


<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
