### PR TITLE
Add black and isort as testing dependencies #2969

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -130,6 +130,8 @@ testing =
     pytest-xdist >= 2
     aboutcode-toolkit >= 7.0.2
     twine
+    black
+    isort
 
 docs =
     Sphinx >= 3.3.1


### PR DESCRIPTION
Added `black` and `isort` as testing dependencies.

Signed-off-by: John M. Horan <johnmhoran@gmail.com>
