### PR TITLE
Fix relaunching scancode on Apple silicon using Rosetta 2 emulation #2835

### DIFF
--- a/configure
+++ b/configure
@@ -120,7 +120,7 @@ CFG_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/bin
 
 # force relaunching under X86-64 architecture on macOS M1/ARM 
 if [[ $OSTYPE == 'darwin'* && $(uname -m) == 'arm64' && $(sysctl -in sysctl.proc_translated) == 0 ]]; then
-    arch -x86_64 /bin/bash -c "$CFG_ROOT_DIR/configure $@"
+    arch -x86_64 /bin/bash -c "$CFG_ROOT_DIR/configure $*"
     exit $?
 fi
 

--- a/configure
+++ b/configure
@@ -119,7 +119,7 @@ CFG_ROOT_DIR="$( cd "$( dirname "${CFG_BIN}" )" && pwd )"
 CFG_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/bin
 
 # force relaunching under X86-64 architecture on macOS M1/ARM 
-if [[ $OSTYPE == 'darwin'* && $(uname -m) == 'arm64' ]]; then
+if [[ $OSTYPE == 'darwin'* && $(uname -m) == 'arm64' && $(sysctl -in sysctl.proc_translated) == 0 ]]; then
     arch -x86_64 /bin/bash -c "$CFG_ROOT_DIR/configure $@"
     exit $?
 fi

--- a/extractcode
+++ b/extractcode
@@ -121,8 +121,8 @@ SCANCODE_BIN="$( realpath "${BASH_SOURCE[0]}" )"
 SCANCODE_ROOT_DIR="$( cd "$( dirname "${SCANCODE_BIN}" )" && pwd )"
 
 # force relaunching under X86-64 architecture on macOS M1/ARM 
-if [[ $OSTYPE == 'darwin'* && $(uname -m) == 'arm64' ]]; then
-    arch -x86_64 /bin/bash -c "$SCANCODE_ROOT_DIR/$COMMAND_TO_RUN $@"
+if [[ $OSTYPE == 'darwin'* && $(uname -m) == 'arm64' && $(sysctl -in sysctl.proc_translated) == 0 ]]; then
+    arch -x86_64 /bin/bash -c "$SCANCODE_ROOT_DIR/$COMMAND_TO_RUN $*"
     exit $?
 fi
 

--- a/scancode
+++ b/scancode
@@ -122,7 +122,7 @@ SCANCODE_ROOT_DIR="$( cd "$( dirname "${SCANCODE_BIN}" )" && pwd )"
 
 # force relaunching under X86-64 architecture on macOS M1/ARM 
 if [[ $OSTYPE == 'darwin'* && $(uname -m) == 'arm64' && $(sysctl -in sysctl.proc_translated) == 0 ]]; then
-    arch -x86_64 /bin/bash -c "$SCANCODE_ROOT_DIR/$COMMAND_TO_RUN $@"
+    arch -x86_64 /bin/bash -c "$SCANCODE_ROOT_DIR/$COMMAND_TO_RUN $*"
     exit $?
 fi
 

--- a/scancode
+++ b/scancode
@@ -121,7 +121,7 @@ SCANCODE_BIN="$( realpath "${BASH_SOURCE[0]}" )"
 SCANCODE_ROOT_DIR="$( cd "$( dirname "${SCANCODE_BIN}" )" && pwd )"
 
 # force relaunching under X86-64 architecture on macOS M1/ARM 
-if [[ $OSTYPE == 'darwin'* && $(uname -m) == 'arm64' ]]; then
+if [[ $OSTYPE == 'darwin'* && $(uname -m) == 'arm64' && $(sysctl -in sysctl.proc_translated) == 0 ]]; then
     arch -x86_64 /bin/bash -c "$SCANCODE_ROOT_DIR/$COMMAND_TO_RUN $@"
     exit $?
 fi


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Related to #2835.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
