### PR TITLE
Consider only copyrights in summry #2972

### DIFF
--- a/src/summarycode/copyright_tallies.py
+++ b/src/summarycode/copyright_tallies.py
@@ -494,6 +494,7 @@ COMMON_NAMES = {
     'cisco': 'Cisco Systems',
 
     'daisy': 'Daisy',
+    'daisyltd': 'Daisy',
 
     'fsf': 'Free Software Foundation',
     'freesoftwarefoundation': 'Free Software Foundation',
@@ -541,6 +542,7 @@ COMMON_NAMES = {
     'regentsoftheuniversityofcalifornia': 'The Regents of the University of California',
 
     'borland': 'Borland',
+    'borlandcorp': 'Borland',
 
     'microsoft': 'Microsoft',
     'microsoftcorp': 'Microsoft',

--- a/src/summarycode/copyright_tallies.py
+++ b/src/summarycode/copyright_tallies.py
@@ -485,49 +485,49 @@ def filter_junk(texts):
 
 
 COMMON_NAMES = {
-    '3dfxinteractiveinc.': '3dfx Interactive, Inc.',
+    '3dfxinteractiveinc.': '3dfx Interactive',
 
     'cern': 'CERN - European Organization for Nuclear Research',
 
-    'ciscosystemsinc': 'Cisco Systems, Inc.',
-    'ciscosystems': 'Cisco Systems, Inc.',
-    'cisco': 'Cisco Systems, Inc.',
+    'ciscosystemsinc': 'Cisco Systems',
+    'ciscosystems': 'Cisco Systems',
+    'cisco': 'Cisco Systems',
 
-    'daisy': 'Daisy Ltd.',
+    'daisy': 'Daisy',
 
-    'fsf': 'Free Software Foundation, Inc.',
-    'freesoftwarefoundation': 'Free Software Foundation, Inc.',
-    'freesoftwarefoundationinc': 'Free Software Foundation, Inc.',
-    'thefreesoftwarefoundation': 'Free Software Foundation, Inc.',
-    'thefreesoftwarefoundationinc': 'Free Software Foundation, Inc.',
+    'fsf': 'Free Software Foundation',
+    'freesoftwarefoundation': 'Free Software Foundation',
+    'freesoftwarefoundationinc': 'Free Software Foundation',
+    'thefreesoftwarefoundation': 'Free Software Foundation',
+    'thefreesoftwarefoundationinc': 'Free Software Foundation',
 
-    'hp': 'Hewlett-Packard, Inc.',
-    'hewlettpackard': 'Hewlett-Packard, Inc.',
-    'hewlettpackardco': 'Hewlett-Packard, Inc.',
-    'hpcompany': 'Hewlett-Packard, Inc.',
-    'hpdevelopmentcompanylp': 'Hewlett-Packard, Inc.',
-    'hpdevelopmentcompany': 'Hewlett-Packard, Inc.',
-    'hewlettpackardcompany': 'Hewlett-Packard, Inc.',
+    'hp': 'Hewlett-Packard',
+    'hewlettpackard': 'Hewlett-Packard',
+    'hewlettpackardco': 'Hewlett-Packard',
+    'hpcompany': 'Hewlett-Packard',
+    'hpdevelopmentcompanylp': 'Hewlett-Packard',
+    'hpdevelopmentcompany': 'Hewlett-Packard',
+    'hewlettpackardcompany': 'Hewlett-Packard',
 
-    'theandroidopensourceproject': 'The Android Open Source Project, Inc.',
-    'androidopensourceproject': 'The Android Open Source Project, Inc.',
+    'theandroidopensourceproject': 'Android Open Source Project',
+    'androidopensourceproject': 'Android Open Source Project',
 
-    'ibm': 'IBM Corporation',
+    'ibm': 'IBM',
 
-    'redhat': 'Red Hat, Inc.',
-    'redhatinc': 'Red Hat, Inc.',
+    'redhat': 'Red Hat',
+    'redhatinc': 'Red Hat',
 
-    'softwareinthepublicinterest': 'Software in the Public Interest, Inc.',
-    'spiinc': 'Software in the Public Interest, Inc.',
+    'softwareinthepublicinterest': 'Software in the Public Interest',
+    'spiinc': 'Software in the Public Interest',
 
-    'suse': 'SuSE, Inc.',
-    'suseinc': 'SuSE, Inc.',
+    'suse': 'SuSE',
+    'suseinc': 'SuSE',
 
-    'sunmicrosystems': 'Sun Microsystems, Inc.',
-    'sunmicrosystemsinc': 'Sun Microsystems, Inc.',
-    'sunmicro': 'Sun Microsystems, Inc.',
+    'sunmicrosystems': 'Sun Microsystems',
+    'sunmicrosystemsinc': 'Sun Microsystems',
+    'sunmicro': 'Sun Microsystems',
 
-    'thaiopensourcesoftwarecenter': 'Thai Open Source Software Center Ltd.',
+    'thaiopensourcesoftwarecenter': 'Thai Open Source Software Center',
 
     'apachefoundation': 'The Apache Software Foundation',
     'apachegroup': 'The Apache Software Foundation',
@@ -540,20 +540,18 @@ COMMON_NAMES = {
 
     'regentsoftheuniversityofcalifornia': 'The Regents of the University of California',
 
-    # 'mit': 'the Massachusetts Institute of Technology',
-
-    'borland': 'Borland Corp.',
+    'borland': 'Borland',
 
     'microsoft': 'Microsoft',
     'microsoftcorp': 'Microsoft',
     'microsoftinc': 'Microsoft',
     'microsoftcorporation': 'Microsoft',
 
-    'google': 'Google Inc.',
-    'googlellc': 'Google Inc.',
-    'googleinc': 'Google Inc.',
+    'google': 'Google',
+    'googlellc': 'Google',
+    'googleinc': 'Google',
 
-    'intel': 'Intel Corporation',
+    'intel': 'Intel',
 }
 
 # Remove everything except letters and numbers

--- a/src/summarycode/summarizer.py
+++ b/src/summarycode/summarizer.py
@@ -213,13 +213,13 @@ def get_primary_language(programming_language_tallies):
 
 def get_origin_info_from_top_level_packages(top_level_packages, codebase):
     """
-    Return a 3-tuple containing the strings of declared license expression,
-    copyright holder, and primary programming language from a
+    Return a 3-tuple containing the declared license expression string, a list
+    of copyright holder, and primary programming language string from a
     ``top_level_packages`` list of detected top-level packages mapping and a
     ``codebase``.
     """
     if not top_level_packages:
-        return '', '', ''
+        return '', [], ''
 
     license_expressions = []
     programming_languages = []
@@ -272,6 +272,9 @@ def get_origin_info_from_top_level_packages(top_level_packages, codebase):
                     continue
                 holders = [h['holder'] for h in key_file_resource.holders]
                 declared_holders.extend(holders)
+    # Normalize holder names before collecting them
+    # This allows us to properly remove declared holders from `other_holders` later
+    declared_holders = [canonical_holder(h) for h in declared_holders]
     declared_holders = unique(declared_holders)
 
     # Programming language

--- a/src/summarycode/summarizer.py
+++ b/src/summarycode/summarizer.py
@@ -18,6 +18,7 @@ from plugincode.post_scan import PostScanPlugin, post_scan_impl
 from cluecode.copyrights import CopyrightDetector
 from packagedcode.utils import combine_expressions
 from packagedcode import models
+from summarycode.copyright_tallies import canonical_holder
 from summarycode.score import compute_license_score
 from summarycode.score import get_field_values_from_codebase_resources
 from summarycode.score import unique
@@ -167,7 +168,7 @@ def get_declared_holders(codebase, holders_tallies):
         codebase, 'holders', key_files_only=True
     )
     entry_by_key_file_holders = {
-        fingerprints.generate(entry['holder']): entry
+        fingerprints.generate(canonical_holder(entry['holder'])): entry
         for entry in key_file_holders
         if entry['holder']
     }

--- a/src/summarycode/summarizer.py
+++ b/src/summarycode/summarizer.py
@@ -223,7 +223,6 @@ def get_origin_info_from_top_level_packages(top_level_packages, codebase):
     license_expressions = []
     programming_languages = []
     copyrights = []
-    parties = []
 
     for package_mapping in top_level_packages:
         package = models.Package.from_dict(package_mapping)
@@ -243,8 +242,6 @@ def get_origin_info_from_top_level_packages(top_level_packages, codebase):
         if copyright_statement:
             copyrights.append(copyright_statement)
 
-        parties.extend(package.parties or [])
-
     # Combine license expressions
     unique_license_expressions = unique(license_expressions)
     combined_declared_license_expression = combine_expressions(
@@ -263,8 +260,6 @@ def get_origin_info_from_top_level_packages(top_level_packages, codebase):
     declared_holders = []
     if holders:
         declared_holders = holders
-    elif parties:
-        declared_holders = [party.name for party in parties or []]
 
     declared_holders = unique(declared_holders)
 

--- a/tests/cluecode/data/copyrights/COPYING_gpl-COPYING_gpl.gpl.yml
+++ b/tests/cluecode/data/copyrights/COPYING_gpl-COPYING_gpl.gpl.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/copyrights/afferogplv1-AfferoGPLv.yml
+++ b/tests/cluecode/data/copyrights/afferogplv1-AfferoGPLv.yml
@@ -13,5 +13,5 @@ holders:
 holders_summary:
   - value: Affero Inc.
     count: 2
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/afferogplv3-AfferoGPLv.yml
+++ b/tests/cluecode/data/copyrights/afferogplv3-AfferoGPLv.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/android_c-c.c.yml
+++ b/tests/cluecode/data/copyrights/android_c-c.c.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Colin Percival
 holders_summary:
-  - value: Colin Percival
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Colin Percival
     count: 1

--- a/tests/cluecode/data/copyrights/apache2_debian_trailing_name_missed-apache.label.yml
+++ b/tests/cluecode/data/copyrights/apache2_debian_trailing_name_missed-apache.label.yml
@@ -75,7 +75,7 @@ holders_summary:
     count: 2
   - value: Board of Trustees of the University of Illinois
     count: 1
-  - value: Cisco Systems, Inc.
+  - value: Cisco Systems
     count: 1
   - value: Eric Haines
     count: 1

--- a/tests/cluecode/data/copyrights/bigelow_holmes-Bigelow&Holmes.yml
+++ b/tests/cluecode/data/copyrights/bigelow_holmes-Bigelow&Holmes.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Bigelow & Holmes
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/copyrights/colin_android-bsdiff_c.c.yml
+++ b/tests/cluecode/data/copyrights/colin_android-bsdiff_c.c.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Colin Percival
 holders_summary:
-  - value: Colin Percival
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Colin Percival
     count: 1

--- a/tests/cluecode/data/copyrights/complex_notice-NOTICE.yml
+++ b/tests/cluecode/data/copyrights/complex_notice-NOTICE.yml
@@ -58,7 +58,7 @@ holders:
 holders_summary:
   - value: David Schultz
     count: 9
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 4
   - value: Mike Barcroft
     count: 2

--- a/tests/cluecode/data/copyrights/complex_notice_sun_microsystems_on_multiple_lines-NOTICE.yml
+++ b/tests/cluecode/data/copyrights/complex_notice_sun_microsystems_on_multiple_lines-NOTICE.yml
@@ -23,7 +23,7 @@ holders:
 holders_summary:
   - value: IBM Corporation
     count: 3
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 3
   - value: Lotus Development Corporation
     count: 1

--- a/tests/cluecode/data/copyrights/config-config_guess.guess.yml
+++ b/tests/cluecode/data/copyrights/config-config_guess.guess.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/config1_guess-config_guess.guess.yml
+++ b/tests/cluecode/data/copyrights/config1_guess-config_guess.guess.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/copyright_is_not_mixed_with_authors.txt.yml
+++ b/tests/cluecode/data/copyrights/copyright_is_not_mixed_with_authors.txt.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/copyright_name_sign_year-c.c.yml
+++ b/tests/cluecode/data/copyrights/copyright_name_sign_year-c.c.yml
@@ -9,5 +9,5 @@ holders:
   - Daisy Ltd.
   - Daisy
 holders_summary:
-  - value: Daisy Ltd.
+  - value: Daisy
     count: 2

--- a/tests/cluecode/data/copyrights/copytest/aosp.txt.yml
+++ b/tests/cluecode/data/copyrights/copytest/aosp.txt.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/copyrights/copytest/hp_co_or_company.txt.yml
+++ b/tests/cluecode/data/copyrights/copytest/hp_co_or_company.txt.yml
@@ -11,5 +11,5 @@ holders:
   - Hewlett-Packard Co.
   - Hewlett-Packard Co.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 3

--- a/tests/cluecode/data/copyrights/copytest/with_format_code.txt.yml
+++ b/tests/cluecode/data/copyrights/copytest/with_format_code.txt.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/copytest/with_trailing_caps.txt.yml
+++ b/tests/cluecode/data/copyrights/copytest/with_trailing_caps.txt.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/coreutils_debian-coreutils.copyright.yml
+++ b/tests/cluecode/data/copyrights/coreutils_debian-coreutils.copyright.yml
@@ -43,7 +43,7 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 11
   - value: Colin Plumb
     count: 2

--- a/tests/cluecode/data/copyrights/ecosv2_0-eCosv.0.yml
+++ b/tests/cluecode/data/copyrights/ecosv2_0-eCosv.0.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/copyrights/ed-ed.copyright.yml
+++ b/tests/cluecode/data/copyrights/ed-ed.copyright.yml
@@ -17,7 +17,7 @@ holders_summary:
     count: 1
   - value: Antonio Diaz Diaz
     count: 1
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: James Troup
     count: 1

--- a/tests/cluecode/data/copyrights/esmertec_java-java.java.yml
+++ b/tests/cluecode/data/copyrights/esmertec_java-java.java.yml
@@ -9,7 +9,7 @@ holders:
   - Esmertec AG
   - The Android Open Source Project
 holders_summary:
-  - value: Esmertec AG
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Esmertec AG
     count: 1

--- a/tests/cluecode/data/copyrights/fsf_py-999_py.py.yml
+++ b/tests/cluecode/data/copyrights/fsf_py-999_py.py.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/gfdlv1_2-GFDLv.2.yml
+++ b/tests/cluecode/data/copyrights/gfdlv1_2-GFDLv.2.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/gfdlv1_3-GFDLv.3.yml
+++ b/tests/cluecode/data/copyrights/gfdlv1_3-GFDLv.3.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/gnome_session-gnome_session.copyright.yml
+++ b/tests/cluecode/data/copyrights/gnome_session-gnome_session.copyright.yml
@@ -29,7 +29,7 @@ holders:
   - Free Software Foundation, Inc.
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: George Lebl
     count: 1
@@ -43,9 +43,9 @@ holders_summary:
     count: 1
   - value: Ray Strode
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: Tom Tromey
     count: 1

--- a/tests/cluecode/data/copyrights/gobjc_4_3-gobjc.copyright.yml
+++ b/tests/cluecode/data/copyrights/gobjc_4_3-gobjc.copyright.yml
@@ -14,9 +14,9 @@ holders:
   - Digital Mars, www.digitalmars.com
   - Red Hat, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2
   - value: Digital Mars, www.digitalmars.com
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/copyrights/google_closure_templates_java_html-html.html.yml
+++ b/tests/cluecode/data/copyrights/google_closure_templates_java_html-html.html.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/copyrights/google_view_layout1_xml-view_layout_xml.xml.yml
+++ b/tests/cluecode/data/copyrights/google_view_layout1_xml-view_layout_xml.xml.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/copyrights/gpl_v1-GPL_v.yml
+++ b/tests/cluecode/data/copyrights/gpl_v1-GPL_v.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/copyrights/gpl_v2-GPL_v.yml
+++ b/tests/cluecode/data/copyrights/gpl_v2-GPL_v.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/copyrights/gpl_v3-GPL_v.yml
+++ b/tests/cluecode/data/copyrights/gpl_v3-GPL_v.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/hewlett_packard-Hewlett_Packard.yml
+++ b/tests/cluecode/data/copyrights/hewlett_packard-Hewlett_Packard.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - HEWLETT-PACKARD COMPANY
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/copyrights/hp_notice-NOTICE.yml
+++ b/tests/cluecode/data/copyrights/hp_notice-NOTICE.yml
@@ -25,5 +25,5 @@ holders_summary:
     count: 4
   - value: Alan D. Brunelle
     count: 2
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/copyrights/hpijs_ppds-hpijs_ppds.label.yml
+++ b/tests/cluecode/data/copyrights/hpijs_ppds-hpijs_ppds.label.yml
@@ -15,9 +15,9 @@ holders:
 holders_summary:
   - value: Henrique de Moraes Holschuh
     count: 1
-  - value: Hewlett-Packard Development Company, L.P.
+  - value: Hewlett-Packard
     count: 1
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard Development Company, L.P.
     count: 1
   - value: Torsten Landschoff
     count: 1

--- a/tests/cluecode/data/copyrights/ijg-IJG.yml
+++ b/tests/cluecode/data/copyrights/ijg-IJG.yml
@@ -19,7 +19,7 @@ holders_summary:
     count: 1
   - value: CompuServe Incorporated
     count: 1
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: M.I.T.
     count: 1

--- a/tests/cluecode/data/copyrights/kbuild-kbuild.copyright.yml
+++ b/tests/cluecode/data/copyrights/kbuild-kbuild.copyright.yml
@@ -17,7 +17,7 @@ holders:
   - Torsten Werner
   - Daniel Baumann
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2
   - value: Daniel Baumann
     count: 1

--- a/tests/cluecode/data/copyrights/lgpl_v2_0-LGPL_v.0.yml
+++ b/tests/cluecode/data/copyrights/lgpl_v2_0-LGPL_v.0.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/copyrights/lgpl_v2_1-LGPL_v.1.yml
+++ b/tests/cluecode/data/copyrights/lgpl_v2_1-LGPL_v.1.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/copyrights/lgpl_v3-LGPL_v.yml
+++ b/tests/cluecode/data/copyrights/lgpl_v3-LGPL_v.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/libc6_i686-libc_i.copyright.yml
+++ b/tests/cluecode/data/copyrights/libc6_i686-libc_i.copyright.yml
@@ -23,7 +23,7 @@ holders:
   - Intel Corporation
   - Craig Metz
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2
   - value: Carnegie Mellon University
     count: 1
@@ -33,7 +33,7 @@ holders_summary:
     count: 1
   - value: Intel Corporation
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The Regents of the University of California
     count: 1

--- a/tests/cluecode/data/copyrights/libcdio10-libcdio.label.yml
+++ b/tests/cluecode/data/copyrights/libcdio10-libcdio.label.yml
@@ -50,7 +50,7 @@ holders_summary:
     count: 1
   - value: Eric Youngdale
     count: 1
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Gerd Knorr
     count: 1

--- a/tests/cluecode/data/copyrights/libgnome_desktop_2-libgnome_desktop.copyright.yml
+++ b/tests/cluecode/data/copyrights/libgnome_desktop_2-libgnome_desktop.copyright.yml
@@ -15,13 +15,13 @@ holders:
   - Sun Microsystems, Inc.
   - Kristian Rietveld
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Kristian Rietveld
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Sid Vicious
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/copyrights/libgtkhtml2_0-libgtkhtml.copyright.yml
+++ b/tests/cluecode/data/copyrights/libgtkhtml2_0-libgtkhtml.copyright.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/libjpeg62-libjpeg.copyright.yml
+++ b/tests/cluecode/data/copyrights/libjpeg62-libjpeg.copyright.yml
@@ -19,7 +19,7 @@ holders_summary:
     count: 1
   - value: CompuServe Incorporated
     count: 1
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: M.I.T.
     count: 1

--- a/tests/cluecode/data/copyrights/libkeyutils1-libkeyutils.label.yml
+++ b/tests/cluecode/data/copyrights/libkeyutils1-libkeyutils.label.yml
@@ -11,7 +11,7 @@ holders:
   - Red Hat
   - Daniel Baumann
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 2
   - value: Daniel Baumann
     count: 1

--- a/tests/cluecode/data/copyrights/libstlport4_6ldbl-libstlport_ldbl.label.yml
+++ b/tests/cluecode/data/copyrights/libstlport4_6ldbl-libstlport_ldbl.label.yml
@@ -15,7 +15,7 @@ holders:
 holders_summary:
   - value: Boris Fomitchev
     count: 1
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: Moscow Center for SPARC Technology
     count: 1

--- a/tests/cluecode/data/copyrights/libxext6-libxext.copyright.yml
+++ b/tests/cluecode/data/copyrights/libxext6-libxext.copyright.yml
@@ -32,15 +32,15 @@ holders_summary:
   - value: Digital Equipment Corporation, Maynard, Massachusetts, and Olivetti Research Limited,
       Cambridge, England
     count: 1
-  - value: Hewlett-Packard Corporation
+  - value: Hewlett-Packard
     count: 1
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard Corporation
     count: 1
   - value: Network Computing Devices
     count: 1
   - value: Silicon Graphics Computer Systems, Inc.
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The Open Group
     count: 1

--- a/tests/cluecode/data/copyrights/mergesort_java-MergeSort_java.java.yml
+++ b/tests/cluecode/data/copyrights/mergesort_java-MergeSort_java.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/copyrights/name_sign_year_correct-c.c.yml
+++ b/tests/cluecode/data/copyrights/name_sign_year_correct-c.c.yml
@@ -9,5 +9,5 @@ holders:
   - Daisy Ltd.
   - Daisy
 holders_summary:
-  - value: Daisy Ltd.
+  - value: Daisy
     count: 2

--- a/tests/cluecode/data/copyrights/ncurses_bin-ncurses_bin.copyright.yml
+++ b/tests/cluecode/data/copyrights/ncurses_bin-ncurses_bin.copyright.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/openoffice_org_report_builder_bin.copyright.yml
+++ b/tests/cluecode/data/copyrights/openoffice_org_report_builder_bin.copyright.yml
@@ -310,17 +310,17 @@ holders:
 holders_summary:
   - value: The Apache Software Foundation
     count: 11
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 8
   - value: Netscape Communications Corporation
     count: 4
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 4
   - value: TWAIN Working Group
     count: 4
   - value: The OpenSSL Project
     count: 4
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 3
   - value: World Wide Web Consortium
     count: 3
@@ -347,8 +347,6 @@ holders_summary:
   - value: David Reveman
     count: 2
   - value: Eric Young
-    count: 2
-  - value: Hewlett-Packard, Inc.
     count: 2
   - value: James Clark
     count: 2
@@ -420,6 +418,10 @@ holders_summary:
     count: 1
   - value: Henrik Just
     count: 1
+  - value: Hewlett Packard, Inc
+    count: 1
+  - value: Hewlett-Packard
+    count: 1
   - value: INRIA, France Telecom
     count: 1
   - value: International Business Machines Corporation and others
@@ -460,7 +462,7 @@ holders_summary:
     count: 1
   - value: Software in the Public Interest, Inc.
     count: 1
-  - value: SuSE, Inc.
+  - value: SuSE
     count: 1
   - value: Tavmjong Bah
     count: 1

--- a/tests/cluecode/data/copyrights/rda.c.yml
+++ b/tests/cluecode/data/copyrights/rda.c.yml
@@ -61,7 +61,7 @@ holders_summary:
     count: 1
   - value: Facebook Technologies, LLC and its affiliates
     count: 1
-  - value: Google Inc.
+  - value: Google
     count: 1
   - value: Jean-loup Gailly and Mark Adler
     count: 1

--- a/tests/cluecode/data/copyrights/red_hat_openoffice_org_report_builder_bin-openoffice_org_report_builder_bin.copyright.yml
+++ b/tests/cluecode/data/copyrights/red_hat_openoffice_org_report_builder_bin-openoffice_org_report_builder_bin.copyright.yml
@@ -9,5 +9,5 @@ holders:
   - Red Hat, Inc
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 2

--- a/tests/cluecode/data/copyrights/redhatref-RedHatref.yml
+++ b/tests/cluecode/data/copyrights/redhatref-RedHatref.yml
@@ -11,7 +11,7 @@ holders:
   - Red Hat, Inc. and others
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 2
   - value: Red Hat, Inc. and others
     count: 1

--- a/tests/cluecode/data/copyrights/seahorse_plugins-seahorse_plugins.copyright.yml
+++ b/tests/cluecode/data/copyrights/seahorse_plugins-seahorse_plugins.copyright.yml
@@ -113,7 +113,7 @@ holders_summary:
     count: 1
   - value: Frederic Peters
     count: 1
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: GNOME i18n Project for Vietnamese
     count: 1
@@ -143,7 +143,7 @@ holders_summary:
     count: 1
   - value: Peter Mattis , Spencer Kimball and Josh MacDonald
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Robert Bihlmeyer
     count: 1

--- a/tests/cluecode/data/copyrights/sissl_v1_1refa-SISSL_v_refa.1refa.yml
+++ b/tests/cluecode/data/copyrights/sissl_v1_1refa-SISSL_v_refa.1refa.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/copyrights/tcl-tcl.copyright.yml
+++ b/tests/cluecode/data/copyrights/tcl-tcl.copyright.yml
@@ -10,7 +10,7 @@ holders:
   - the Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation
   - Software in the Public Interest
 holders_summary:
-  - value: Software in the Public Interest, Inc.
+  - value: Software in the Public Interest
     count: 1
   - value: the Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation
     count: 1

--- a/tests/cluecode/data/copyrights/texinfo_tex-texinfo_tex.tex.yml
+++ b/tests/cluecode/data/copyrights/texinfo_tex-texinfo_tex.tex.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/thirdpartyproject_prop-ThirdPartyProject_prop.prop.yml
+++ b/tests/cluecode/data/copyrights/thirdpartyproject_prop-ThirdPartyProject_prop.prop.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/copyrights/trailing_redistribution-bspatch_c.c.yml
+++ b/tests/cluecode/data/copyrights/trailing_redistribution-bspatch_c.c.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Colin Percival
 holders_summary:
-  - value: Colin Percival
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Colin Percival
     count: 1

--- a/tests/cluecode/data/copyrights/ttf_malayalam_fonts-ttf_malayalam_fonts.copyright.yml
+++ b/tests/cluecode/data/copyrights/ttf_malayalam_fonts-ttf_malayalam_fonts.copyright.yml
@@ -45,7 +45,7 @@ holders_summary:
   - value: Rachana Akshara Vedi Chitrajakumar R , Hussain KH , Rajeev Sebastian , Gangadharan
       N , Vijayakumaran Nair , Subash Kuraiakose
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Suresh P
     count: 1

--- a/tests/cluecode/data/copyrights/two_digits_years-digits_c.c.yml
+++ b/tests/cluecode/data/copyrights/two_digits_years-digits_c.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/copyrights/web_app_dtd_b_sun-web_app_dtd.dtd.yml
+++ b/tests/cluecode/data/copyrights/web_app_dtd_b_sun-web_app_dtd.dtd.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/copyrights/web_app_dtd_sun_twice-web_app_b_dtd.dtd.yml
+++ b/tests/cluecode/data/copyrights/web_app_dtd_sun_twice-web_app_b_dtd.dtd.yml
@@ -10,7 +10,7 @@ holders:
   - Sun Microsystems, Inc., 901 San Antonio Road, Palo Alto, California 94303, U.S.A.
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: Sun Microsystems, Inc., 901 San Antonio Road, Palo Alto, California 94303, U.S.A.
     count: 1

--- a/tests/cluecode/data/copyrights/xfonts_utils-xfonts_utils.copyright.yml
+++ b/tests/cluecode/data/copyrights/xfonts_utils-xfonts_utils.copyright.yml
@@ -41,7 +41,7 @@ holders_summary:
     count: 3
   - value: Juliusz Chroboczek
     count: 2
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 2
   - value: Steve Langasek
     count: 2

--- a/tests/cluecode/data/holders/holder_in_license-COPYING_gpl.gpl.yml
+++ b/tests/cluecode/data/holders/holder_in_license-COPYING_gpl.gpl.yml
@@ -5,5 +5,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/holders/holder_mergesort_java-MergeSort_java.java.yml
+++ b/tests/cluecode/data/holders/holder_mergesort_java-MergeSort_java.java.yml
@@ -4,5 +4,5 @@ what:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/android-mock-livetests-com-google-android-testing-mocking-test/AndroidManifest.xml.yml
+++ b/tests/cluecode/data/ics/android-mock-livetests-com-google-android-testing-mocking-test/AndroidManifest.xml.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/android-mock-src-com-google-android-testing-mocking/AndroidMock.java.yml
+++ b/tests/cluecode/data/ics/android-mock-src-com-google-android-testing-mocking/AndroidMock.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/android-mock-src-com-google-android-testing-mocking/GeneratedMockJar.readme.yml
+++ b/tests/cluecode/data/ics/android-mock-src-com-google-android-testing-mocking/GeneratedMockJar.readme.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/android-mock/Android.mk.yml
+++ b/tests/cluecode/data/ics/android-mock/Android.mk.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/android-mock/NOTICE.yml
+++ b/tests/cluecode/data/ics/android-mock/NOTICE.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/android-mock/regenerate_from_source.sh.yml
+++ b/tests/cluecode/data/ics/android-mock/regenerate_from_source.sh.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/antlr/Android.mk.yml
+++ b/tests/cluecode/data/ics/antlr/Android.mk.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/apache-http/CleanSpec.mk.yml
+++ b/tests/cluecode/data/ics/apache-http/CleanSpec.mk.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/apache-http/ThirdPartyProject.prop.yml
+++ b/tests/cluecode/data/ics/apache-http/ThirdPartyProject.prop.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/apache-xml/NOTICE.yml
+++ b/tests/cluecode/data/ics/apache-xml/NOTICE.yml
@@ -35,7 +35,7 @@ holders_summary:
     count: 4
   - value: IBM Corporation
     count: 3
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 3
   - value: Lotus Development Corporation
     count: 1

--- a/tests/cluecode/data/ics/astl-include/algorithm.yml
+++ b/tests/cluecode/data/ics/astl-include/algorithm.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/astl-include/basic_ios.h.yml
+++ b/tests/cluecode/data/ics/astl-include/basic_ios.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/astl-include/streambuf.yml
+++ b/tests/cluecode/data/ics/astl-include/streambuf.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/astl-include/string.yml
+++ b/tests/cluecode/data/ics/astl-include/string.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/astl-src/ostream.cpp.yml
+++ b/tests/cluecode/data/ics/astl-src/ostream.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/astl-tests/test_vector.cpp.yml
+++ b/tests/cluecode/data/ics/astl-tests/test_vector.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/astl/Android.mk.yml
+++ b/tests/cluecode/data/ics/astl/Android.mk.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/astl/NOTICE.yml
+++ b/tests/cluecode/data/ics/astl/NOTICE.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/bison-build-aux/config.guess.yml
+++ b/tests/cluecode/data/ics/bison-build-aux/config.guess.yml
@@ -11,5 +11,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/bison-build-aux/config.rpath.yml
+++ b/tests/cluecode/data/ics/bison-build-aux/config.rpath.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-build-aux/depcomp.yml
+++ b/tests/cluecode/data/ics/bison-build-aux/depcomp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-build-aux/mdate-sh.yml
+++ b/tests/cluecode/data/ics/bison-build-aux/mdate-sh.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-build-aux/missing.yml
+++ b/tests/cluecode/data/ics/bison-build-aux/missing.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-build-aux/texinfo.tex.yml
+++ b/tests/cluecode/data/ics/bison-build-aux/texinfo.tex.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-build-aux/ylwrap.yml
+++ b/tests/cluecode/data/ics/bison-build-aux/ylwrap.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-data-m4sugar/m4sugar.m4.yml
+++ b/tests/cluecode/data/ics/bison-data-m4sugar/m4sugar.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-data/Makefile.am.yml
+++ b/tests/cluecode/data/ics/bison-data/Makefile.am.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-data/README.yml
+++ b/tests/cluecode/data/ics/bison-data/README.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-data/c++.m4.yml
+++ b/tests/cluecode/data/ics/bison-data/c++.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-djgpp/Makefile.maint.yml
+++ b/tests/cluecode/data/ics/bison-djgpp/Makefile.maint.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-djgpp/README.in.yml
+++ b/tests/cluecode/data/ics/bison-djgpp/README.in.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-djgpp/config.bat.yml
+++ b/tests/cluecode/data/ics/bison-djgpp/config.bat.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-djgpp/config.sed.yml
+++ b/tests/cluecode/data/ics/bison-djgpp/config.sed.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-djgpp/subpipe.h.yml
+++ b/tests/cluecode/data/ics/bison-djgpp/subpipe.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-doc/Makefile.am.yml
+++ b/tests/cluecode/data/ics/bison-doc/Makefile.am.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-doc/bison.texinfo.yml
+++ b/tests/cluecode/data/ics/bison-doc/bison.texinfo.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-doc/fdl.texi.yml
+++ b/tests/cluecode/data/ics/bison-doc/fdl.texi.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-doc/gpl.texi.yml
+++ b/tests/cluecode/data/ics/bison-doc/gpl.texi.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/bison-doc/refcard.tex.yml
+++ b/tests/cluecode/data/ics/bison-doc/refcard.tex.yml
@@ -11,5 +11,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 3

--- a/tests/cluecode/data/ics/bison-examples/Makefile.am.yml
+++ b/tests/cluecode/data/ics/bison-examples/Makefile.am.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-examples/extexi.yml
+++ b/tests/cluecode/data/ics/bison-examples/extexi.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/Makefile.am.yml
+++ b/tests/cluecode/data/ics/bison-lib/Makefile.am.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/abitset.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/abitset.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/abitset.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/abitset.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/argmatch.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/argmatch.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/argmatch.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/argmatch.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/basename.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/basename.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/bbitset.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/bbitset.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/bitset.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/bitset.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/bitset.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/bitset.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/bitsetv-print.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/bitsetv-print.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/bitsetv.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/bitsetv.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/dirname.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/dirname.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/dirname.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/dirname.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/dup-safer.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/dup-safer.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/error.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/error.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/error.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/error.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/exit.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/exit.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/exitfail.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/exitfail.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/get-errno.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/get-errno.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/getopt.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/getopt.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/getopt1.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/getopt1.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/getopt_.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/getopt_.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/getopt_int.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/getopt_int.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/gettext.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/gettext.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/hard-locale.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/hard-locale.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/hard-locale.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/hard-locale.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/hash.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/hash.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/hash.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/hash.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/malloc.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/malloc.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/mbswidth.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/mbswidth.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/mbswidth.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/mbswidth.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/obstack.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/obstack.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/obstack.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/obstack.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/quote.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/quote.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/quote.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/quote.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/quotearg.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/quotearg.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/quotearg.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/quotearg.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/stdbool_.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/stdbool_.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/stdio-safer.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/stdio-safer.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/stpcpy.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/stpcpy.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/stpcpy.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/stpcpy.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/strdup.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/strdup.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/strdup.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/strdup.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/strerror.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/strerror.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/stripslash.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/stripslash.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/strndup.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/strndup.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/strndup.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/strndup.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/strtol.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/strtol.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/strtoul.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/strtoul.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/strverscmp.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/strverscmp.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/strverscmp.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/strverscmp.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/subpipe.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/subpipe.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/subpipe.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/subpipe.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/timevar.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/timevar.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/timevar.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/timevar.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/unistd-safer.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/unistd-safer.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/unlocked-io.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/unlocked-io.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/xalloc-die.c.yml
+++ b/tests/cluecode/data/ics/bison-lib/xalloc-die.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-lib/xalloc.h.yml
+++ b/tests/cluecode/data/ics/bison-lib/xalloc.h.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/bison-i18n.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/bison-i18n.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/c-working.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/c-working.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/cxx.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/cxx.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/dirname.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/dirname.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/dos.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/dos.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/error.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/error.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/exitfail.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/exitfail.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/extensions.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/extensions.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/gettext_gl.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/gettext_gl.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/iconv.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/iconv.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/inttypes_h_gl.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/inttypes_h_gl.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/lib-ld_gl.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/lib-ld_gl.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/lib-link.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/lib-link.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/m4.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/m4.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/mbrtowc.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/mbrtowc.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/mbstate_t.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/mbstate_t.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/mbswidth.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/mbswidth.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/nls.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/nls.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/obstack.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/obstack.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/onceonly.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/onceonly.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/progtest.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/progtest.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/quotearg.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/quotearg.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/stdbool.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/stdbool.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/stdio-safer.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/stdio-safer.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/stpcpy.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/stpcpy.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/strndup.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/strndup.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/strtol.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/strtol.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/ulonglong_gl.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/ulonglong_gl.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/unlocked-io.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/unlocked-io.m4.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/warning.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/warning.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-m4/xstrndup.m4.yml
+++ b/tests/cluecode/data/ics/bison-m4/xstrndup.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/LR0.c.yml
+++ b/tests/cluecode/data/ics/bison-src/LR0.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/LR0.h.yml
+++ b/tests/cluecode/data/ics/bison-src/LR0.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/assoc.c.yml
+++ b/tests/cluecode/data/ics/bison-src/assoc.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/closure.c.yml
+++ b/tests/cluecode/data/ics/bison-src/closure.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/closure.h.yml
+++ b/tests/cluecode/data/ics/bison-src/closure.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/complain.c.yml
+++ b/tests/cluecode/data/ics/bison-src/complain.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/complain.h.yml
+++ b/tests/cluecode/data/ics/bison-src/complain.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/conflicts.c.yml
+++ b/tests/cluecode/data/ics/bison-src/conflicts.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/conflicts.h.yml
+++ b/tests/cluecode/data/ics/bison-src/conflicts.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/derives.c.yml
+++ b/tests/cluecode/data/ics/bison-src/derives.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/files.c.yml
+++ b/tests/cluecode/data/ics/bison-src/files.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/getargs.c.yml
+++ b/tests/cluecode/data/ics/bison-src/getargs.c.yml
@@ -10,5 +10,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/bison-src/getargs.h.yml
+++ b/tests/cluecode/data/ics/bison-src/getargs.h.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/gram.c.yml
+++ b/tests/cluecode/data/ics/bison-src/gram.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/gram.h.yml
+++ b/tests/cluecode/data/ics/bison-src/gram.h.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/lalr.c.yml
+++ b/tests/cluecode/data/ics/bison-src/lalr.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/lalr.h.yml
+++ b/tests/cluecode/data/ics/bison-src/lalr.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/main.c.yml
+++ b/tests/cluecode/data/ics/bison-src/main.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/muscle_tab.c.yml
+++ b/tests/cluecode/data/ics/bison-src/muscle_tab.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/muscle_tab.h.yml
+++ b/tests/cluecode/data/ics/bison-src/muscle_tab.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/nullable.c.yml
+++ b/tests/cluecode/data/ics/bison-src/nullable.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/nullable.h.yml
+++ b/tests/cluecode/data/ics/bison-src/nullable.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/output.c.yml
+++ b/tests/cluecode/data/ics/bison-src/output.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/output.h.yml
+++ b/tests/cluecode/data/ics/bison-src/output.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/parse-gram.c.yml
+++ b/tests/cluecode/data/ics/bison-src/parse-gram.c.yml
@@ -10,5 +10,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/bison-src/parse-gram.h.yml
+++ b/tests/cluecode/data/ics/bison-src/parse-gram.h.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/print.c.yml
+++ b/tests/cluecode/data/ics/bison-src/print.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/print.h.yml
+++ b/tests/cluecode/data/ics/bison-src/print.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/reader.c.yml
+++ b/tests/cluecode/data/ics/bison-src/reader.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/reader.h.yml
+++ b/tests/cluecode/data/ics/bison-src/reader.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/reduce.c.yml
+++ b/tests/cluecode/data/ics/bison-src/reduce.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/scan-skel.c.yml
+++ b/tests/cluecode/data/ics/bison-src/scan-skel.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/scan-skel.l.yml
+++ b/tests/cluecode/data/ics/bison-src/scan-skel.l.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/state.h.yml
+++ b/tests/cluecode/data/ics/bison-src/state.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/symtab.c.yml
+++ b/tests/cluecode/data/ics/bison-src/symtab.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/symtab.h.yml
+++ b/tests/cluecode/data/ics/bison-src/symtab.h.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/system.h.yml
+++ b/tests/cluecode/data/ics/bison-src/system.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/uniqstr.c.yml
+++ b/tests/cluecode/data/ics/bison-src/uniqstr.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-src/vcg.h.yml
+++ b/tests/cluecode/data/ics/bison-src/vcg.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/Makefile.am.yml
+++ b/tests/cluecode/data/ics/bison-tests/Makefile.am.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/actions.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/actions.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/atconfig.yml
+++ b/tests/cluecode/data/ics/bison-tests/atconfig.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/atlocal.yml
+++ b/tests/cluecode/data/ics/bison-tests/atlocal.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/c++.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/c++.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/calc.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/calc.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/conflicts.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/conflicts.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/cxx-type.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/cxx-type.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/existing.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/existing.at.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/glr-regression.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/glr-regression.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/headers.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/headers.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/local.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/local.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/output.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/output.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/sets.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/sets.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/synclines.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/synclines.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/testsuite.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/testsuite.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison-tests/torture.at.yml
+++ b/tests/cluecode/data/ics/bison-tests/torture.at.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/Android.mk.yml
+++ b/tests/cluecode/data/ics/bison/Android.mk.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/bison/COPYING.yml
+++ b/tests/cluecode/data/ics/bison/COPYING.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/bison/ChangeLog.yml
+++ b/tests/cluecode/data/ics/bison/ChangeLog.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/GNUmakefile.yml
+++ b/tests/cluecode/data/ics/bison/GNUmakefile.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/INSTALL.yml
+++ b/tests/cluecode/data/ics/bison/INSTALL.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/Makefile.am.yml
+++ b/tests/cluecode/data/ics/bison/Makefile.am.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/Makefile.cfg.yml
+++ b/tests/cluecode/data/ics/bison/Makefile.cfg.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/Makefile.maint.yml
+++ b/tests/cluecode/data/ics/bison/Makefile.maint.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/Makefile.yml
+++ b/tests/cluecode/data/ics/bison/Makefile.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/NEWS.yml
+++ b/tests/cluecode/data/ics/bison/NEWS.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/NOTICE.yml
+++ b/tests/cluecode/data/ics/bison/NOTICE.yml
@@ -11,5 +11,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 3

--- a/tests/cluecode/data/ics/bison/PACKAGING.yml
+++ b/tests/cluecode/data/ics/bison/PACKAGING.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/README.yml
+++ b/tests/cluecode/data/ics/bison/README.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/TODO.yml
+++ b/tests/cluecode/data/ics/bison/TODO.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/aclocal.m4.yml
+++ b/tests/cluecode/data/ics/bison/aclocal.m4.yml
@@ -42,7 +42,7 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 17
 copyrights_summary:
   - value: Copyright (c) Free Software Foundation, Inc.

--- a/tests/cluecode/data/ics/bison/config.log.yml
+++ b/tests/cluecode/data/ics/bison/config.log.yml
@@ -13,5 +13,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 4

--- a/tests/cluecode/data/ics/bison/config.status.yml
+++ b/tests/cluecode/data/ics/bison/config.status.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/bison/configure.ac.yml
+++ b/tests/cluecode/data/ics/bison/configure.ac.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bison/configure.yml
+++ b/tests/cluecode/data/ics/bison/configure.yml
@@ -13,5 +13,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 4

--- a/tests/cluecode/data/ics/blktrace-btt/NOTICE.yml
+++ b/tests/cluecode/data/ics/blktrace-btt/NOTICE.yml
@@ -25,5 +25,5 @@ holders_summary:
     count: 4
   - value: Alan D. Brunelle
     count: 2
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/blktrace/NOTICE.yml
+++ b/tests/cluecode/data/ics/blktrace/NOTICE.yml
@@ -27,7 +27,7 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 3
   - value: Jens Axboe
     count: 2

--- a/tests/cluecode/data/ics/blktrace/strverscmp.c.yml
+++ b/tests/cluecode/data/ics/blktrace/strverscmp.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-bluez-audio/android_audio_hw.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-bluez-audio/android_audio_hw.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-bluez-common/android_bluez.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-bluez-common/android_bluez.c.yml
@@ -9,7 +9,7 @@ holders:
   - Marcel Holtmann
   - The Android Open Source Project
 holders_summary:
-  - value: Marcel Holtmann
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Marcel Holtmann
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-bluez-gdbus/NOTICE.yml
+++ b/tests/cluecode/data/ics/bluetooth-bluez-gdbus/NOTICE.yml
@@ -11,7 +11,7 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2
   - value: Marcel Holtmann
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-bluez-lib/NOTICE.yml
+++ b/tests/cluecode/data/ics/bluetooth-bluez-lib/NOTICE.yml
@@ -27,7 +27,7 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2
   - value: Marcel Holtmann
     count: 2

--- a/tests/cluecode/data/ics/bluetooth-bluez-src/NOTICE.yml
+++ b/tests/cluecode/data/ics/bluetooth-bluez-src/NOTICE.yml
@@ -15,7 +15,7 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2
   - value: Marcel Holtmann
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-bluez-test/NOTICE.yml
+++ b/tests/cluecode/data/ics/bluetooth-bluez-test/NOTICE.yml
@@ -33,7 +33,7 @@ holders:
 holders_summary:
   - value: Marcel Holtmann
     count: 7
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2
   - value: Maxim Krasnyansky
     count: 2

--- a/tests/cluecode/data/ics/bluetooth-bluez-tools/NOTICE.yml
+++ b/tests/cluecode/data/ics/bluetooth-bluez-tools/NOTICE.yml
@@ -33,7 +33,7 @@ holders:
 holders_summary:
   - value: Marcel Holtmann
     count: 4
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2
   - value: Nokia Corporation
     count: 2

--- a/tests/cluecode/data/ics/bluetooth-bluez/Android.mk.yml
+++ b/tests/cluecode/data/ics/bluetooth-bluez/Android.mk.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-bluez/COPYING.LIB.yml
+++ b/tests/cluecode/data/ics/bluetooth-bluez/COPYING.LIB.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/bluetooth-bluez/NOTICE.yml
+++ b/tests/cluecode/data/ics/bluetooth-bluez/NOTICE.yml
@@ -47,7 +47,7 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 4
   - value: Marcel Holtmann
     count: 4

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-fam/fam-module.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-fam/fam-module.c.yml
@@ -9,7 +9,7 @@ holders:
   - Red Hat, Inc.
   - Sebastian Droge
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Sebastian Droge
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-fen/fen-data.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-fen/fen-data.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-fen/gfendirectorymonitor.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-fen/gfendirectorymonitor.c.yml
@@ -11,9 +11,9 @@ holders:
   - Sebastian Droge
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Sebastian Droge
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-tests/buffered-input-stream.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-tests/buffered-input-stream.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-tests/desktop-app-info.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-tests/desktop-app-info.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-win32/gwinhttpfile.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-win32/gwinhttpfile.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Novell, Inc.
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/test-mime.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/test-mime.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Jonathan Blandford
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/xdgmime.h.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/xdgmime.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Jonathan Blandford
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/xdgmimealias.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/xdgmimealias.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Matthias Clasen
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/xdgmimealias.h.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/xdgmimealias.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/xdgmimeicon.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/xdgmimeicon.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/xdgmimemagic.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio-xdgmime/xdgmimemagic.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Jonathan Blandford
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio/gappinfo.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio/gappinfo.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio/gbufferedinputstream.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio/gbufferedinputstream.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Jurg Billeter
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio/gdatainputstream.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio/gdatainputstream.c.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: Jurg Billeter
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio/gdesktopappinfo.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio/gdesktopappinfo.c.yml
@@ -9,7 +9,7 @@ holders:
   - Red Hat, Inc.
   - Ryan Lortie
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Ryan Lortie
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio/gmount.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio/gmount.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gio/gwin32mount.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gio/gwin32mount.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Hans Breuer
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib-gnulib/asnprintf.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib-gnulib/asnprintf.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib-gnulib/printf-args.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib-gnulib/printf-args.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib-gnulib/printf-parse.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib-gnulib/printf-parse.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib-gnulib/vasnprintf.h.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib-gnulib/vasnprintf.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gconvert.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gconvert.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gdatasetprivate.h.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gdatasetprivate.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gerror.h.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gerror.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gfileutils.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gfileutils.c.yml
@@ -9,7 +9,7 @@ holders:
   - Red Hat, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gkeyfile.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gkeyfile.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gkeyfile.h.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gkeyfile.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gmain.h.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gmain.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gpoll.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gpoll.c.yml
@@ -13,11 +13,11 @@ holders:
   - Red Hat, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Owen Taylor
     count: 1
   - value: Peter Mattis, Spencer Kimball and Josh MacDonald
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gqsort.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gqsort.c.yml
@@ -13,7 +13,7 @@ holders:
 holders_summary:
   - value: Eazel, Inc.
     count: 1
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Peter Mattis, Spencer Kimball and Josh MacDonald
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gstrfuncs.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gstrfuncs.c.yml
@@ -9,7 +9,7 @@ holders:
   - Peter Mattis, Spencer Kimball and Josh MacDonald
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Peter Mattis, Spencer Kimball and Josh MacDonald
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gunicode.h.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gunicode.h.yml
@@ -9,7 +9,7 @@ holders:
   - Tom Tromey
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Tom Tromey
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gunidecomp.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gunidecomp.c.yml
@@ -9,7 +9,7 @@ holders:
   - Tom Tromey
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Tom Tromey
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/guniprop.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/guniprop.c.yml
@@ -9,7 +9,7 @@ holders:
   - Tom Tromey
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Tom Tromey
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-glib/gutils.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-glib/gutils.c.yml
@@ -11,9 +11,9 @@ holders:
   - Red Hat Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Peter Mattis, Spencer Kimball and Josh MacDonald
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gobject/gboxed.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gobject/gboxed.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gobject/gclosure.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gobject/gclosure.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Imendio AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gobject/gsourceclosure.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gobject/gsourceclosure.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-gobject/gtypemodule.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-gobject/gtypemodule.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-m4macros/glib-gettext.m4.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-m4macros/glib-gettext.m4.yml
@@ -9,7 +9,7 @@ holders:
   - Free Software Foundation, Inc.
   - Red Hat, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-tests-gobject/accumulator.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-tests-gobject/accumulator.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-tests-gobject/override.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-tests-gobject/override.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: James Henstridge
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-tests-gobject/references.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-tests-gobject/references.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-tests-gobject/testcommon.h.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-tests-gobject/testcommon.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib-tests/hash-test.c.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib-tests/hash-test.c.yml
@@ -9,7 +9,7 @@ holders:
   - Peter Mattis, Spencer Kimball and Josh MacDonald
   - The Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Peter Mattis, Spencer Kimball and Josh MacDonald
     count: 1

--- a/tests/cluecode/data/ics/bluetooth-glib/COPYING.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib/COPYING.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/bluetooth-glib/acinclude.m4.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib/acinclude.m4.yml
@@ -21,5 +21,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 8

--- a/tests/cluecode/data/ics/bluetooth-glib/glib-gettextize.in.yml
+++ b/tests/cluecode/data/ics/bluetooth-glib/glib-gettextize.in.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/bouncycastle-src-main-java-org-bouncycastle-crypto-digests/OpenSSLDigest.java.yml
+++ b/tests/cluecode/data/ics/bouncycastle-src-main-java-org-bouncycastle-crypto-digests/OpenSSLDigest.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/chromium-android-ui-base-l10n/l10n_util.cc.yml
+++ b/tests/cluecode/data/ics/chromium-android-ui-base-l10n/l10n_util.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/chromium-android/prefix.h.yml
+++ b/tests/cluecode/data/ics/chromium-android/prefix.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/chromium-base-third_party-dmg_fp/ThirdPartyProject.prop.yml
+++ b/tests/cluecode/data/ics/chromium-base-third_party-dmg_fp/ThirdPartyProject.prop.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-base-third_party-dynamic_annotations/dynamic_annotations.c.yml
+++ b/tests/cluecode/data/ics/chromium-base-third_party-dynamic_annotations/dynamic_annotations.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-base-third_party-nspr/prcpucfg.h.yml
+++ b/tests/cluecode/data/ics/chromium-base-third_party-nspr/prcpucfg.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-base-third_party-nspr/prtime.cc.yml
+++ b/tests/cluecode/data/ics/chromium-base-third_party-nspr/prtime.cc.yml
@@ -9,7 +9,7 @@ holders:
   - Google Inc
   - the Initial Developer
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1
   - value: the Initial Developer
     count: 1

--- a/tests/cluecode/data/ics/chromium-base/md5.cc.yml
+++ b/tests/cluecode/data/ics/chromium-base/md5.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-build/install-build-deps.sh.yml
+++ b/tests/cluecode/data/ics/chromium-build/install-build-deps.sh.yml
@@ -15,7 +15,7 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 4
   - value: The Chromium Authors
     count: 1

--- a/tests/cluecode/data/ics/chromium-chrome-browser-resources/about_credits.html.yml
+++ b/tests/cluecode/data/ics/chromium-chrome-browser-resources/about_credits.html.yml
@@ -216,9 +216,9 @@ holders:
   - Jean-loup Gailly and Mark Adler
   - Sun Microsystems Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 11
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 8
   - value: the Initial Developer
     count: 6
@@ -234,7 +234,7 @@ holders_summary:
     count: 2
   - value: Netscape Communications Corporation
     count: 2
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 2
   - value: The Khronos Group Inc.
     count: 2
@@ -257,7 +257,7 @@ holders_summary:
     count: 1
   - value: Chih-Hao Tsai Beckman Institute, University of Illinois
     count: 1
-  - value: Cisco Systems, Inc.
+  - value: Cisco Systems
     count: 1
   - value: Colin Percival
     count: 1
@@ -330,7 +330,7 @@ holders_summary:
     count: 1
   - value: Peter Johnson and other Yasm developers
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Remco Treffkorn, and others
     count: 1

--- a/tests/cluecode/data/ics/chromium-chrome-browser-userfeedback-proto/annotations.proto.yml
+++ b/tests/cluecode/data/ics/chromium-chrome-browser-userfeedback-proto/annotations.proto.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-chrome-browser-userfeedback-proto/chrome.proto.yml
+++ b/tests/cluecode/data/ics/chromium-chrome-browser-userfeedback-proto/chrome.proto.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-chrome-common-extensions-docs-examples-apps-hello-php/NOTICE.yml
+++ b/tests/cluecode/data/ics/chromium-chrome-common-extensions-docs-examples-apps-hello-php/NOTICE.yml
@@ -15,7 +15,7 @@ holders:
 holders_summary:
   - value: Andy Smith
     count: 1
-  - value: Google Inc.
+  - value: Google
     count: 1
   - value: John Resig
     count: 1

--- a/tests/cluecode/data/ics/chromium-chrome-common-extensions-docs-examples-apps-hello-php/popuplib.js.yml
+++ b/tests/cluecode/data/ics/chromium-chrome-common-extensions-docs-examples-apps-hello-php/popuplib.js.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-chrome-common-extensions-docs-examples-extensions-benchmark-jst/jsevalcontext.js.yml
+++ b/tests/cluecode/data/ics/chromium-chrome-common-extensions-docs-examples-extensions-benchmark-jst/jsevalcontext.js.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-chrome-common-extensions-docs-examples-extensions-wave/background.html.yml
+++ b/tests/cluecode/data/ics/chromium-chrome-common-extensions-docs-examples-extensions-wave/background.html.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-googleurl-base/basictypes.h.yml
+++ b/tests/cluecode/data/ics/chromium-googleurl-base/basictypes.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-googleurl-base/logging.cc.yml
+++ b/tests/cluecode/data/ics/chromium-googleurl-base/logging.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-googleurl-base/logging.h.yml
+++ b/tests/cluecode/data/ics/chromium-googleurl-base/logging.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-googleurl-src/gurl_unittest.cc.yml
+++ b/tests/cluecode/data/ics/chromium-googleurl-src/gurl_unittest.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-googleurl-src/url_canon_ip.cc.yml
+++ b/tests/cluecode/data/ics/chromium-googleurl-src/url_canon_ip.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-googleurl-src/url_common.h.yml
+++ b/tests/cluecode/data/ics/chromium-googleurl-src/url_common.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-googleurl-src/url_test_utils.h.yml
+++ b/tests/cluecode/data/ics/chromium-googleurl-src/url_test_utils.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-googleurl/LICENSE.txt.yml
+++ b/tests/cluecode/data/ics/chromium-googleurl/LICENSE.txt.yml
@@ -9,7 +9,7 @@ holders:
   - Google Inc.
   - the Initial Developer
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1
   - value: the Initial Developer
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-man/vcdiff.1.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-man/vcdiff.1.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src-google/output_string.h.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src-google/output_string.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src-gtest/gtest.cc.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src-gtest/gtest.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src-gtest/gtest_main.cc.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src-gtest/gtest_main.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/addrcache.cc.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/addrcache.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/blockhash.cc.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/blockhash.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/blockhash_test.cc.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/blockhash_test.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/codetablewriter_interface.h.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/codetablewriter_interface.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/gflags.cc.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/gflags.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/mutex.h.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/mutex.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/rolling_hash.h.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/rolling_hash.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/vcdiff_test.sh.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-src/vcdiff_test.sh.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-vsprojects/vcdiff_test.bat.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff-vsprojects/vcdiff_test.bat.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/COPYING.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/COPYING.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/INSTALL.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/INSTALL.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/aclocal.m4.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/aclocal.m4.yml
@@ -46,5 +46,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: '19'

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/compile.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/compile.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/configure.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/configure.yml
@@ -16,5 +16,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 4

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/depcomp.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/depcomp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/ltmain.sh.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/ltmain.sh.yml
@@ -10,5 +10,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/missing.yml
+++ b/tests/cluecode/data/ics/chromium-sdch-open-vcdiff/missing.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gmock-include-gmock/gmock-cardinalities.h.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gmock-include-gmock/gmock-cardinalities.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gmock-scripts-generator-cpp/ast.py.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gmock-scripts-generator-cpp/ast.py.yml
@@ -9,7 +9,7 @@ holders:
   - Neal Norwitz
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1
   - value: Neal Norwitz
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gmock-scripts-generator-cpp/gmock_class_test.py.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gmock-scripts-generator-cpp/gmock_class_test.py.yml
@@ -9,7 +9,7 @@ holders:
   - Neal Norwitz
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1
   - value: Neal Norwitz
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gmock-scripts-generator/gmock_gen.py.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gmock-scripts-generator/gmock_gen.py.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gmock-scripts/fuse_gmock_files.py.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gmock-scripts/fuse_gmock_files.py.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gmock-scripts/gmock_doctor.py.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gmock-scripts/gmock_doctor.py.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gmock-scripts/upload.py.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gmock-scripts/upload.py.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gmock-test/gmock_test_utils.py.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gmock-test/gmock_test_utils.py.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gmock/COPYING.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gmock/COPYING.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gtest-include-gtest-internal/gtest-linked_ptr.h.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gtest-include-gtest-internal/gtest-linked_ptr.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gtest-include-gtest-internal/gtest-tuple.h.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gtest-include-gtest-internal/gtest-tuple.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gtest-samples/sample10_unittest.cc.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gtest-samples/sample10_unittest.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gtest-scripts/gen_gtest_pred_impl.py.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gtest-scripts/gen_gtest_pred_impl.py.yml
@@ -11,5 +11,5 @@ holders:
   - Google Inc.
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 3

--- a/tests/cluecode/data/ics/chromium-testing-gtest-src/gtest-port.cc.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gtest-src/gtest-port.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gtest-test/gtest-linked_ptr_test.cc.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gtest-test/gtest-linked_ptr_test.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gtest-test/gtest_catch_exceptions_test.py.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gtest-test/gtest_catch_exceptions_test.py.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gtest-test/gtest_filter_unittest.py.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gtest-test/gtest_filter_unittest.py.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-testing-gtest-test/gtest_shuffle_test.py.yml
+++ b/tests/cluecode/data/ics/chromium-testing-gtest-test/gtest_shuffle_test.py.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libevent/config.guess.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libevent/config.guess.yml
@@ -11,5 +11,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/chromium-third_party-libevent/configure.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libevent/configure.yml
@@ -16,5 +16,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 4

--- a/tests/cluecode/data/ics/chromium-third_party-libevent/evport.c.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libevent/evport.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libevent/missing.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libevent/missing.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-overrides-talk-base/logging.h.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-overrides-talk-base/logging.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/asyncfile.cc.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/asyncfile.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/asyncfile.h.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/asyncfile.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/basicpacketsocketfactory.cc.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/basicpacketsocketfactory.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/buffer.h.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/buffer.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/event.cc.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/event.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/fileutils.cc.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/fileutils.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/httpbase.cc.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/httpbase.cc.yml
@@ -9,5 +9,5 @@ holders:
   - Google Inc.
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 2

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/macconversion.cc.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/macconversion.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/macutils.cc.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/macutils.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/socketstream.h.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/socketstream.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/stringutils.cc.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-base/stringutils.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/call.cc.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/call.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/codec.h.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/codec.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/mediamonitor.cc.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/mediamonitor.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/mediamonitor.h.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/mediamonitor.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/srtpfilter.h.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/srtpfilter.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/v4llookup.cc.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/v4llookup.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/videocommon.h.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source-talk-session-phone/videocommon.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/chromium-third_party-libjingle-source/COPYING.yml
+++ b/tests/cluecode/data/ics/chromium-third_party-libjingle-source/COPYING.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/activation-exit-codes.h.yml
+++ b/tests/cluecode/data/ics/dbus-bus/activation-exit-codes.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/activation.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/activation.c.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: Imendio HB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/bus.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/bus.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/config-parser-trivial.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/config-parser-trivial.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/connection.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/connection.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/connection.h.yml
+++ b/tests/cluecode/data/ics/dbus-bus/connection.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/dbus-daemon.1.in.yml
+++ b/tests/cluecode/data/ics/dbus-bus/dbus-daemon.1.in.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/desktop-file.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/desktop-file.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/dir-watch-inotify.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/dir-watch-inotify.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Mandriva
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/dispatch.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/dispatch.c.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: Imendio HB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/driver.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/driver.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/main.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/main.c.yml
@@ -9,7 +9,7 @@ holders:
   - Red Hat, Inc.
   - Red Hat, Inc., CodeFactory AB, and others
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Red Hat, Inc., CodeFactory AB, and others
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/services.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/services.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/signals.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/signals.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-bus/utils.c.yml
+++ b/tests/cluecode/data/ics/dbus-bus/utils.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-cmake-bus/dbus-daemon.xml.yml
+++ b/tests/cluecode/data/ics/dbus-cmake-bus/dbus-daemon.xml.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-address.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-address.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-auth-util.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-auth-util.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-auth.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-auth.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-connection.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-connection.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-connection.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-connection.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-credentials-util.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-credentials-util.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-errors.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-errors.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-errors.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-errors.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-file-unix.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-file-unix.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-file.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-file.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-hash.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-hash.c.yml
@@ -18,11 +18,11 @@ holders:
   - Sun Microsystems, Inc.
   - the Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 2
   - value: The Regents of the University of California
     count: 2
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: the Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-hash.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-hash.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-internals.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-internals.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-internals.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-internals.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-keyring.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-keyring.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-keyring.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-keyring.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-marshal-basic.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-marshal-basic.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-marshal-basic.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-marshal-basic.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-marshal-recursive-util.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-marshal-recursive-util.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-md5.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-md5.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Aladdin Enterprises
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-memory.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-memory.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-message-factory.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-message-factory.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-message-private.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-message-private.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-message-util.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-message-util.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-message.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-message.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-misc.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-misc.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-nonce.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-nonce.c.yml
@@ -9,7 +9,7 @@ holders:
   - Klaralvdalens Datakonsult AB, a KDAB Group company
   - FSF
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Klaralvdalens Datakonsult AB, a KDAB Group company
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-object-tree.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-object-tree.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-protocol.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-protocol.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-server-debug-pipe.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-server-debug-pipe.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-server-socket.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-server-socket.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-server-socket.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-server-socket.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-server-win.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-server-win.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Ralf Habacker
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-server-win.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-server-win.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Ralf Habacker
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-server.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-server.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-sha.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-sha.c.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: A.M. Kuchling
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-spawn-win.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-spawn-win.c.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: Novell, Inc.
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-spawn.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-spawn.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-string-util.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-string-util.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Ralf Habacker
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-string.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-string.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Ralf Habacker
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-pthread.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-pthread.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-util-unix.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-util-unix.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-util-win.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-util-win.c.yml
@@ -13,7 +13,7 @@ holders:
 holders_summary:
   - value: CodeFactory AB
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Werner Almesberger
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-win.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-win.c.yml
@@ -31,7 +31,7 @@ holders_summary:
     count: 2
   - value: Novell, Inc.
     count: 2
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 2
   - value: Christian Ehrlicher
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-win.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-win.h.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: Novell, Inc.
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-wince-glue.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-sysdeps-wince-glue.c.yml
@@ -27,5 +27,5 @@ holders_summary:
     count: 1
   - value: Ralf Habacker
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-threads-internal.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-threads-internal.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-threads.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-threads.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-transport-protected.h.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-transport-protected.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-dbus/dbus-userdb-util.c.yml
+++ b/tests/cluecode/data/ics/dbus-dbus/dbus-userdb-util.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-test/decode-gcov.c.yml
+++ b/tests/cluecode/data/ics/dbus-test/decode-gcov.c.yml
@@ -10,7 +10,7 @@ holders:
   - Red Hat Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-tools/dbus-cleanup-sockets.1.yml
+++ b/tests/cluecode/data/ics/dbus-tools/dbus-cleanup-sockets.1.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-tools/dbus-cleanup-sockets.c.yml
+++ b/tests/cluecode/data/ics/dbus-tools/dbus-cleanup-sockets.c.yml
@@ -15,5 +15,5 @@ holders:
 holders_summary:
   - value: Michael Meeks
     count: 2
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 2

--- a/tests/cluecode/data/ics/dbus-tools/dbus-launch.c.yml
+++ b/tests/cluecode/data/ics/dbus-tools/dbus-launch.c.yml
@@ -11,7 +11,7 @@ holders:
   - Thiago Macieira
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 2
   - value: Thiago Macieira
     count: 1

--- a/tests/cluecode/data/ics/dbus-tools/dbus-print-message.c.yml
+++ b/tests/cluecode/data/ics/dbus-tools/dbus-print-message.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Philip Blundell
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-tools/dbus-uuidgen.1.yml
+++ b/tests/cluecode/data/ics/dbus-tools/dbus-uuidgen.1.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/dbus-tools/dbus-uuidgen.c.yml
+++ b/tests/cluecode/data/ics/dbus-tools/dbus-uuidgen.c.yml
@@ -9,5 +9,5 @@ holders:
   - Red Hat, Inc.
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 2

--- a/tests/cluecode/data/ics/dbus-tools/dbus-viewer.c.yml
+++ b/tests/cluecode/data/ics/dbus-tools/dbus-viewer.c.yml
@@ -9,5 +9,5 @@ holders:
   - Red Hat, Inc.
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 2

--- a/tests/cluecode/data/ics/dbus/COPYING.yml
+++ b/tests/cluecode/data/ics/dbus/COPYING.yml
@@ -11,7 +11,7 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2
   - value: Lawrence E. Rosen
     count: 1

--- a/tests/cluecode/data/ics/dbus/configure.in.yml
+++ b/tests/cluecode/data/ics/dbus/configure.in.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/dhcpcd/ifaddrs.c.yml
+++ b/tests/cluecode/data/ics/dhcpcd/ifaddrs.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/dnsmasq/COPYING-v3.yml
+++ b/tests/cluecode/data/ics/dnsmasq/COPYING-v3.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/doclava-src-com-google-doclava/AnnotationInstanceInfo.java.yml
+++ b/tests/cluecode/data/ics/doclava-src-com-google-doclava/AnnotationInstanceInfo.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/doclava-src-com-google-doclava/Doclava2.java.yml
+++ b/tests/cluecode/data/ics/doclava-src-com-google-doclava/Doclava2.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/doclava/NOTICE.yml
+++ b/tests/cluecode/data/ics/doclava/NOTICE.yml
@@ -13,5 +13,5 @@ holders:
 holders_summary:
   - value: John Resig
     count: 2
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/dropbear/configure.yml
+++ b/tests/cluecode/data/ics/dropbear/configure.yml
@@ -15,5 +15,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 5

--- a/tests/cluecode/data/ics/emma-core-java12-com-vladium-emma-report-lcov/ReportGenerator.java.yml
+++ b/tests/cluecode/data/ics/emma-core-java12-com-vladium-emma-report-lcov/ReportGenerator.java.yml
@@ -13,7 +13,7 @@ holders:
   - Vlad Roubtsov
   - Tim Baverstock
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1
   - value: Tim Baverstock
     count: 1

--- a/tests/cluecode/data/ics/emma/Android.mk.yml
+++ b/tests/cluecode/data/ics/emma/Android.mk.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/emma/test.sh.yml
+++ b/tests/cluecode/data/ics/emma/test.sh.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/expat-conftools/libtool.m4.yml
+++ b/tests/cluecode/data/ics/expat-conftools/libtool.m4.yml
@@ -10,5 +10,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/expat-conftools/ltmain.sh.yml
+++ b/tests/cluecode/data/ics/expat-conftools/ltmain.sh.yml
@@ -10,5 +10,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/expat/configure.yml
+++ b/tests/cluecode/data/ics/expat/configure.yml
@@ -16,5 +16,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 5

--- a/tests/cluecode/data/ics/eyes-free/NOTICE.yml
+++ b/tests/cluecode/data/ics/eyes-free/NOTICE.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/fdlibm/NOTICE.yml
+++ b/tests/cluecode/data/ics/fdlibm/NOTICE.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/fdlibm/configure.yml
+++ b/tests/cluecode/data/ics/fdlibm/configure.yml
@@ -11,5 +11,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 3

--- a/tests/cluecode/data/ics/fdlibm/e_acos.c.yml
+++ b/tests/cluecode/data/ics/fdlibm/e_acos.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/fdlibm/e_exp.c.yml
+++ b/tests/cluecode/data/ics/fdlibm/e_exp.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/fdlibm/k_tan.c.yml
+++ b/tests/cluecode/data/ics/fdlibm/k_tan.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/fdlibm/makefile.in.yml
+++ b/tests/cluecode/data/ics/fdlibm/makefile.in.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/flac-include-share/alloc.h.yml
+++ b/tests/cluecode/data/ics/flac-include-share/alloc.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/flac-libFLAC-ppc/Makefile.in.yml
+++ b/tests/cluecode/data/ics/flac-libFLAC-ppc/Makefile.in.yml
@@ -10,7 +10,7 @@ holders:
   - Free Software Foundation, Inc.
   - Josh Coalson
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Josh Coalson
     count: 1

--- a/tests/cluecode/data/ics/flac-libFLAC/Makefile.in.yml
+++ b/tests/cluecode/data/ics/flac-libFLAC/Makefile.in.yml
@@ -10,7 +10,7 @@ holders:
   - Free Software Foundation, Inc.
   - Josh Coalson
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Josh Coalson
     count: 1

--- a/tests/cluecode/data/ics/genext2fs/aclocal.m4.yml
+++ b/tests/cluecode/data/ics/genext2fs/aclocal.m4.yml
@@ -39,5 +39,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 16

--- a/tests/cluecode/data/ics/genext2fs/configure.yml
+++ b/tests/cluecode/data/ics/genext2fs/configure.yml
@@ -13,5 +13,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 3

--- a/tests/cluecode/data/ics/google-diff-match-patch-name-fraser-neil-plaintext/diff_match_patch.java.yml
+++ b/tests/cluecode/data/ics/google-diff-match-patch-name-fraser-neil-plaintext/diff_match_patch.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/gtest-test/gtest_filter_unittest.py.yml
+++ b/tests/cluecode/data/ics/gtest-test/gtest_filter_unittest.py.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/gtest-test/gtest_nc_test.py.yml
+++ b/tests/cluecode/data/ics/gtest-test/gtest_nc_test.py.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/guava-src-com-google-common-annotations/GwtCompatible.java.yml
+++ b/tests/cluecode/data/ics/guava-src-com-google-common-annotations/GwtCompatible.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/guava-src-com-google-common-annotations/VisibleForTesting.java.yml
+++ b/tests/cluecode/data/ics/guava-src-com-google-common-annotations/VisibleForTesting.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/guava-src-com-google-common-base/CharMatcher.java.yml
+++ b/tests/cluecode/data/ics/guava-src-com-google-common-base/CharMatcher.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/guava-src-com-google-common-base/Charsets.java.yml
+++ b/tests/cluecode/data/ics/guava-src-com-google-common-base/Charsets.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/guava-src-com-google-common-io/NullOutputStream.java.yml
+++ b/tests/cluecode/data/ics/guava-src-com-google-common-io/NullOutputStream.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/harfbuzz-contrib/harfbuzz-unicode-icu.c.yml
+++ b/tests/cluecode/data/ics/harfbuzz-contrib/harfbuzz-unicode-icu.c.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-buffer-private.h.yml
+++ b/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-buffer-private.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: David Turner and Werner Lemberg
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-dump.c.yml
+++ b/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-dump.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-global.h.yml
+++ b/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-global.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Nokia Corporation and/or its subsidiary(-ies)
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-gpos.c.yml
+++ b/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-gpos.c.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: David Turner and Werner Lemberg
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-impl.c.yml
+++ b/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-impl.c.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: Nokia Corporation and/or its subsidiary(-ies)
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-shape.h.yml
+++ b/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-shape.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-stream.c.yml
+++ b/tests/cluecode/data/ics/harfbuzz-src/harfbuzz-stream.c.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: Nokia Corporation and/or its subsidiary(-ies)
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/iproute2-include-netinet/icmp6.h.yml
+++ b/tests/cluecode/data/ics/iproute2-include-netinet/icmp6.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/iptables-extensions/libxt_AUDIT.c.yml
+++ b/tests/cluecode/data/ics/iptables-extensions/libxt_AUDIT.c.yml
@@ -9,7 +9,7 @@ holders:
   - Thomas Graf
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Thomas Graf
     count: 1

--- a/tests/cluecode/data/ics/iptables-extensions/libxt_CHECKSUM.c.yml
+++ b/tests/cluecode/data/ics/iptables-extensions/libxt_CHECKSUM.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Harald Welte
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/iptables-include-linux-netfilter/xt_AUDIT.h.yml
+++ b/tests/cluecode/data/ics/iptables-include-linux-netfilter/xt_AUDIT.h.yml
@@ -9,7 +9,7 @@ holders:
   - Thomas Graf
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Thomas Graf
     count: 1

--- a/tests/cluecode/data/ics/iptables-include-linux-netfilter/xt_CHECKSUM.h.yml
+++ b/tests/cluecode/data/ics/iptables-include-linux-netfilter/xt_CHECKSUM.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Harald Welte
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/javasqlite-src-main-native/sqlite_jni_defs.h.yml
+++ b/tests/cluecode/data/ics/javasqlite-src-main-native/sqlite_jni_defs.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/jhead/main.c.yml
+++ b/tests/cluecode/data/ics/jhead/main.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/jpeg/README.yml
+++ b/tests/cluecode/data/ics/jpeg/README.yml
@@ -19,7 +19,7 @@ holders_summary:
     count: 1
   - value: CompuServe Incorporated
     count: 1
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: M.I.T.
     count: 1

--- a/tests/cluecode/data/ics/jpeg/config.guess.yml
+++ b/tests/cluecode/data/ics/jpeg/config.guess.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/jpeg/config.sub.yml
+++ b/tests/cluecode/data/ics/jpeg/config.sub.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/jpeg/configure.yml
+++ b/tests/cluecode/data/ics/jpeg/configure.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/jpeg/jmem-android.c.yml
+++ b/tests/cluecode/data/ics/jpeg/jmem-android.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-asm-generic/tlb.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-asm-generic/tlb.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Linus Torvalds and others
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux-mtd/flashchip.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux-mtd/flashchip.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/aio_abi.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/aio_abi.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/android_alarm.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/android_alarm.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/android_pmem.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/android_pmem.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google, Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/android_power.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/android_power.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/ashmem.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/ashmem.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/ata.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/ata.h.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Jeff Garzik
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/binder.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/binder.h.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Palmsource, Inc.
 holders_summary:
-  - value: Palmsource, Inc.
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Palmsource, Inc.
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/capella_cm3602.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/capella_cm3602.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google, Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/cpcap_audio.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/cpcap_audio.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google, Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/dm-ioctl.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/dm-ioctl.h.yml
@@ -9,7 +9,7 @@ holders:
   - Sistina Software (UK) Limited
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Sistina Software (UK) Limited
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/ethtool.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/ethtool.h.yml
@@ -15,9 +15,9 @@ holders:
 holders_summary:
   - value: David S. Miller
     count: 1
-  - value: Intel Corporation
+  - value: Intel
     count: 1
   - value: Jeff Garzik
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/ion.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/ion.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google, Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/jbd.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/jbd.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/keychord.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/keychord.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google, Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/kernel-headers-original-linux/rtc.h.yml
+++ b/tests/cluecode/data/ics/kernel-headers-original-linux/rtc.h.yml
@@ -9,7 +9,7 @@ holders:
   - Hewlett-Packard Co.
   - Stephane Eranian
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: Stephane Eranian
     count: 1

--- a/tests/cluecode/data/ics/libffi-darwin-x86/ffi.h.yml
+++ b/tests/cluecode/data/ics/libffi-darwin-x86/ffi.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-darwin-x86/ffitarget.h.yml
+++ b/tests/cluecode/data/ics/libffi-darwin-x86/ffitarget.h.yml
@@ -9,7 +9,7 @@ holders:
   - Red Hat, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-doc/libffi.texi.yml
+++ b/tests/cluecode/data/ics/libffi-doc/libffi.texi.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-include/ffi.h.in.yml
+++ b/tests/cluecode/data/ics/libffi-include/ffi.h.in.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-include/ffi_common.h.yml
+++ b/tests/cluecode/data/ics/libffi-include/ffi_common.h.yml
@@ -9,7 +9,7 @@ holders:
   - Red Hat, Inc.
   - Free Software Foundation, Inc
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-alpha/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-alpha/ffi.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-alpha/ffitarget.h.yml
+++ b/tests/cluecode/data/ics/libffi-src-alpha/ffitarget.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-arm/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-arm/ffi.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-cris/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-cris/ffi.c.yml
@@ -17,7 +17,7 @@ holders_summary:
     count: 1
   - value: Cygnus Solutions
     count: 1
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Simon Posnjak
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-frv/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-frv/ffi.c.yml
@@ -13,7 +13,7 @@ holders:
 holders_summary:
   - value: Anthony Green
     count: 1
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-frv/ffitarget.h.yml
+++ b/tests/cluecode/data/ics/libffi-src-frv/ffitarget.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-ia64/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-ia64/ffi.c.yml
@@ -9,7 +9,7 @@ holders:
   - Red Hat, Inc.
   - Hewlett Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-ia64/ia64_flags.h.yml
+++ b/tests/cluecode/data/ics/libffi-src-ia64/ia64_flags.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-m32r/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-m32r/ffi.c.yml
@@ -9,7 +9,7 @@ holders:
   - Renesas Technology
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Renesas Technology
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-mips/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-mips/ffi.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: David Daney
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-pa/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-pa/ffi.c.yml
@@ -11,9 +11,9 @@ holders:
   - Red Hat, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Randolph Chung
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-powerpc/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-powerpc/ffi.c.yml
@@ -11,9 +11,9 @@ holders:
   - Free Software Foundation, Inc
   - Red Hat, Inc
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Geoffrey Keating
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-powerpc/ffi_darwin.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-powerpc/ffi_darwin.c.yml
@@ -11,7 +11,7 @@ holders:
   - John Hornkvist
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Geoffrey Keating
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-powerpc/ffitarget.h.yml
+++ b/tests/cluecode/data/ics/libffi-src-powerpc/ffitarget.h.yml
@@ -9,7 +9,7 @@ holders:
   - Red Hat, Inc.
   - Free Software Foundation, Inc
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-s390/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-s390/ffi.c.yml
@@ -9,7 +9,7 @@ holders:
   - Software AG
   - Red Hat, Inc
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Software AG
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-sh/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-sh/ffi.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Kaz Kojima
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-sparc/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-sparc/ffi.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-x86/ffi.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-x86/ffi.c.yml
@@ -17,11 +17,11 @@ holders:
 holders_summary:
   - value: Bo Thorsen
     count: 1
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Ranjit Mathew
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Roger Sayle
     count: 1

--- a/tests/cluecode/data/ics/libffi-src-x86/ffi64.c.yml
+++ b/tests/cluecode/data/ics/libffi-src-x86/ffi64.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Bo Thorsen
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src/closures.c.yml
+++ b/tests/cluecode/data/ics/libffi-src/closures.c.yml
@@ -9,7 +9,7 @@ holders:
   - Red Hat, Inc.
   - Free Software Foundation, Inc
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src/debug.c.yml
+++ b/tests/cluecode/data/ics/libffi-src/debug.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src/java_raw_api.c.yml
+++ b/tests/cluecode/data/ics/libffi-src/java_raw_api.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src/prep_cif.c.yml
+++ b/tests/cluecode/data/ics/libffi-src/prep_cif.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src/raw_api.c.yml
+++ b/tests/cluecode/data/ics/libffi-src/raw_api.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-src/types.c.yml
+++ b/tests/cluecode/data/ics/libffi-src/types.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/libffi-testsuite-lib/libffi-dg.exp.yml
+++ b/tests/cluecode/data/ics/libffi-testsuite-lib/libffi-dg.exp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/libffi-testsuite-lib/target-libpath.exp.yml
+++ b/tests/cluecode/data/ics/libffi-testsuite-lib/target-libpath.exp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/libffi-testsuite-lib/wrapper.exp.yml
+++ b/tests/cluecode/data/ics/libffi-testsuite-lib/wrapper.exp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/libffi-testsuite/run-all-tests.yml
+++ b/tests/cluecode/data/ics/libffi-testsuite/run-all-tests.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/libffi/Android.mk.yml
+++ b/tests/cluecode/data/ics/libffi/Android.mk.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/libffi/aclocal.m4.yml
+++ b/tests/cluecode/data/ics/libffi/aclocal.m4.yml
@@ -50,5 +50,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 21

--- a/tests/cluecode/data/ics/libffi/configure.yml
+++ b/tests/cluecode/data/ics/libffi/configure.yml
@@ -16,5 +16,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 4

--- a/tests/cluecode/data/ics/libffi/depcomp.yml
+++ b/tests/cluecode/data/ics/libffi/depcomp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/libffi/ltcf-c.sh.yml
+++ b/tests/cluecode/data/ics/libffi/ltcf-c.sh.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/libffi/ltcf-cxx.sh.yml
+++ b/tests/cluecode/data/ics/libffi/ltcf-cxx.sh.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/libffi/ltconfig.yml
+++ b/tests/cluecode/data/ics/libffi/ltconfig.yml
@@ -11,5 +11,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 3

--- a/tests/cluecode/data/ics/libffi/ltmain.sh.yml
+++ b/tests/cluecode/data/ics/libffi/ltmain.sh.yml
@@ -10,5 +10,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/libffi/missing.yml
+++ b/tests/cluecode/data/ics/libffi/missing.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/libpcap/config.guess.yml
+++ b/tests/cluecode/data/ics/libpcap/config.guess.yml
@@ -11,5 +11,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/libpcap/grammar.c.yml
+++ b/tests/cluecode/data/ics/libpcap/grammar.c.yml
@@ -11,7 +11,7 @@ holders:
   - Free Software Foundation, Inc.
   - The Regents of the University of California
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: The Regents of the University of California
     count: 1

--- a/tests/cluecode/data/ics/libpcap/tokdefs.h.yml
+++ b/tests/cluecode/data/ics/libpcap/tokdefs.h.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/libvpx/LICENSE.yml
+++ b/tests/cluecode/data/ics/libvpx/LICENSE.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/mesa3d-include-pixelflinger2/pixelflinger2_interface.h.yml
+++ b/tests/cluecode/data/ics/mesa3d-include-pixelflinger2/pixelflinger2_interface.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/mesa3d-src-glsl-glcpp/glcpp-parse.c.yml
+++ b/tests/cluecode/data/ics/mesa3d-src-glsl-glcpp/glcpp-parse.c.yml
@@ -10,7 +10,7 @@ holders:
   - Free Software Foundation, Inc.
   - Intel Corporation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Intel Corporation
     count: 1

--- a/tests/cluecode/data/ics/mesa3d-src-glsl/glsl_parser.cpp.yml
+++ b/tests/cluecode/data/ics/mesa3d-src-glsl/glsl_parser.cpp.yml
@@ -10,7 +10,7 @@ holders:
   - Free Software Foundation, Inc.
   - Intel Corporation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1
   - value: Intel Corporation
     count: 1

--- a/tests/cluecode/data/ics/mesa3d-src-glsl/glsl_parser.h.yml
+++ b/tests/cluecode/data/ics/mesa3d-src-glsl/glsl_parser.h.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/mesa3d-src-pixelflinger2/pixelflinger2.cpp.yml
+++ b/tests/cluecode/data/ics/mesa3d-src-pixelflinger2/pixelflinger2.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/mesa3d-test/egl.cpp.yml
+++ b/tests/cluecode/data/ics/mesa3d-test/egl.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/mesa3d/NOTICE.yml
+++ b/tests/cluecode/data/ics/mesa3d/NOTICE.yml
@@ -21,11 +21,11 @@ holders_summary:
     count: 1
   - value: Alexander Chemeris
     count: 1
+  - value: Android Open Source Project
+    count: 1
   - value: Brian Paul
     count: 1
   - value: Luca Barbieri
-    count: 1
-  - value: The Android Open Source Project, Inc.
     count: 1
   - value: VMware, Inc.
     count: 1

--- a/tests/cluecode/data/ics/mtpd/NOTICE.yml
+++ b/tests/cluecode/data/ics/mtpd/NOTICE.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/mtpd/l2tp.c.yml
+++ b/tests/cluecode/data/ics/mtpd/l2tp.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/netperf/MODULE_LICENSE_HP.yml
+++ b/tests/cluecode/data/ics/netperf/MODULE_LICENSE_HP.yml
@@ -9,5 +9,5 @@ holders:
   - Hewlett-Packard Company
   - Hewlett-Packard Co.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 2

--- a/tests/cluecode/data/ics/netperf/netcpu_kstat10.c.yml
+++ b/tests/cluecode/data/ics/netperf/netcpu_kstat10.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/netcpu_none.c.yml
+++ b/tests/cluecode/data/ics/netperf/netcpu_none.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/netlib.c.yml
+++ b/tests/cluecode/data/ics/netperf/netlib.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/netlib.h.yml
+++ b/tests/cluecode/data/ics/netperf/netlib.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/netperf.c.yml
+++ b/tests/cluecode/data/ics/netperf/netperf.c.yml
@@ -11,5 +11,5 @@ holders:
   - Hewlett-Packard Co.
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 3

--- a/tests/cluecode/data/ics/netperf/netserver.c.yml
+++ b/tests/cluecode/data/ics/netperf/netserver.c.yml
@@ -11,6 +11,6 @@ holders:
   - Hewlett-Packard Co.
   - Hewlett-Packard Co.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 3
 notes: may fail on Co. vs Company.

--- a/tests/cluecode/data/ics/netperf/netsh.h.yml
+++ b/tests/cluecode/data/ics/netperf/netsh.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/nettest_bsd.c.yml
+++ b/tests/cluecode/data/ics/netperf/nettest_bsd.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Co.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/nettest_bsd.h.yml
+++ b/tests/cluecode/data/ics/netperf/nettest_bsd.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/nettest_dlpi.c.yml
+++ b/tests/cluecode/data/ics/netperf/nettest_dlpi.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Co.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/nettest_dlpi.h.yml
+++ b/tests/cluecode/data/ics/netperf/nettest_dlpi.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/nettest_sctp.c.yml
+++ b/tests/cluecode/data/ics/netperf/nettest_sctp.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Co.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/nettest_sctp.h.yml
+++ b/tests/cluecode/data/ics/netperf/nettest_sctp.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/nettest_sdp.c.yml
+++ b/tests/cluecode/data/ics/netperf/nettest_sdp.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Co.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/nettest_sdp.h.yml
+++ b/tests/cluecode/data/ics/netperf/nettest_sdp.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/nettest_unix.c.yml
+++ b/tests/cluecode/data/ics/netperf/nettest_unix.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Co.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/nettest_xti.c.yml
+++ b/tests/cluecode/data/ics/netperf/nettest_xti.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Co.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/netperf/nettest_xti.h.yml
+++ b/tests/cluecode/data/ics/netperf/nettest_xti.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/neven/FaceDetector_jni.cpp.yml
+++ b/tests/cluecode/data/ics/neven/FaceDetector_jni.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/neven/NOTICE.yml
+++ b/tests/cluecode/data/ics/neven/NOTICE.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/oauth-core-src-main-java-net-oauth-signature/RSA_SHA1.java.yml
+++ b/tests/cluecode/data/ics/oauth-core-src-main-java-net-oauth-signature/RSA_SHA1.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google, Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/oauth-core-src-main-java-net-oauth/OAuthException.java.yml
+++ b/tests/cluecode/data/ics/oauth-core-src-main-java-net-oauth/OAuthException.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google, Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/opencv-cxcore-include/cvwimage.h.yml
+++ b/tests/cluecode/data/ics/opencv-cxcore-include/cvwimage.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/opencv/NOTICE.yml
+++ b/tests/cluecode/data/ics/opencv/NOTICE.yml
@@ -63,7 +63,7 @@ holders_summary:
     count: 2
   - value: Chih-Chung Chang and Chih-Jen Lin
     count: 1
-  - value: Google Inc.
+  - value: Google
     count: 1
   - value: Liu Liu
     count: 1

--- a/tests/cluecode/data/ics/openssl-apps/ecparam.c.yml
+++ b/tests/cluecode/data/ics/openssl-apps/ecparam.c.yml
@@ -9,7 +9,7 @@ holders:
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-apps/s_server.c.yml
+++ b/tests/cluecode/data/ics/openssl-apps/s_server.c.yml
@@ -19,7 +19,7 @@ holders_summary:
     count: 1
   - value: Nokia
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-apps/speed.c.yml
+++ b/tests/cluecode/data/ics/openssl-apps/speed.c.yml
@@ -13,7 +13,7 @@ holders:
 holders_summary:
   - value: Eric Young
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-bn/bn.h.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-bn/bn.h.yml
@@ -15,7 +15,7 @@ holders:
 holders_summary:
   - value: Eric Young
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-bn/bn_gf2m.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-bn/bn_gf2m.c.yml
@@ -9,7 +9,7 @@ holders:
   - Sun Microsystems, Inc.
   - The OpenSSL Project
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-des/rpc_des.h.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-des/rpc_des.h.yml
@@ -13,7 +13,7 @@ holders:
 holders_summary:
   - value: Eric Young
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-ec/ec.h.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-ec/ec.h.yml
@@ -9,7 +9,7 @@ holders:
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-ec/ec2_mult.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-ec/ec2_mult.c.yml
@@ -9,7 +9,7 @@ holders:
   - Sun Microsystems, Inc.
   - The OpenSSL Project
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-ec/ec2_smpl.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-ec/ec2_smpl.c.yml
@@ -9,7 +9,7 @@ holders:
   - Sun Microsystems, Inc.
   - The OpenSSL Project
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-ec/ec_curve.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-ec/ec_curve.c.yml
@@ -9,7 +9,7 @@ holders:
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-ec/ec_mult.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-ec/ec_mult.c.yml
@@ -9,7 +9,7 @@ holders:
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-ec/ecp_mont.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-ec/ecp_mont.c.yml
@@ -9,7 +9,7 @@ holders:
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-ec/ecp_nist.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-ec/ecp_nist.c.yml
@@ -9,7 +9,7 @@ holders:
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-ec/ecp_smpl.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-ec/ecp_smpl.c.yml
@@ -9,7 +9,7 @@ holders:
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-ecdh/ecdh.h.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-ecdh/ecdh.h.yml
@@ -9,7 +9,7 @@ holders:
   - Sun Microsystems, Inc.
   - The OpenSSL Project
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-ecdsa/ecdsatest.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-ecdsa/ecdsatest.c.yml
@@ -9,7 +9,7 @@ holders:
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-engine/eng_fat.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-engine/eng_fat.c.yml
@@ -9,7 +9,7 @@ holders:
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-engine/engine.h.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-engine/engine.h.yml
@@ -9,7 +9,7 @@ holders:
   - The OpenSSL Project
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto-x509/x509.h.yml
+++ b/tests/cluecode/data/ics/openssl-crypto-x509/x509.h.yml
@@ -13,7 +13,7 @@ holders:
 holders_summary:
   - value: Eric Young
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: Tim Hudson
     count: 1

--- a/tests/cluecode/data/ics/openssl-crypto/cryptlib.c.yml
+++ b/tests/cluecode/data/ics/openssl-crypto/cryptlib.c.yml
@@ -15,7 +15,7 @@ holders:
 holders_summary:
   - value: Eric Young
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-include-openssl/ssl.h.yml
+++ b/tests/cluecode/data/ics/openssl-include-openssl/ssl.h.yml
@@ -19,7 +19,7 @@ holders_summary:
     count: 1
   - value: Nokia
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-include-openssl/ssl3.h.yml
+++ b/tests/cluecode/data/ics/openssl-include-openssl/ssl3.h.yml
@@ -15,7 +15,7 @@ holders:
 holders_summary:
   - value: Eric Young
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-include-openssl/tls1.h.yml
+++ b/tests/cluecode/data/ics/openssl-include-openssl/tls1.h.yml
@@ -19,7 +19,7 @@ holders_summary:
     count: 1
   - value: Nokia
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/s3_lib.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/s3_lib.c.yml
@@ -19,7 +19,7 @@ holders_summary:
     count: 1
   - value: Nokia
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/ssl_cert.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/ssl_cert.c.yml
@@ -15,7 +15,7 @@ holders:
 holders_summary:
   - value: Eric Young
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/openssl-ssl/ssltest.c.yml
+++ b/tests/cluecode/data/ics/openssl-ssl/ssltest.c.yml
@@ -19,7 +19,7 @@ holders_summary:
     count: 1
   - value: Nokia
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: The OpenSSL Project
     count: 1

--- a/tests/cluecode/data/ics/oprofile-daemon/init.c.yml
+++ b/tests/cluecode/data/ics/oprofile-daemon/init.c.yml
@@ -9,7 +9,7 @@ holders:
   - OProfile
   - Hewlett-Packard Co.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: OProfile
     count: 1

--- a/tests/cluecode/data/ics/oprofile-daemon/opd_trans.c.yml
+++ b/tests/cluecode/data/ics/oprofile-daemon/opd_trans.c.yml
@@ -11,7 +11,7 @@ holders:
   - Hewlett-Packard Co.
   - IBM Corporation
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: IBM Corporation
     count: 1

--- a/tests/cluecode/data/ics/oprofile-daemon/oprofiled.c.yml
+++ b/tests/cluecode/data/ics/oprofile-daemon/oprofiled.c.yml
@@ -9,7 +9,7 @@ holders:
   - OProfile
   - Hewlett-Packard Co.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: OProfile
     count: 1

--- a/tests/cluecode/data/ics/oprofile-include/sstream.yml
+++ b/tests/cluecode/data/ics/oprofile-include/sstream.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/oprofile-libpopt/findme.c.yml
+++ b/tests/cluecode/data/ics/oprofile-libpopt/findme.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/oprofile-opcontrol/opcontrol.cpp.yml
+++ b/tests/cluecode/data/ics/oprofile-opcontrol/opcontrol.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/oprofile/popt.h.yml
+++ b/tests/cluecode/data/ics/oprofile/popt.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/ppp-pppd/NOTICE.yml
+++ b/tests/cluecode/data/ics/ppp-pppd/NOTICE.yml
@@ -39,6 +39,8 @@ holders:
 holders_summary:
   - value: Paul Mackerras
     count: 7
+  - value: Android Open Source Project
+    count: 1
   - value: Carnegie Mellon University
     count: 1
   - value: Eric Rosenquist
@@ -51,9 +53,7 @@ holders_summary:
     count: 1
   - value: RSA Data Security, Inc.
     count: 1
-  - value: Sun Microsystems, Inc.
-    count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Sun Microsystems
     count: 1
   - value: Tommi Komulainen
     count: 1

--- a/tests/cluecode/data/ics/ppp-pppd/chap_ms.c.yml
+++ b/tests/cluecode/data/ics/ppp-pppd/chap_ms.c.yml
@@ -9,7 +9,7 @@ holders:
   - Eric Rosenquist
   - The Android Open Source Project
 holders_summary:
-  - value: Eric Rosenquist
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Eric Rosenquist
     count: 1

--- a/tests/cluecode/data/ics/ppp-pppd/eap.c.yml
+++ b/tests/cluecode/data/ics/ppp-pppd/eap.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/ppp-pppd/ecp.c.yml
+++ b/tests/cluecode/data/ics/ppp-pppd/ecp.c.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Paul Mackerras
 holders_summary:
-  - value: Paul Mackerras
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Paul Mackerras
     count: 1

--- a/tests/cluecode/data/ics/ppp-pppd/ecp.h.yml
+++ b/tests/cluecode/data/ics/ppp-pppd/ecp.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/ppp-pppd/pppd.8.yml
+++ b/tests/cluecode/data/ics/ppp-pppd/pppd.8.yml
@@ -27,17 +27,17 @@ holders:
 holders_summary:
   - value: Paul Mackerras
     count: 2
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 2
   - value: Andrew Tridgell
+    count: 1
+  - value: Android Open Source Project
     count: 1
   - value: Carnegie Mellon University
     count: 1
   - value: Eric Rosenquist
     count: 1
   - value: Pedro Roque Marques
-    count: 1
-  - value: The Android Open Source Project, Inc.
     count: 1
   - value: Tommi Komulainen
     count: 1

--- a/tests/cluecode/data/ics/ppp-pppd/sys-solaris.c.yml
+++ b/tests/cluecode/data/ics/ppp-pppd/sys-solaris.c.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: Paul Mackerras
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/proguard-docs/GPL.html.yml
+++ b/tests/cluecode/data/ics/proguard-docs/GPL.html.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/proguard/NOTICE.yml
+++ b/tests/cluecode/data/ics/proguard/NOTICE.yml
@@ -11,7 +11,7 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2
   - value: Eric Lafortune
     count: 1

--- a/tests/cluecode/data/ics/protobuf-editors/proto.vim.yml
+++ b/tests/cluecode/data/ics/protobuf-editors/proto.vim.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/protobuf-gtest-scons/SConscript.yml
+++ b/tests/cluecode/data/ics/protobuf-gtest-scons/SConscript.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/protobuf-gtest/aclocal.m4.yml
+++ b/tests/cluecode/data/ics/protobuf-gtest/aclocal.m4.yml
@@ -61,5 +61,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 26

--- a/tests/cluecode/data/ics/protobuf-java-src-main-java-com-google-protobuf/AbstractMessage.java.yml
+++ b/tests/cluecode/data/ics/protobuf-java-src-main-java-com-google-protobuf/AbstractMessage.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/protobuf-m4/libtool.m4.yml
+++ b/tests/cluecode/data/ics/protobuf-m4/libtool.m4.yml
@@ -13,5 +13,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 3

--- a/tests/cluecode/data/ics/protobuf-m4/ltoptions.m4.yml
+++ b/tests/cluecode/data/ics/protobuf-m4/ltoptions.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/protobuf-m4/ltsugar.m4.yml
+++ b/tests/cluecode/data/ics/protobuf-m4/ltsugar.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/protobuf-m4/ltversion.m4.yml
+++ b/tests/cluecode/data/ics/protobuf-m4/ltversion.m4.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/protobuf-src-google-protobuf-compiler-javamicro/javamicro_params.h.yml
+++ b/tests/cluecode/data/ics/protobuf-src-google-protobuf-compiler-javamicro/javamicro_params.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/protobuf-src-google-protobuf-io/tokenizer.cc.yml
+++ b/tests/cluecode/data/ics/protobuf-src-google-protobuf-io/tokenizer.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/protobuf-src-google-protobuf-stubs/structurally_valid.cc.yml
+++ b/tests/cluecode/data/ics/protobuf-src-google-protobuf-stubs/structurally_valid.cc.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/protobuf/INSTALL.txt.yml
+++ b/tests/cluecode/data/ics/protobuf/INSTALL.txt.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/protobuf/README.txt.yml
+++ b/tests/cluecode/data/ics/protobuf/README.txt.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/protobuf/aclocal.m4.yml
+++ b/tests/cluecode/data/ics/protobuf/aclocal.m4.yml
@@ -41,5 +41,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 17

--- a/tests/cluecode/data/ics/protobuf/configure.yml
+++ b/tests/cluecode/data/ics/protobuf/configure.yml
@@ -16,5 +16,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 4

--- a/tests/cluecode/data/ics/protobuf/ltmain.sh.yml
+++ b/tests/cluecode/data/ics/protobuf/ltmain.sh.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/qemu-android-utils/mapfile.c.yml
+++ b/tests/cluecode/data/ics/qemu-android-utils/mapfile.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/qemu-android/android.h.yml
+++ b/tests/cluecode/data/ics/qemu-android/android.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/qemu-android/main-common.c.yml
+++ b/tests/cluecode/data/ics/qemu-android/main-common.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/qemu-android/main.c.yml
+++ b/tests/cluecode/data/ics/qemu-android/main.c.yml
@@ -9,5 +9,5 @@ holders:
   - The Android Open Source Project
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 2

--- a/tests/cluecode/data/ics/qemu-android/qemu-setup.c.yml
+++ b/tests/cluecode/data/ics/qemu-android/qemu-setup.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/qemu-android/snapshot.c.yml
+++ b/tests/cluecode/data/ics/qemu-android/snapshot.c.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Fabrice Bellard
 holders_summary:
-  - value: Fabrice Bellard
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Fabrice Bellard
     count: 1

--- a/tests/cluecode/data/ics/qemu-audio/alsaaudio.c.yml
+++ b/tests/cluecode/data/ics/qemu-audio/alsaaudio.c.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Vassili Karpov
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1
   - value: Vassili Karpov
     count: 1

--- a/tests/cluecode/data/ics/qemu-audio/audio.c.yml
+++ b/tests/cluecode/data/ics/qemu-audio/audio.c.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Vassili Karpov
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1
   - value: Vassili Karpov
     count: 1

--- a/tests/cluecode/data/ics/qemu-audio/coreaudio.c.yml
+++ b/tests/cluecode/data/ics/qemu-audio/coreaudio.c.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Mike Kronenberg
 holders_summary:
-  - value: Mike Kronenberg
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Mike Kronenberg
     count: 1

--- a/tests/cluecode/data/ics/qemu-audio/esdaudio.c.yml
+++ b/tests/cluecode/data/ics/qemu-audio/esdaudio.c.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Frederick Reeve
 holders_summary:
-  - value: Frederick Reeve
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Frederick Reeve
     count: 1

--- a/tests/cluecode/data/ics/qemu-audio/wavaudio.c.yml
+++ b/tests/cluecode/data/ics/qemu-audio/wavaudio.c.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Vassili Karpov
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1
   - value: Vassili Karpov
     count: 1

--- a/tests/cluecode/data/ics/qemu-audio/winaudio.c.yml
+++ b/tests/cluecode/data/ics/qemu-audio/winaudio.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/qemu-distrib-sdl-1.2.12-src-hermes/COPYING.LIB.yml
+++ b/tests/cluecode/data/ics/qemu-distrib-sdl-1.2.12-src-hermes/COPYING.LIB.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/qemu-distrib-sdl-1.2.12/COPYING.yml
+++ b/tests/cluecode/data/ics/qemu-distrib-sdl-1.2.12/COPYING.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/qemu-elff/dwarf.h.yml
+++ b/tests/cluecode/data/ics/qemu-elff/dwarf.h.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: Silicon Graphics, Inc.
     count: 1
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/qemu-gdb-xml/arm-core.xml.yml
+++ b/tests/cluecode/data/ics/qemu-gdb-xml/arm-core.xml.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/qemu-gdb-xml/power-altivec.xml.yml
+++ b/tests/cluecode/data/ics/qemu-gdb-xml/power-altivec.xml.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/qemu-hw/mmc.h.yml
+++ b/tests/cluecode/data/ics/qemu-hw/mmc.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1

--- a/tests/cluecode/data/ics/qemu-pc-bios-bochs/configure.yml
+++ b/tests/cluecode/data/ics/qemu-pc-bios-bochs/configure.yml
@@ -15,5 +15,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 4

--- a/tests/cluecode/data/ics/qemu-slirp-android/helper.h.yml
+++ b/tests/cluecode/data/ics/qemu-slirp-android/helper.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/qemu/a.out.h.yml
+++ b/tests/cluecode/data/ics/qemu/a.out.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/qemu/acl.c.yml
+++ b/tests/cluecode/data/ics/qemu/acl.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/qemu/android-trace.h.yml
+++ b/tests/cluecode/data/ics/qemu/android-trace.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/qemu/arm-dis.c.yml
+++ b/tests/cluecode/data/ics/qemu/arm-dis.c.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/qemu/dma-helpers.c.yml
+++ b/tests/cluecode/data/ics/qemu/dma-helpers.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/qemu/dynlink-static.c.yml
+++ b/tests/cluecode/data/ics/qemu/dynlink-static.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/qemu/dynlink.h.yml
+++ b/tests/cluecode/data/ics/qemu/dynlink.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/qemu/feature_to_c.sh.yml
+++ b/tests/cluecode/data/ics/qemu/feature_to_c.sh.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/qemu/i386-dis.c.yml
+++ b/tests/cluecode/data/ics/qemu/i386-dis.c.yml
@@ -11,5 +11,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/qemu/os-posix.c.yml
+++ b/tests/cluecode/data/ics/qemu/os-posix.c.yml
@@ -11,5 +11,5 @@ holders:
 holders_summary:
   - value: Fabrice Bellard
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/qemu/ppc-dis.c.yml
+++ b/tests/cluecode/data/ics/qemu/ppc-dis.c.yml
@@ -14,5 +14,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 3

--- a/tests/cluecode/data/ics/qemu/qdict.c.yml
+++ b/tests/cluecode/data/ics/qemu/qdict.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/qemu/qemu-error.c.yml
+++ b/tests/cluecode/data/ics/qemu/qemu-error.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/qemu/qemu-io.c.yml
+++ b/tests/cluecode/data/ics/qemu/qemu-io.c.yml
@@ -9,7 +9,7 @@ holders:
   - Red Hat, Inc.
   - Silicon Graphics, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1
   - value: Silicon Graphics, Inc.
     count: 1

--- a/tests/cluecode/data/ics/qemu/qemu-thread.c.yml
+++ b/tests/cluecode/data/ics/qemu/qemu-thread.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Red Hat, Inc.
 holders_summary:
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/qemu/softmmu_outside_jit.c.yml
+++ b/tests/cluecode/data/ics/qemu/softmmu_outside_jit.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/qemu/tcpdump.c.yml
+++ b/tests/cluecode/data/ics/qemu/tcpdump.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/qemu/vnc-android.c.yml
+++ b/tests/cluecode/data/ics/qemu/vnc-android.c.yml
@@ -15,5 +15,5 @@ holders_summary:
     count: 1
   - value: Fabrice Bellard
     count: 1
-  - value: Red Hat, Inc.
+  - value: Red Hat
     count: 1

--- a/tests/cluecode/data/ics/quake-quake-src/gnu.txt.yml
+++ b/tests/cluecode/data/ics/quake-quake-src/gnu.txt.yml
@@ -9,5 +9,5 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/quake-src-com-android-quake/QuakeActivity.java.yml
+++ b/tests/cluecode/data/ics/quake-src-com-android-quake/QuakeActivity.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/quake-src-com-android-quake/QuakeLib.java.yml
+++ b/tests/cluecode/data/ics/quake-src-com-android-quake/QuakeLib.java.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/quake-src-com-android-quake/QuakeView.java.yml
+++ b/tests/cluecode/data/ics/quake-src-com-android-quake/QuakeView.java.yml
@@ -9,5 +9,5 @@ holders:
   - The Android Open Source Project
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 2

--- a/tests/cluecode/data/ics/quake/AndroidManifest.xml.yml
+++ b/tests/cluecode/data/ics/quake/AndroidManifest.xml.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/quake/NOTICE.yml
+++ b/tests/cluecode/data/ics/quake/NOTICE.yml
@@ -15,7 +15,7 @@ holders:
   - Free Software Foundation, Inc.
   - the Free Software Foundation
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 4
   - value: Id Software Inc.
     count: 1

--- a/tests/cluecode/data/ics/safe-iop-include/safe_iop.h.yml
+++ b/tests/cluecode/data/ics/safe-iop-include/safe_iop.h.yml
@@ -9,7 +9,7 @@ holders:
   - redpig@dataspill.org
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1
   - value: redpig@dataspill.org
     count: 1

--- a/tests/cluecode/data/ics/safe-iop-src/safe_iop.c.yml
+++ b/tests/cluecode/data/ics/safe-iop-src/safe_iop.c.yml
@@ -9,7 +9,7 @@ holders:
   - redpig@dataspill.org
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1
   - value: redpig@dataspill.org
     count: 1

--- a/tests/cluecode/data/ics/skia-emoji/EmojiFont.cpp.yml
+++ b/tests/cluecode/data/ics/skia-emoji/EmojiFont.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-gm/strokerects.cpp.yml
+++ b/tests/cluecode/data/ics/skia-gm/strokerects.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/skia-gpu-src/GrGpu.cpp.yml
+++ b/tests/cluecode/data/ics/skia-gpu-src/GrGpu.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/skia-include-core/SkBitmap.h.yml
+++ b/tests/cluecode/data/ics/skia-include-core/SkBitmap.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-include-core/SkColorPriv.h.yml
+++ b/tests/cluecode/data/ics/skia-include-core/SkColorPriv.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-include-core/SkRegion.h.yml
+++ b/tests/cluecode/data/ics/skia-include-core/SkRegion.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-include-core/SkScalar.h.yml
+++ b/tests/cluecode/data/ics/skia-include-core/SkScalar.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-include-core/SkTRegistry.h.yml
+++ b/tests/cluecode/data/ics/skia-include-core/SkTRegistry.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-include-ports/SkHarfBuzzFont.h.yml
+++ b/tests/cluecode/data/ics/skia-include-ports/SkHarfBuzzFont.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/skia-include-views/SkOSWindow_wxwidgets.h.yml
+++ b/tests/cluecode/data/ics/skia-include-views/SkOSWindow_wxwidgets.h.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - MyCompanyName
 holders_summary:
-  - value: MyCompanyName
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: MyCompanyName
     count: 1

--- a/tests/cluecode/data/ics/skia-src-animator/SkOperandIterpolator.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-animator/SkOperandIterpolator.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-src-core/SkBitmap.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-core/SkBitmap.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-src-core/SkBlitter_4444.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-core/SkBlitter_4444.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-src-core/SkColorTable.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-core/SkColorTable.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-src-core/SkFilterProc.h.yml
+++ b/tests/cluecode/data/ics/skia-src-core/SkFilterProc.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-src-images/SkImageDecoder_libjpeg.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-images/SkImageDecoder_libjpeg.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-src-opts/opts_check_arm.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-opts/opts_check_arm.cpp.yml
@@ -9,7 +9,7 @@ holders:
   - Code Aurora Forum
   - The Android Open Source Project
 holders_summary:
-  - value: Code Aurora Forum
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Code Aurora Forum
     count: 1

--- a/tests/cluecode/data/ics/skia-src-pdf/SkPDFFont.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-pdf/SkPDFFont.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/skia-src-ports/SkDebug_brew.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-ports/SkDebug_brew.cpp.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Company 100, Inc.
 holders_summary:
-  - value: Company 100, Inc.
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Company 100, Inc.
     count: 1

--- a/tests/cluecode/data/ics/skia-src-ports/SkFontHost_fontconfig.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-ports/SkFontHost_fontconfig.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/skia-src-ports/SkFontHost_none.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-ports/SkFontHost_none.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/skia-src-ports/SkOSFile_brew.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-ports/SkOSFile_brew.cpp.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Company 100, Inc.
 holders_summary:
-  - value: Company 100, Inc.
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Company 100, Inc.
     count: 1

--- a/tests/cluecode/data/ics/skia-src-ports/SkXMLParser_empty.cpp.yml
+++ b/tests/cluecode/data/ics/skia-src-ports/SkXMLParser_empty.cpp.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Skia Inc.
 holders_summary:
-  - value: Skia Inc.
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Skia Inc.
     count: 1

--- a/tests/cluecode/data/ics/sonivox-docs/JET_Authoring_Guidelines.html.yml
+++ b/tests/cluecode/data/ics/sonivox-docs/JET_Authoring_Guidelines.html.yml
@@ -11,9 +11,9 @@ holders:
   - The Android Open Source Project
   - Sonic Network, Inc.
 holders_summary:
-  - value: Sonic Network, Inc.
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Sonic Network, Inc.
     count: 1
   - value: techdoc.dot Jennifer Hruska
     count: 1

--- a/tests/cluecode/data/ics/sonivox-docs/JET_Creator_User_Manual.html.yml
+++ b/tests/cluecode/data/ics/sonivox-docs/JET_Creator_User_Manual.html.yml
@@ -11,9 +11,9 @@ holders:
   - The Android Open Source Project
   - Sonic Network, Inc.
 holders_summary:
+  - value: Android Open Source Project
+    count: 1
   - value: Confidential
     count: 1
   - value: Sonic Network, Inc.
-    count: 1
-  - value: The Android Open Source Project, Inc.
     count: 1

--- a/tests/cluecode/data/ics/sonivox-docs/JET_Programming_Manual.html.yml
+++ b/tests/cluecode/data/ics/sonivox-docs/JET_Programming_Manual.html.yml
@@ -9,7 +9,7 @@ holders:
   - The Android Open Source Project
   - Sonic Network, Inc.
 holders_summary:
-  - value: Sonic Network, Inc.
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Sonic Network, Inc.
     count: 1

--- a/tests/cluecode/data/ics/sonivox-jet_tools-JetCreator/JetAudition.py.yml
+++ b/tests/cluecode/data/ics/sonivox-jet_tools-JetCreator/JetAudition.py.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/srtp-crypto-cipher/aes.c.yml
+++ b/tests/cluecode/data/ics/srtp-crypto-cipher/aes.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Cisco Systems, Inc.
 holders_summary:
-  - value: Cisco Systems, Inc.
+  - value: Cisco Systems
     count: 1

--- a/tests/cluecode/data/ics/srtp-crypto-hash/hmac.c.yml
+++ b/tests/cluecode/data/ics/srtp-crypto-hash/hmac.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Cisco Systems, Inc.
 holders_summary:
-  - value: Cisco Systems, Inc.
+  - value: Cisco Systems
     count: 1

--- a/tests/cluecode/data/ics/srtp-crypto-include/auth.h.yml
+++ b/tests/cluecode/data/ics/srtp-crypto-include/auth.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Cisco Systems, Inc.
 holders_summary:
-  - value: Cisco Systems, Inc.
+  - value: Cisco Systems
     count: 1

--- a/tests/cluecode/data/ics/srtp-doc/intro.txt.yml
+++ b/tests/cluecode/data/ics/srtp-doc/intro.txt.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Cisco Systems, Inc.
 holders_summary:
-  - value: Cisco Systems, Inc.
+  - value: Cisco Systems
     count: 1

--- a/tests/cluecode/data/ics/srtp-include/ekt.h.yml
+++ b/tests/cluecode/data/ics/srtp-include/ekt.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Cisco Systems, Inc.
 holders_summary:
-  - value: Cisco Systems, Inc.
+  - value: Cisco Systems
     count: 1

--- a/tests/cluecode/data/ics/srtp/LICENSE.yml
+++ b/tests/cluecode/data/ics/srtp/LICENSE.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Cisco Systems, Inc.
 holders_summary:
-  - value: Cisco Systems, Inc.
+  - value: Cisco Systems
     count: 1

--- a/tests/cluecode/data/ics/srtp/config.guess.yml
+++ b/tests/cluecode/data/ics/srtp/config.guess.yml
@@ -11,5 +11,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 2

--- a/tests/cluecode/data/ics/srtp/config.log.yml
+++ b/tests/cluecode/data/ics/srtp/config.log.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/stlport-src/dll_main.cpp.yml
+++ b/tests/cluecode/data/ics/stlport-src/dll_main.cpp.yml
@@ -15,7 +15,7 @@ holders:
 holders_summary:
   - value: Boris Fomitchev
     count: 1
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: Moscow Center for SPARC Technology
     count: 1

--- a/tests/cluecode/data/ics/stlport-stlport-stl/_function.h.yml
+++ b/tests/cluecode/data/ics/stlport-stlport-stl/_function.h.yml
@@ -15,7 +15,7 @@ holders:
 holders_summary:
   - value: Boris Fomitchev
     count: 1
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: Moscow Center for SPARC Technology
     count: 1

--- a/tests/cluecode/data/ics/stlport-stlport-stl/_function_adaptors.h.yml
+++ b/tests/cluecode/data/ics/stlport-stlport-stl/_function_adaptors.h.yml
@@ -19,7 +19,7 @@ holders:
 holders_summary:
   - value: Boris Fomitchev
     count: 1
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: Meridian'93
     count: 1

--- a/tests/cluecode/data/ics/stlport-stlport-stl/_hash_fun.h.yml
+++ b/tests/cluecode/data/ics/stlport-stlport-stl/_hash_fun.h.yml
@@ -9,7 +9,7 @@ holders:
   - Silicon Graphics Computer Systems, Inc.
   - Hewlett-Packard Company
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: Silicon Graphics Computer Systems, Inc.
     count: 1

--- a/tests/cluecode/data/ics/stlport-stlport-stl/_heap.h.yml
+++ b/tests/cluecode/data/ics/stlport-stlport-stl/_heap.h.yml
@@ -9,7 +9,7 @@ holders:
   - Hewlett-Packard Company
   - Silicon Graphics Computer Systems, Inc.
 holders_summary:
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: Silicon Graphics Computer Systems, Inc.
     count: 1

--- a/tests/cluecode/data/ics/stlport-stlport/numeric.yml
+++ b/tests/cluecode/data/ics/stlport-stlport/numeric.yml
@@ -13,7 +13,7 @@ holders:
 holders_summary:
   - value: Boris Fomitchev
     count: 1
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: Silicon Graphics Computer Systems, Inc.
     count: 1

--- a/tests/cluecode/data/ics/stlport/LICENSE.yml
+++ b/tests/cluecode/data/ics/stlport/LICENSE.yml
@@ -15,7 +15,7 @@ holders:
 holders_summary:
   - value: Boris Fomitchev
     count: 1
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: Moscow Center for SPARC Technology
     count: 1

--- a/tests/cluecode/data/ics/stlport/README.yml
+++ b/tests/cluecode/data/ics/stlport/README.yml
@@ -15,7 +15,7 @@ holders:
 holders_summary:
   - value: Boris Fomitchev
     count: 1
-  - value: Hewlett-Packard, Inc.
+  - value: Hewlett-Packard
     count: 1
   - value: Moscow Center for SPARC Technology
     count: 1

--- a/tests/cluecode/data/ics/strace/Makefile.in.yml
+++ b/tests/cluecode/data/ics/strace/Makefile.in.yml
@@ -8,5 +8,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/strace/aclocal.m4.yml
+++ b/tests/cluecode/data/ics/strace/aclocal.m4.yml
@@ -43,5 +43,5 @@ holders:
   - Free Software Foundation, Inc.
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 18

--- a/tests/cluecode/data/ics/strace/config.log.yml
+++ b/tests/cluecode/data/ics/strace/config.log.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/strace/depcomp.yml
+++ b/tests/cluecode/data/ics/strace/depcomp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Free Software Foundation, Inc.
 holders_summary:
-  - value: Free Software Foundation, Inc.
+  - value: Free Software Foundation
     count: 1

--- a/tests/cluecode/data/ics/svox-pico-compat-jni/com_android_tts_compat_SynthProxy.cpp.yml
+++ b/tests/cluecode/data/ics/svox-pico-compat-jni/com_android_tts_compat_SynthProxy.cpp.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/svox-pico-res-xml/tts_engine.xml.yml
+++ b/tests/cluecode/data/ics/svox-pico-res-xml/tts_engine.xml.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/svox-pico-res-xml/voices_list.xml.yml
+++ b/tests/cluecode/data/ics/svox-pico-res-xml/voices_list.xml.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/svox-pico/AndroidManifest.xml.yml
+++ b/tests/cluecode/data/ics/svox-pico/AndroidManifest.xml.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/tcpdump/pmap_prot.h.yml
+++ b/tests/cluecode/data/ics/tcpdump/pmap_prot.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Sun Microsystems, Inc.
 holders_summary:
-  - value: Sun Microsystems, Inc.
+  - value: Sun Microsystems
     count: 1

--- a/tests/cluecode/data/ics/tinyxml/Android.mk.yml
+++ b/tests/cluecode/data/ics/tinyxml/Android.mk.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/webp-examples/dwebp.c.yml
+++ b/tests/cluecode/data/ics/webp-examples/dwebp.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/webp-include-webp/encode.h.yml
+++ b/tests/cluecode/data/ics/webp-include-webp/encode.h.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/webp-src-dec/Android.mk.yml
+++ b/tests/cluecode/data/ics/webp-src-dec/Android.mk.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - The Android Open Source Project
 holders_summary:
-  - value: The Android Open Source Project, Inc.
+  - value: Android Open Source Project
     count: 1

--- a/tests/cluecode/data/ics/webp-src-enc/dsp.c.yml
+++ b/tests/cluecode/data/ics/webp-src-enc/dsp.c.yml
@@ -7,5 +7,5 @@ copyrights:
 holders:
   - Google Inc.
 holders_summary:
-  - value: Google Inc.
+  - value: Google
     count: 1

--- a/tests/cluecode/data/ics/webrtc/NOTICE.yml
+++ b/tests/cluecode/data/ics/webrtc/NOTICE.yml
@@ -17,9 +17,9 @@ holders:
 holders_summary:
   - value: Takuya OOURA
     count: 2
-  - value: Steven J. Ross
+  - value: Android Open Source Project
     count: 1
-  - value: The Android Open Source Project, Inc.
+  - value: Steven J. Ross
     count: 1
   - value: The WebRTC project authors
     count: 1

--- a/tests/cluecode/data/ics/zlib-contrib-delphi/readme.txt.yml
+++ b/tests/cluecode/data/ics/zlib-contrib-delphi/readme.txt.yml
@@ -9,5 +9,5 @@ holders:
   - Borland Corp.
   - Borland
 holders_summary:
-  - value: Borland Corp.
+  - value: Borland
     count: 2

--- a/tests/summarycode/data/summary/multiple_package_data/multiple_package_data.expected.json
+++ b/tests/summarycode/data/summary/multiple_package_data/multiple_package_data.expected.json
@@ -111,7 +111,7 @@
       "conflicting_license_categories": false,
       "ambiguous_compound_licensing": false
     },
-    "declared_holder": "Demo Corporation, Example Corp.",
+    "declared_holder": "Example Corp.",
     "primary_language": "Python",
     "other_license_expressions": [
       {

--- a/tests/summarycode/data/summary/single_file/single_file.expected.json
+++ b/tests/summarycode/data/summary/single_file/single_file.expected.json
@@ -12,7 +12,7 @@
       "conflicting_license_categories": false,
       "ambiguous_compound_licensing": false
     },
-    "declared_holder": "Mort Bay Consulting Pty. Ltd. (Australia) and others, Sun Microsystems, Inc.",
+    "declared_holder": "Mort Bay Consulting Pty. Ltd. (Australia) and others, Sun Microsystems",
     "primary_language": "",
     "other_license_expressions": [],
     "other_holders": [],

--- a/tests/summarycode/data/summary/use_holder_from_package_resource/codebase/README.txt
+++ b/tests/summarycode/data/summary/use_holder_from_package_resource/codebase/README.txt
@@ -1,0 +1,1 @@
+Copyright (c) Example Corporation

--- a/tests/summarycode/data/summary/use_holder_from_package_resource/codebase/setup.py
+++ b/tests/summarycode/data/summary/use_holder_from_package_resource/codebase/setup.py
@@ -1,0 +1,32 @@
+# Copyright 2020 Google LLC
+# Copyright 2021 Fraunhofer FKIE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+setup(
+    name="atheris",
+    version=__version__,
+    author="Bitshift",
+    author_email="atheris@google.com",
+    url="https://github.com/google/atheris/",
+    description="A coverage-guided fuzzer for Python and Python extensions.",
+    long_description=open("README.md", "r").read(),
+    long_description_content_type="text/markdown",
+    packages=["atheris"],
+    package_dir={"atheris": "src"},
+    py_modules=["atheris_no_libfuzzer"],
+    ext_modules=ext_modules,
+    setup_requires=["pybind11>=2.5.0"],
+    cmdclass={"build_ext": BuildExt},
+    zip_safe=False,
+)

--- a/tests/summarycode/data/summary/use_holder_from_package_resource/use_holder_from_package_resource.expected.json
+++ b/tests/summarycode/data/summary/use_holder_from_package_resource/use_holder_from_package_resource.expected.json
@@ -75,10 +75,15 @@
       "conflicting_license_categories": false,
       "ambiguous_compound_licensing": false
     },
-    "declared_holder": "Example Corporation, Google Inc., Fraunhofer FKIE",
+    "declared_holder": "Google, Fraunhofer FKIE",
     "primary_language": "Python",
     "other_license_expressions": [],
-    "other_holders": [],
+    "other_holders": [
+      {
+        "value": "Example Corporation",
+        "count": 1
+      }
+    ],
     "other_languages": []
   },
   "files": [

--- a/tests/summarycode/data/summary/use_holder_from_package_resource/use_holder_from_package_resource.expected.json
+++ b/tests/summarycode/data/summary/use_holder_from_package_resource/use_holder_from_package_resource.expected.json
@@ -1,0 +1,331 @@
+{
+  "dependencies": [
+    {
+      "purl": "pkg:pypi/pybind11",
+      "extracted_requirement": ">=2.5.0",
+      "scope": "setup",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_resolved": false,
+      "resolved_package": {},
+      "dependency_uid": "pkg:pypi/pybind11?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:pypi/atheris?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_path": "codebase/setup.py",
+      "datasource_id": "pypi_setup_py"
+    }
+  ],
+  "packages": [
+    {
+      "type": "pypi",
+      "namespace": null,
+      "name": "atheris",
+      "version": null,
+      "qualifiers": {},
+      "subpath": null,
+      "primary_language": "Python",
+      "description": "A coverage-guided fuzzer for Python and Python extensions.",
+      "release_date": null,
+      "parties": [
+        {
+          "type": "person",
+          "role": "author",
+          "name": "Bitshift",
+          "email": null,
+          "url": null
+        }
+      ],
+      "keywords": [],
+      "homepage_url": "https://github.com/google/atheris/",
+      "download_url": null,
+      "size": null,
+      "sha1": null,
+      "md5": null,
+      "sha256": null,
+      "sha512": null,
+      "bug_tracking_url": null,
+      "code_view_url": null,
+      "vcs_url": null,
+      "copyright": null,
+      "license_expression": null,
+      "declared_license": null,
+      "notice_text": null,
+      "source_packages": [],
+      "extra_data": {},
+      "repository_homepage_url": "https://pypi.org/project/atheris",
+      "repository_download_url": null,
+      "api_data_url": "https://pypi.org/pypi/atheris/json",
+      "package_uid": "pkg:pypi/atheris?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_paths": [
+        "codebase/setup.py"
+      ],
+      "datasource_ids": [
+        "pypi_setup_py"
+      ],
+      "purl": "pkg:pypi/atheris"
+    }
+  ],
+  "summary": {
+    "declared_license_expression": "apache-2.0",
+    "license_clarity_score": {
+      "score": 100,
+      "declared_license": true,
+      "identification_precision": true,
+      "has_license_text": true,
+      "declared_copyrights": true,
+      "conflicting_license_categories": false,
+      "ambiguous_compound_licensing": false
+    },
+    "declared_holder": "Example Corporation, Google Inc., Fraunhofer FKIE",
+    "primary_language": "Python",
+    "other_license_expressions": [],
+    "other_holders": [],
+    "other_languages": []
+  },
+  "files": [
+    {
+      "path": "codebase",
+      "type": "directory",
+      "name": "codebase",
+      "base_name": "codebase",
+      "extension": "",
+      "size": 0,
+      "sha1": null,
+      "md5": null,
+      "sha256": null,
+      "mime_type": null,
+      "file_type": null,
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": false,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "percentage_of_license_text": 0,
+      "copyrights": [],
+      "holders": [],
+      "authors": [],
+      "package_data": [],
+      "for_packages": [],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": false,
+      "is_top_level": true,
+      "is_key_file": false,
+      "files_count": 2,
+      "dirs_count": 0,
+      "size_count": 1215,
+      "scan_errors": []
+    },
+    {
+      "path": "codebase/README.txt",
+      "type": "file",
+      "name": "README.txt",
+      "base_name": "README",
+      "extension": ".txt",
+      "size": 33,
+      "sha1": "49c764d8447393378fcd13c8ab69c807a3ce67e9",
+      "md5": "d5a15a5aab582d924dddd5a87a5fdca1",
+      "sha256": "44bbf9c92da0a4ae21795690dc8b9ae553f57b5b3d7a9d6ce794869a7e0542c3",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text, with no line terminators",
+      "programming_language": null,
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": false,
+      "is_script": false,
+      "licenses": [],
+      "license_expressions": [],
+      "percentage_of_license_text": 0,
+      "copyrights": [
+        {
+          "copyright": "Copyright (c) Example Corporation",
+          "start_line": 1,
+          "end_line": 1
+        }
+      ],
+      "holders": [
+        {
+          "holder": "Example Corporation",
+          "start_line": 1,
+          "end_line": 1
+        }
+      ],
+      "authors": [],
+      "package_data": [],
+      "for_packages": [
+        "pkg:pypi/atheris?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
+      "is_legal": false,
+      "is_manifest": false,
+      "is_readme": true,
+      "is_top_level": true,
+      "is_key_file": true,
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    },
+    {
+      "path": "codebase/setup.py",
+      "type": "file",
+      "name": "setup.py",
+      "base_name": "setup",
+      "extension": ".py",
+      "size": 1182,
+      "sha1": "ca26ea89aab5d6ac910fe4e092cd7c8857e62322",
+      "md5": "2761f0e079fcd2b07af5088c4712f8f0",
+      "sha256": "a047b71004e6b070d174d260b95dca5930a6ce51948e66afec25692c157408c5",
+      "mime_type": "text/plain",
+      "file_type": "ASCII text",
+      "programming_language": "Python",
+      "is_binary": false,
+      "is_text": true,
+      "is_archive": false,
+      "is_media": false,
+      "is_source": true,
+      "is_script": false,
+      "licenses": [
+        {
+          "key": "apache-2.0",
+          "score": 100.0,
+          "name": "Apache License 2.0",
+          "short_name": "Apache 2.0",
+          "category": "Permissive",
+          "is_exception": false,
+          "is_unknown": false,
+          "owner": "Apache Software Foundation",
+          "homepage_url": "http://www.apache.org/licenses/",
+          "text_url": "http://www.apache.org/licenses/LICENSE-2.0",
+          "reference_url": "https://scancode-licensedb.aboutcode.org/apache-2.0",
+          "scancode_text_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.LICENSE",
+          "scancode_data_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/licenses/apache-2.0.yml",
+          "spdx_license_key": "Apache-2.0",
+          "spdx_url": "https://spdx.org/licenses/Apache-2.0",
+          "start_line": 4,
+          "end_line": 14,
+          "matched_rule": {
+            "identifier": "apache-2.0_7.RULE",
+            "license_expression": "apache-2.0",
+            "licenses": [
+              "apache-2.0"
+            ],
+            "referenced_filenames": [],
+            "is_license_text": false,
+            "is_license_notice": true,
+            "is_license_reference": false,
+            "is_license_tag": false,
+            "is_license_intro": false,
+            "has_unknown": false,
+            "matcher": "2-aho",
+            "rule_length": 85,
+            "matched_length": 85,
+            "match_coverage": 100.0,
+            "rule_relevance": 100
+          }
+        }
+      ],
+      "license_expressions": [
+        "apache-2.0"
+      ],
+      "percentage_of_license_text": 53.12,
+      "copyrights": [
+        {
+          "copyright": "Copyright 2020 Google LLC",
+          "start_line": 1,
+          "end_line": 1
+        },
+        {
+          "copyright": "Copyright 2021 Fraunhofer FKIE",
+          "start_line": 2,
+          "end_line": 2
+        }
+      ],
+      "holders": [
+        {
+          "holder": "Google LLC",
+          "start_line": 1,
+          "end_line": 1
+        },
+        {
+          "holder": "Fraunhofer FKIE",
+          "start_line": 2,
+          "end_line": 2
+        }
+      ],
+      "authors": [],
+      "package_data": [
+        {
+          "type": "pypi",
+          "namespace": null,
+          "name": "atheris",
+          "version": null,
+          "qualifiers": {},
+          "subpath": null,
+          "primary_language": "Python",
+          "description": "A coverage-guided fuzzer for Python and Python extensions.",
+          "release_date": null,
+          "parties": [
+            {
+              "type": "person",
+              "role": "author",
+              "name": "Bitshift",
+              "email": null,
+              "url": null
+            }
+          ],
+          "keywords": [],
+          "homepage_url": "https://github.com/google/atheris/",
+          "download_url": null,
+          "size": null,
+          "sha1": null,
+          "md5": null,
+          "sha256": null,
+          "sha512": null,
+          "bug_tracking_url": null,
+          "code_view_url": null,
+          "vcs_url": null,
+          "copyright": null,
+          "license_expression": null,
+          "declared_license": {},
+          "notice_text": null,
+          "source_packages": [],
+          "file_references": [],
+          "extra_data": {},
+          "dependencies": [
+            {
+              "purl": "pkg:pypi/pybind11",
+              "extracted_requirement": ">=2.5.0",
+              "scope": "setup",
+              "is_runtime": true,
+              "is_optional": false,
+              "is_resolved": false,
+              "resolved_package": {}
+            }
+          ],
+          "repository_homepage_url": "https://pypi.org/project/atheris",
+          "repository_download_url": null,
+          "api_data_url": "https://pypi.org/pypi/atheris/json",
+          "datasource_id": "pypi_setup_py",
+          "purl": "pkg:pypi/atheris"
+        }
+      ],
+      "for_packages": [
+        "pkg:pypi/atheris?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
+      "is_legal": false,
+      "is_manifest": true,
+      "is_readme": false,
+      "is_top_level": true,
+      "is_key_file": true,
+      "files_count": 0,
+      "dirs_count": 0,
+      "size_count": 0,
+      "scan_errors": []
+    }
+  ]
+}

--- a/tests/summarycode/data/tallies/copyright_tallies/tallies2.expected.json
+++ b/tests/summarycode/data/tallies/copyright_tallies/tallies2.expected.json
@@ -16,7 +16,7 @@
         "count": 1
       },
       {
-        "value": "Sun Microsystems, Inc.",
+        "value": "Sun Microsystems",
         "count": 1
       }
     ],

--- a/tests/summarycode/test_summarizer.py
+++ b/tests/summarycode/test_summarizer.py
@@ -125,6 +125,18 @@ class TestScanSummary(FileDrivenTesting):
         ])
         check_json_scan(expected_file, result_file, remove_uuid=True, remove_file_date=True, regen=REGEN_TEST_FIXTURES)
 
+    def test_summary_use_holder_from_package_resource(self):
+        test_dir = self.get_test_loc('summary/use_holder_from_package_resource/codebase')
+        result_file = self.get_temp_file('json')
+        expected_file = self.get_test_loc('summary/use_holder_from_package_resource/use_holder_from_package_resource.expected.json')
+        run_scan_click([
+            '-clip',
+            '--summary',
+            '--classify',
+            '--json-pp', result_file, test_dir
+        ])
+        check_json_scan(expected_file, result_file, remove_uuid=True, remove_file_date=True, regen=REGEN_TEST_FIXTURES)
+
     def test_summary_clear_holder(self):
         test_dir = self.get_test_loc('summary/holders/clear_holder')
         result_file = self.get_temp_file('json')


### PR DESCRIPTION
I removed the logic that uses author or maintainers as the declared holder if no explicit copyright was detected from package data. However, I am still not sure about how I feel the `tally` functions normalize copyright holders to a different value for the sake of grouping as it can be misleading. 

Reference: https://github.com/nexB/scancode-toolkit/issues/2972