### PR TITLE
Yield Packages before other yieldables #3028

### DIFF
--- a/src/packagedcode/alpine.py
+++ b/src/packagedcode/alpine.py
@@ -92,6 +92,7 @@ class AlpineInstalledDatabaseHandler(models.DatafileHandler):
             for ref in package.file_references
         }
 
+        resources = []
         for res in root_resource.walk(codebase):
             ref = file_references_by_path.get(res.path)
             if not ref:
@@ -102,8 +103,7 @@ class AlpineInstalledDatabaseHandler(models.DatafileHandler):
             del file_references_by_path[res.path]
             res.for_packages.append(package_uid)
             res.save(codebase)
-
-            yield res
+            resources.append(res)
 
         # if we have left over file references, add these to extra data
         if file_references_by_path:
@@ -111,6 +111,7 @@ class AlpineInstalledDatabaseHandler(models.DatafileHandler):
             package.extra_data['missing_file_references'] = missing
 
         yield package
+        yield from resources
 
 
 class AlpineApkbuildHandler(models.DatafileHandler):

--- a/src/packagedcode/cocoapods.py
+++ b/src/packagedcode/cocoapods.py
@@ -164,7 +164,6 @@ class BasePodHandler(models.DatafileHandler):
 
                 for resource in sibling_podspecs:
                     datafile_path = resource.path
-                    yield resource
                     for package_data in resource.package_data:
                         package_data = models.PackageData.from_dict(package_data)
                         package = models.Package.from_package_data(
@@ -173,6 +172,7 @@ class BasePodHandler(models.DatafileHandler):
                         )
                         cls.assign_package_to_resources(package, resource, codebase)
                         yield package
+                    yield resource
 
             else:
                 # has_no_podspec:


### PR DESCRIPTION
* Update assembly method of cocoapods and pypi package
  handlers to yield Package objects before Resources and Dependencies

Referenced-by: https://github.com/nexB/scancode-toolkit/issues/3028
Signed-off-by: Jono Yang <jyang@nexb.com>

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
