### PR TITLE
Clarify `unknown` license keys #2827

### DIFF
--- a/src/licensedcode/data/licenses/free-unknown.yml
+++ b/src/licensedcode/data/licenses/free-unknown.yml
@@ -5,4 +5,5 @@ category: Unstated License
 owner: Unspecified
 is_unknown: yes
 spdx_license_key: LicenseRef-scancode-free-unknown
-
+notes: This case applies to software with a notice that refers in a non-specific manner to a
+  free or open-source license, but where it is not possible to determine that specific license.

--- a/src/licensedcode/data/licenses/generic-cla.yml
+++ b/src/licensedcode/data/licenses/generic-cla.yml
@@ -4,5 +4,5 @@ short_name: Generic CLA
 name: Prior Generic Contributor License Agreement
 category: Unstated License
 owner: Unspecified
-notes: this is a generic license for CLAs.
 spdx_license_key: LicenseRef-scancode-generic-cla
+notes: this is a generic license for CLAs.

--- a/src/licensedcode/data/licenses/generic-exception.yml
+++ b/src/licensedcode/data/licenses/generic-exception.yml
@@ -3,8 +3,9 @@ short_name: Generic Exception Notice
 name: Generic Exception Notice
 category: Unstated License
 owner: Unspecified
-notes: this is a generic license exception notice. Actual terms are most commonly related to
-    rare, one-off extra permission to the A/L/GPL licenses
 is_exception: yes
 is_generic: yes
 spdx_license_key: LicenseRef-scancode-generic-exception
+notes: This is a generic license exception notice where the exception text has not been named
+    and published publicly. Actual terms are most commonly related to rare, one-off
+    extra permission to the A/L/GPL licenses.

--- a/src/licensedcode/data/licenses/generic-export-compliance.yml
+++ b/src/licensedcode/data/licenses/generic-export-compliance.yml
@@ -3,7 +3,7 @@ short_name: Generic Export Compliance Notice
 name: Generic Export Compliance Notice
 category: Unstated License
 owner: Unspecified
-notes: this is a generic export compliance notice. Actual terms are most commonly related to
-    cryptography
 is_generic: yes
 spdx_license_key: LicenseRef-scancode-generic-export-compliance
+notes: This is a generic export compliance notice where the text has not been named and
+    published publicly. Actual terms are most commonly related to cryptography.

--- a/src/licensedcode/data/licenses/generic-tos.yml
+++ b/src/licensedcode/data/licenses/generic-tos.yml
@@ -3,7 +3,7 @@ short_name: Generic ToS
 name: Generic Terms of Service
 category: Unstated License
 owner: Unspecified
-notes: this is a generic license for Terms of Service such as aprivary terms and and other ToS-like
-    agreement found in software but that are not directly licenses.
 is_generic: yes
 spdx_license_key: LicenseRef-scancode-generic-tos
+notes: This is a generic license for Terms of Service such as privacy terms and and other
+    ToS-like agreements found in software that are not directly licenses.

--- a/src/licensedcode/data/licenses/generic-trademark.yml
+++ b/src/licensedcode/data/licenses/generic-trademark.yml
@@ -3,11 +3,10 @@ short_name: Generic Trademark Notice
 name: Generic Trademark and Name Protection Notice
 category: Unstated License
 owner: Unspecified
-notes: this is a generic export Trademark and name realted notice. Actual terms are most commonly
-    related to name use restrictions and no endorsement. This should be used only for rare one-off
-    notices.
 is_generic: yes
 spdx_license_key: LicenseRef-scancode-generic-trademark
 other_spdx_license_keys:
     - LicenseRef-scancode-trademark-notice
-
+notes: This is a generic Trademark and name realted notice. Actual terms are most commonly
+    related to name use restrictions and no endorsement. This should be used only for rare one-off
+    notices.

--- a/src/licensedcode/data/licenses/unknown-license-reference.yml
+++ b/src/licensedcode/data/licenses/unknown-license-reference.yml
@@ -4,6 +4,7 @@ name: Unknown License file reference
 category: Unstated License
 owner: Unspecified
 is_unknown: yes
-notes: This is reference to a license file with no clear license. this was known before as "see-license"
-    and "license-file-reference"
 spdx_license_key: LicenseRef-scancode-unknown-license-reference
+notes: This applies to the case of a file with no clear license, which may be referenced
+    via URL or text such as "See license in..." or "This file is licensed under...",
+    but where the reference cannot be resolved to a specific named, public license.

--- a/src/licensedcode/data/licenses/unknown-spdx.yml
+++ b/src/licensedcode/data/licenses/unknown-spdx.yml
@@ -5,5 +5,4 @@ category: Unstated License
 owner: Unspecified
 is_unknown: yes
 spdx_license_key: LicenseRef-scancode-unknown-spdx
-notes: This is something that clearly ressembles a license in an SPDX license
- expression but is not conclusively an SPDX license ID.
+notes: This applies to an invalid reference to an SPDX license identifier.

--- a/src/licensedcode/data/licenses/unknown.yml
+++ b/src/licensedcode/data/licenses/unknown.yml
@@ -5,4 +5,5 @@ category: Unstated License
 owner: Unspecified
 is_unknown: yes
 spdx_license_key: LicenseRef-scancode-unknown
-notes: This is something that clearly ressembles a license but is not conclusive.
+notes: This applies to the case where there is text referring to a license, but it is not
+  possible to determine exactly which license.


### PR DESCRIPTION
Update the notes for license data files with `unknown` license
keys with text authored by @DennisClark. See also:
https://github.com/nexB/scancode-toolkit/issues/3021

Reference: https://github.com/nexB/scancode-toolkit/issues/2827
Signed-off-by: Ayan Sinha Mahapatra <ayansmahapatra@gmail.com>

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

