### PR TITLE
Update DatafileHandler default methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,13 @@ Important API changes:
   under the ``venv`` subdirectory. You mus be aware of this if you use ScanCode
   from a git clone
 
+- ``DatafileHandler.assemble()``, ``DatafileHandler.assemble_from_many()``, and
+  the other ``.assemble()``` methods from the other Package handlers from
+  packagedcode, have been updated to yield Package items before Dependency or
+  Resource items. This is particulary important in the case where we are calling
+  the ``assemble()`` method outside of the scancode-toolkit context, where we
+  need to ensure that a Package exists before we assocate a Resource or
+  Dependency to it.
 
 Copyright detection:
 ~~~~~~~~~~~~~~~~~~~~

--- a/src/packagedcode/alpine.py
+++ b/src/packagedcode/alpine.py
@@ -81,16 +81,6 @@ class AlpineInstalledDatabaseHandler(models.DatafileHandler):
 
         package.license_expression = cls.compute_normalized_license(package)
 
-
-        dependent_packages = package_data.dependencies
-        if dependent_packages:
-            yield from models.Dependency.from_dependent_packages(
-                dependent_packages=dependent_packages,
-                datafile_path=resource.path,
-                datasource_id=package_data.datasource_id,
-                package_uid=package_uid,
-            )
-
         root_path = Path(root_resource.path)
         # a file ref extends from the root of the filesystem
         file_references_by_path = {
@@ -117,6 +107,15 @@ class AlpineInstalledDatabaseHandler(models.DatafileHandler):
 
         yield package
         yield from resources
+
+        dependent_packages = package_data.dependencies
+        if dependent_packages:
+            yield from models.Dependency.from_dependent_packages(
+                dependent_packages=dependent_packages,
+                datafile_path=resource.path,
+                datasource_id=package_data.datasource_id,
+                package_uid=package_uid,
+            )
 
 
 class AlpineApkbuildHandler(models.DatafileHandler):

--- a/src/packagedcode/debian.py
+++ b/src/packagedcode/debian.py
@@ -241,14 +241,18 @@ class DebianInstalledStatusDatabaseHandler(models.DatafileHandler):
         package_file_references.extend(package_data.file_references)
         package_uid = package.package_uid
 
+        dependencies = []
         dependent_packages = package_data.dependencies
         if dependent_packages:
-            yield from models.Dependency.from_dependent_packages(
-                dependent_packages=dependent_packages,
-                datafile_path=resource.path,
-                datasource_id=package_data.datasource_id,
-                package_uid=package_uid,
+            deps = list(
+                models.Dependency.from_dependent_packages(
+                    dependent_packages=dependent_packages,
+                    datafile_path=resource.path,
+                    datasource_id=package_data.datasource_id,
+                    package_uid=package_uid,
+                )
             )
+            dependencies.extend(deps)
 
         # Multi-Arch can be: "foreign", "same", "allowed", "all", "optional" or
         # empty/non-present. See https://wiki.debian.org/Multiarch/HOWTO
@@ -312,12 +316,15 @@ class DebianInstalledStatusDatabaseHandler(models.DatafileHandler):
             # yield possible dependencies
             dependent_packages = package_data.dependencies
             if dependent_packages:
-                yield from models.Dependency.from_dependent_packages(
-                    dependent_packages=dependent_packages,
-                    datafile_path=res.path,
-                    datasource_id=package_data.datasource_id,
-                    package_uid=package_uid,
+                deps = list(
+                    models.Dependency.from_dependent_packages(
+                        dependent_packages=dependent_packages,
+                        datafile_path=res.path,
+                        datasource_id=package_data.datasource_id,
+                        package_uid=package_uid,
+                    )
                 )
+                dependencies.extend(deps)
 
             resources.append(res)
 
@@ -353,6 +360,7 @@ class DebianInstalledStatusDatabaseHandler(models.DatafileHandler):
 
         yield package
         yield from resources
+        yield from dependencies
 
 
 class DebianDistrolessInstalledDatabaseHandler(models.DatafileHandler):

--- a/src/packagedcode/models.py
+++ b/src/packagedcode/models.py
@@ -914,6 +914,12 @@ class DatafileHandler:
           not be further processed,
         - a Dependency to add to top-level dependencies
 
+        Package items must be yielded before Dependency or Resource items. This
+        is to ensure that a Package is created before we associate a Resource or
+        Dependency to a Package. This is particulary important in the case where
+        we are calling the `assemble()` method outside of the scancode-toolkit
+        context.
+
         The approach is to find and process all the neighboring related datafiles
          to this datafile at once.
 
@@ -1037,6 +1043,13 @@ class DatafileHandler:
 
         This is a convenience method that subclasses can reuse when overriding
         `assemble()`
+
+        Like in ``DatafileHandler.assemble()``, Package items must be yielded
+        before Dependency or Resource items. This is to ensure that a Package is
+        created before we associate a Resource or Dependency to a Package. This
+        is particulary important in the case where we are calling the
+        ``assemble()`` method outside of the scancode-toolkit context, as
+        ``assemble()`` can call ``assemble_from_many()``.
 
         NOTE: ATTENTION!: this may not work well for datafile that yield
         multiple PackageData for unrelated Packages


### PR DESCRIPTION
This PR updates `DatafileHandler.assemble()` and `DatafileHandler.assemble_from_many()` to yield Packages, Dependencies, and Resources before associating Packages to Resources using a `package_adder`. This is to help with using packagedcode Package handlers in scancode.io, where a Package needs to be created in scancode.io before it can be associated with a Resource.


