### PR TITLE
Convert package data dict to PackageData #2971

### DIFF
--- a/src/packagedcode/debian.py
+++ b/src/packagedcode/debian.py
@@ -402,10 +402,11 @@ class DebianDistrolessInstalledDatabaseHandler(models.DatafileHandler):
                 continue
 
             for pkgdt in res.package_data:
+                pkgdt = models.PackageData.from_dict(pkgdt)
                 package.update(
                     package_data=pkgdt,
                     datafile_path=res.path,
-            )
+                )
 
             res.for_packages.append(package_uid)
             res.save(codebase)
@@ -545,7 +546,7 @@ def parse_debian_files_list(location, datasource_id, package_type):
 
             ref = models.FileReference(path=path, md5=md5sum)
             file_references.append(ref)
-    
+
     if not file_references:
         return
 

--- a/src/packagedcode/debian.py
+++ b/src/packagedcode/debian.py
@@ -402,7 +402,6 @@ class DebianDistrolessInstalledDatabaseHandler(models.DatafileHandler):
                 continue
 
             for pkgdt in res.package_data:
-                pkgdt = models.PackageData.from_dict(pkgdt)
                 package.update(
                     package_data=pkgdt,
                     datafile_path=res.path,

--- a/src/packagedcode/models.py
+++ b/src/packagedcode/models.py
@@ -1274,6 +1274,9 @@ class Package(PackageData):
         if not package_data:
             return
 
+        if isinstance(package_data, dict):
+            package_data = PackageData.from_dict(package_data)
+
         if not self.is_compatible(package_data, include_qualifiers=False):
             if TRACE_UPDATE:
                 logger_debug(f'update: {self.purl} not compatible with: {package_data.purl}')


### PR DESCRIPTION
This PR addresses the issue where scancode encountered errors when scanning for system packages from a distroless docker root filesystem. The issue was that the package data on the resource, which is in a dictionary, was being passed into `Package.update()` when `Package.update()` was expecting a `PackageData` object instead.