### PR TITLE
Improve release scripts #3040

### DIFF
--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -170,7 +170,7 @@ jobs:
             --dest=thirdparty \
             --sdists
           venv/bin/python setup.py --quiet sdist --formats=$formats 
-          venv/bin/python etc/release/scancode_rename_archives.py dist/ _py3-$operating_system
+          venv/bin/python etc/release/scancode_rename_archives.py dist/ _py$python_version-$operating_system
 
       - name: Collect built linux app
         uses: actions/upload-artifact@v3
@@ -230,7 +230,7 @@ jobs:
             --dest=thirdparty \
             --sdists
           venv/bin/python setup.py --quiet sdist --formats=$formats 
-          venv/bin/python etc/release/scancode_rename_archives.py dist/ _py3-$operating_system
+          venv/bin/python etc/release/scancode_rename_archives.py dist/ _py$python_version-$operating_system
 
       - name: Collect built mac app
         uses: actions/upload-artifact@v3

--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -363,8 +363,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, macos-12]
-        pyver: ["3.9", "3.10"]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11, macos-12]
+        pyver: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -411,8 +411,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [windows-2022]
-        pyver: ["3.9", "3.10"]
+       os: [windows-2019, windows-2022]
+       pyver: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -460,7 +460,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
+        # , ubuntu-22.04]
         pyver: [3.8]
 
     steps:

--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -148,7 +148,7 @@ jobs:
           operating_system=linux
           python_dot_version=3.8
           python_version=38
-          echo -n "$python_version" > PYTHON_EXECUTABLE
+          echo -n "python$python_dot_version" > PYTHON_EXECUTABLE
           rm -rf thirdparty build dist
           rm -rf .eggs src/scancode_toolkit.egg-info src/scancode_toolkit_mini.egg-info
           mkdir -p thirdparty
@@ -363,8 +363,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11, macos-12]
-        pyver: ["3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-22.04, macos-12]
+        pyver: ["3.9", "3.10"]
+        # os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11, macos-12]
+        # pyver: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -411,8 +413,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-       os: [windows-2019, windows-2022]
-       pyver: ["3.7", "3.8", "3.9", "3.10"]
+       os: [windows-2022]
+       pyver: ["3.9", "3.10"]
+       #os: [windows-2019, windows-2022]
+       #pyver: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -460,8 +464,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
-        # , ubuntu-22.04]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
         pyver: [3.8]
 
     steps:

--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -148,18 +148,17 @@ jobs:
           operating_system=linux
           python_dot_version=3.8
           python_version=38
-          echo -n "python$python_dot_version" > PYTHON_EXECUTABLE
+          echo -n "python3" > PYTHON_EXECUTABLE
           rm -rf thirdparty build dist
           rm -rf .eggs src/scancode_toolkit.egg-info src/scancode_toolkit_mini.egg-info
           mkdir -p thirdparty
           venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements-linux.txt \
             --requirements=requirements.txt \
-            --sdist-only libfwsi-python \
             --dest=thirdparty \
-            --python-version=$python_version \
             --operating-system=$operating_system \
             --wheels
+            # --python-version=$python_version \
           venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements-native.txt \
             --requirements=requirements-linux.txt \
@@ -171,7 +170,7 @@ jobs:
             --dest=thirdparty \
             --sdists
           venv/bin/python setup.py --quiet sdist --formats=$formats 
-          venv/bin/python etc/release/scancode_rename_archives.py dist/ _py$python_version-$operating_system
+          venv/bin/python etc/release/scancode_rename_archives.py dist/ _py3-$operating_system
 
       - name: Collect built linux app
         uses: actions/upload-artifact@v3
@@ -203,7 +202,6 @@ jobs:
           ./configure --dev
           ./scancode --reindex-licenses
 
-
       - name: Build mac app archive
         run: |
           source venv/bin/activate
@@ -211,17 +209,16 @@ jobs:
           operating_system=macos
           python_dot_version=3.8
           python_version=38
-          echo -n "python$python_dot_version" > PYTHON_EXECUTABLE
+          echo -n "python3" > PYTHON_EXECUTABLE
           rm -rf thirdparty build dist
           rm -rf .eggs src/scancode_toolkit.egg-info src/scancode_toolkit_mini.egg-info
           mkdir -p thirdparty
           venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements.txt \
-            --sdist-only libfwsi-python \
             --dest=thirdparty \
-            --python-version=$python_version \
             --operating-system=$operating_system \
             --wheels
+            # --python-version=$python_version \
           venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements-native.txt \
             --wheel-only extractcode \
@@ -233,7 +230,7 @@ jobs:
             --dest=thirdparty \
             --sdists
           venv/bin/python setup.py --quiet sdist --formats=$formats 
-          venv/bin/python etc/release/scancode_rename_archives.py dist/ _py$python_version-$operating_system
+          venv/bin/python etc/release/scancode_rename_archives.py dist/ _py3-$operating_system
 
       - name: Collect built mac app
         uses: actions/upload-artifact@v3
@@ -278,11 +275,10 @@ jobs:
           mkdir -p thirdparty
           venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements.txt \
-            --sdist-only libfwsi-python \
             --dest=thirdparty \
-            --python-version=$python_version \
             --operating-system=$operating_system \
             --wheels
+            # --python-version=$python_version \
           venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements-native.txt \
             --wheel-only extractcode \
@@ -464,7 +460,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
         pyver: [3.8]
 
     steps:
@@ -502,7 +498,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-12]
+        os: [macos-10.15, macos-11, macos-12]
         pyver: [3.8]
 
     steps:
@@ -540,7 +536,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [windows-2022]
+        os: [windows-2019, windows-2022]
         pyver: [3.8]
 
     steps:

--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -367,8 +367,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11, macos-12]
-        pyver: ["3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-22.04, macos-12]
+        pyver: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -388,18 +388,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: main_sdist
-          path: dist
-
-      - name: Download a single artifact miniw
-        uses: actions/download-artifact@v3
-        with:
-          name: mini_wheel
-          path: dist
-
-      - name: Download a single artifact minis
-        uses: actions/download-artifact@v3
-        with:
-          name: mini_sdist
           path: dist
 
       - name: test install wheels and sdist
@@ -427,8 +415,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [windows-2019, windows-2022]
-        pyver: ["3.7", "3.8", "3.9", "3.10"]
+        os: [windows-2022]
+        pyver: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -448,18 +436,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: main_sdist
-          path: dist
-
-      - name: Download a single artifact miniw
-        uses: actions/download-artifact@v3
-        with:
-          name: mini_wheel
-          path: dist
-
-      - name: Download a single artifact minis
-        uses: actions/download-artifact@v3
-        with:
-          name: mini_sdist
           path: dist
 
       - name: test install wheels and sdist
@@ -488,7 +464,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04]
         pyver: [3.8]
 
     steps:
@@ -526,7 +502,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-12]
         pyver: [3.8]
 
     steps:
@@ -564,7 +540,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022]
         pyver: [3.8]
 
     steps:

--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -3,12 +3,12 @@ name: Create ScanCode release archives, then test and publish to GH and PyPI
 # This is executed automatically on a tag
 
 # Summary of the steps:
-# - build wheel and sdist for main and same for mini flavor
-#   - then upload all wheels and sdist to PyPI
-# - build release app archives, one for each of linux, windows, macos on Python 3.8
-#   - then create gh-release and upload app archives to release
-# TODO: for each of linux, windows, macos: smoke test wheel, sdist and release archives
-# TODO: add changelog to release text body
+# - Build wheel and sdist for the "main" scancode, then build these for the "mini" flavor
+#  - test each wheel and sdist on every possible OS x Python version combinations
+# - Build release app archives, one for each of linux, windows, macos on Python 3.8
+#  - test each on its target OS and Python version
+# - Create gh-release and upload app archives to release
+# - Upload all wheels and sdist to PyPI
 
 
 on:
@@ -27,7 +27,7 @@ jobs:
       run:
         shell: bash
     strategy:
-      fail-fast: false
+      fail-fast: true
 
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +41,6 @@ jobs:
         run: |
           ./configure --dev
           ./scancode --reindex-licenses
-
 
       - name: Build main wheel
         run: |
@@ -75,7 +74,7 @@ jobs:
       run:
         shell: bash
     strategy:
-      fail-fast: false
+      fail-fast: true
 
     steps:
       - uses: actions/checkout@v2
@@ -127,7 +126,7 @@ jobs:
       run:
         shell: bash
     strategy:
-      fail-fast: false
+      fail-fast: true
 
     steps:
       - uses: actions/checkout@v2
@@ -154,15 +153,23 @@ jobs:
           rm -rf .eggs src/scancode_toolkit.egg-info src/scancode_toolkit_mini.egg-info
           mkdir -p thirdparty
           venv/bin/python etc/scripts/fetch_thirdparty.py \
-            --requirements=requirements-native.txt \
-            --dest=thirdparty \
-            --sdists
-          venv/bin/python etc/scripts/fetch_thirdparty.py \
+            --requirements=requirements-linux.txt \
             --requirements=requirements.txt \
+            --sdist-only libfwsi-python \
             --dest=thirdparty \
             --python-version=$python_version \
             --operating-system=$operating_system \
             --wheels
+          venv/bin/python etc/scripts/fetch_thirdparty.py \
+            --requirements=requirements-native.txt \
+            --requirements=requirements-linux.txt \
+            --wheel-only packagedcode-msitools \
+            --wheel-only rpm-inspector-rpm \
+            --wheel-only extractcode-7z \
+            --wheel-only extractcode-libarchive \
+            --wheel-only typecode-libmagic \
+            --dest=thirdparty \
+            --sdists
           venv/bin/python setup.py --quiet sdist --formats=$formats 
           venv/bin/python etc/release/scancode_rename_archives.py dist/ _py$python_version-$operating_system
 
@@ -173,7 +180,7 @@ jobs:
           path: dist/*
 
 
-  build_scancode_for_release_mac:
+  build_scancode_for_release_macos:
     name: Build ScanCode Release archives for mac
     runs-on: ubuntu-20.04
 
@@ -181,7 +188,7 @@ jobs:
       run:
         shell: bash
     strategy:
-      fail-fast: false
+      fail-fast: true
 
     steps:
       - uses: actions/checkout@v2
@@ -209,18 +216,25 @@ jobs:
           rm -rf .eggs src/scancode_toolkit.egg-info src/scancode_toolkit_mini.egg-info
           mkdir -p thirdparty
           venv/bin/python etc/scripts/fetch_thirdparty.py \
-            --requirements=requirements-native.txt \
-            --dest=thirdparty \
-            --sdists
-          venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements.txt \
+            --sdist-only libfwsi-python \
             --dest=thirdparty \
             --python-version=$python_version \
             --operating-system=$operating_system \
             --wheels
+          venv/bin/python etc/scripts/fetch_thirdparty.py \
+            --requirements=requirements-native.txt \
+            --wheel-only extractcode \
+            --wheel-only extractcode-7z \
+            --wheel-only extractcode-libarchive \
+            --wheel-only typecode-libmagic \
+            --wheel-only packagedcode-msitools \
+            --wheel-only rpm-inspector-rpm \
+            --dest=thirdparty \
+            --sdists
           venv/bin/python setup.py --quiet sdist --formats=$formats 
           venv/bin/python etc/release/scancode_rename_archives.py dist/ _py$python_version-$operating_system
- 
+
       - name: Collect built mac app
         uses: actions/upload-artifact@v3
         with:
@@ -228,7 +242,7 @@ jobs:
           path: dist/*
 
 
-  build_scancode_for_release_win:
+  build_scancode_for_release_windows:
     name: Build ScanCode Release archives for windows
     runs-on: ubuntu-20.04
 
@@ -236,7 +250,7 @@ jobs:
       run:
         shell: bash
     strategy:
-      fail-fast: false
+      fail-fast: true
 
     steps:
       - uses: actions/checkout@v2
@@ -250,7 +264,7 @@ jobs:
         run: |
           ./configure --dev
           ./scancode --reindex-licenses
- 
+
       - name: Build windows app archive
         run: |
           source venv/bin/activate
@@ -263,18 +277,25 @@ jobs:
           rm -rf .eggs src/scancode_toolkit.egg-info src/scancode_toolkit_mini.egg-info
           mkdir -p thirdparty
           venv/bin/python etc/scripts/fetch_thirdparty.py \
-            --requirements=requirements-native.txt \
-            --dest=thirdparty \
-            --sdists
-          venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements.txt \
+            --sdist-only libfwsi-python \
             --dest=thirdparty \
             --python-version=$python_version \
             --operating-system=$operating_system \
             --wheels
+          venv/bin/python etc/scripts/fetch_thirdparty.py \
+            --requirements=requirements-native.txt \
+            --wheel-only extractcode \
+            --wheel-only extractcode-7z \
+            --wheel-only extractcode-libarchive \
+            --wheel-only typecode-libmagic \
+            --wheel-only packagedcode-msitools \
+            --wheel-only rpm-inspector-rpm \
+            --dest=thirdparty \
+            --sdists
           venv/bin/python setup.py --quiet sdist --formats=$formats 
           venv/bin/python etc/release/scancode_rename_archives.py dist/ _py$python_version-$operating_system
- 
+
       - name: Collect built windows app
         uses: actions/upload-artifact@v3
         with:
@@ -289,7 +310,7 @@ jobs:
       run:
         shell: bash
     strategy:
-      fail-fast: false
+      fail-fast: true
 
     steps:
       - uses: actions/checkout@v2
@@ -299,7 +320,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Install requirements and prepare index
+      - name: Install requirements
         run: |
           ./configure --dev
 
@@ -312,11 +333,19 @@ jobs:
           mkdir -p thirdparty
           venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements.txt \
+            --requirements=requirements-native.txt \
+            --requirements=requirements-linux.txt \
+            --wheel-only extractcode \
+            --wheel-only extractcode-7z \
+            --wheel-only extractcode-libarchive \
+            --wheel-only typecode-libmagic \
+            --wheel-only packagedcode-msitools \
+            --wheel-only rpm-inspector-rpm \
             --dest=thirdparty \
             --sdists
           venv/bin/python setup.py --quiet sdist --formats=$formats 
           venv/bin/python etc/release/scancode_rename_archives.py dist/  _sources
- 
+
       - name: Collect built source app tarball
         uses: actions/upload-artifact@v3
         with:
@@ -324,49 +353,256 @@ jobs:
           path: dist/*
 
 
-  publish_to_pypi:
-    name: Publish to PyPI
-    needs: [build_scancode_for_pypi, build_scancode_for_pypi_mini]
-    runs-on: ubuntu-20.04
+  smoke_test_install_and_run_pypi_dists_posix:
+    name: Test install and run each PyPI wheels and sdist
+    needs:
+      - build_scancode_for_pypi
+      - build_scancode_for_pypi_mini
+    runs-on: ${{ matrix.os }}
+
     defaults:
       run:
         shell: bash
+
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        dist_names: [main_wheel, main_sdist, mini_wheel, mini_sdist]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11, macos-12]
+        pyver: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
-      - name: Set up Python
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.pyver }} on ${{ matrix.os }}
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.pyver }}
 
-      - name: Download a single artifact
+      - name: Download a single artifact mainw
         uses: actions/download-artifact@v3
         with:
-          name: ${{ matrix.dist_names }}
+          name: main_wheel
           path: dist
 
-      - name: Publish distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+      - name: Download a single artifact mains
+        uses: actions/download-artifact@v3
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          name: main_sdist
+          path: dist
+
+      - name: Download a single artifact miniw
+        uses: actions/download-artifact@v3
+        with:
+          name: mini_wheel
+          path: dist
+
+      - name: Download a single artifact minis
+        uses: actions/download-artifact@v3
+        with:
+          name: mini_sdist
+          path: dist
+
+      - name: test install wheels and sdist
+        run: |
+          for f in `find dist -type f`; \
+            do \
+              rm -rf tvenv;  \
+              python -m venv tvenv;  \
+              tvenv/bin/python etc/release/scancode_release_tests.py pypi $f tvenv/bin/ ;  \
+              tvenv/bin/pip uninstall --yes scancode-toolkit ;  \
+            done
+
+
+  smoke_test_install_and_run_pypi_dists_windows:
+    name: Test install and run each PyPI wheels and sdist
+    needs:
+      - build_scancode_for_pypi
+      - build_scancode_for_pypi_mini
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [windows-2019, windows-2022]
+        pyver: ["3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.pyver }} on ${{ matrix.os }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.pyver }}
+
+      - name: Download a single artifact mainw
+        uses: actions/download-artifact@v3
+        with:
+          name: main_wheel
+          path: dist
+
+      - name: Download a single artifact mains
+        uses: actions/download-artifact@v3
+        with:
+          name: main_sdist
+          path: dist
+
+      - name: Download a single artifact miniw
+        uses: actions/download-artifact@v3
+        with:
+          name: mini_wheel
+          path: dist
+
+      - name: Download a single artifact minis
+        uses: actions/download-artifact@v3
+        with:
+          name: mini_sdist
+          path: dist
+
+      - name: test install wheels and sdist
+        run: |
+          echo "license: gpl-2.0" > some.file
+          python -m venv venv
+          venv/Scripts/python.exe -m pip install --upgrade pip
+          for f in `find dist -type f`; \
+            do \
+              venv/Scripts/python.exe -m pip install --force-reinstall "$f[full]" ; \
+              venv/Scripts/scancode -clipeu --json-pp - some.file ; \
+              venv/Scripts/python.exe -m pip uninstall --yes scancode-toolkit ; \
+            done
+
+
+  smoke_test_install_and_run_app_archives_on_linux:
+    name: Test app archive installation and run on ${{ matrix.os }}
+    needs:
+      - build_scancode_for_release_linux
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        pyver: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.pyver }} on ${{ matrix.os }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.pyver }}
+
+      - name: Download a single artifact linux_app
+        uses: actions/download-artifact@v3
+        with:
+          name: linux_app
+          path: dist
+
+      - name: test install app archive
+        run: |
+          for f in `find dist -type f`; \
+            do \
+                python etc/release/scancode_release_tests.py app $f; \
+            done
+
+
+  smoke_test_install_and_run_app_archives_on_macos:
+    name: Test app archive installation and run on ${{ matrix.os }}
+    needs:
+      - build_scancode_for_release_macos
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [macos-11, macos-12]
+        pyver: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.pyver }} on ${{ matrix.os }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.pyver }}
+
+      - name: Download a single artifact macos_app
+        uses: actions/download-artifact@v3
+        with:
+          name: macos_app
+          path: dist
+
+      - name: test install app archive
+        run: |
+          for f in `find dist -type f`; \
+            do \
+                python etc/release/scancode_release_tests.py app $f; \
+            done
+
+
+  smoke_test_install_and_run_app_archives_on_windows:
+    name: Test app archive installation and run on ${{ matrix.os }}
+    needs:
+      - build_scancode_for_release_windows
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [windows-2019, windows-2022]
+        pyver: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.pyver }} on ${{ matrix.os }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.pyver }}
+
+      - name: Download a single artifact windows_app
+        uses: actions/download-artifact@v3
+        with:
+          name: windows_app
+          path: dist
+
+      - name: test install app archive
+        run: |
+          for f in `find dist -type f`; \
+            do \
+                python etc/release/scancode_release_tests.py app $f; \
+            done
 
 
   publish_to_gh_release:
     name: Publish to GH Release
     needs:
-      - build_scancode_for_release_linux
-      - build_scancode_for_release_win
-      - build_scancode_for_release_mac
+      - smoke_test_install_and_run_app_archives_on_linux
+      - smoke_test_install_and_run_app_archives_on_windows
+      - smoke_test_install_and_run_app_archives_on_macos
       - build_scancode_for_release_source
+
     runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
     strategy:
-      fail-fast: false
+      fail-fast: true
 
     steps:
       - name: Download a single artifact source_app
@@ -393,8 +629,49 @@ jobs:
           name: windows_app
           path: dist
 
-      - name: Create release and publish archives
-        uses: softprops/action-gh-release@v1
+      - name: Mock GH release
+        run: |
+          ls -al dist
+
+      #- name: Create release and publish archives
+      #  uses: softprops/action-gh-release@v1
+      #  with:
+      #    draft: true
+      #    files: dist/*
+
+
+  publish_to_pypi:
+    name: Publish to PyPI
+    needs:
+      - smoke_test_install_and_run_pypi_dists_windows
+      - smoke_test_install_and_run_pypi_dists_posix
+      - publish_to_gh_release
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: true
+      matrix:
+        dist_names: [main_wheel, main_sdist, mini_wheel, mini_sdist]
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v1
         with:
-          draft: true
-          files: dist/*
+          python-version: 3.8
+
+      - name: Download a single artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.dist_names }}
+          path: dist
+
+      - name: Mock PyPI upload
+        run: |
+          ls -al dist
+
+      #- name: Publish distributions to PyPI
+      #  uses: pypa/gh-action-pypi-publish@master
+      #  with:
+      #    password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -148,7 +148,7 @@ jobs:
           operating_system=linux
           python_dot_version=3.8
           python_version=38
-          echo -n "python3" > PYTHON_EXECUTABLE
+          echo -n "$python_version" > PYTHON_EXECUTABLE
           rm -rf thirdparty build dist
           rm -rf .eggs src/scancode_toolkit.egg-info src/scancode_toolkit_mini.egg-info
           mkdir -p thirdparty
@@ -157,8 +157,8 @@ jobs:
             --requirements=requirements.txt \
             --dest=thirdparty \
             --operating-system=$operating_system \
+            --python-version=$python_version \
             --wheels
-            # --python-version=$python_version \
           venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements-native.txt \
             --requirements=requirements-linux.txt \
@@ -217,8 +217,8 @@ jobs:
             --requirements=requirements.txt \
             --dest=thirdparty \
             --operating-system=$operating_system \
+            --python-version=$python_version \
             --wheels
-            # --python-version=$python_version \
           venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements-native.txt \
             --wheel-only extractcode \
@@ -277,8 +277,8 @@ jobs:
             --requirements=requirements.txt \
             --dest=thirdparty \
             --operating-system=$operating_system \
+            --python-version=$python_version \
             --wheels
-            # --python-version=$python_version \
           venv/bin/python etc/scripts/fetch_thirdparty.py \
             --requirements=requirements-native.txt \
             --wheel-only extractcode \

--- a/README.rst
+++ b/README.rst
@@ -133,14 +133,15 @@ Installation
 ============
 
 Before installing ScanCode make sure that you have installed the prerequisites
-properly. This means installing Python 3.98 for x86/64 architectures. (Python 3.7+ is supported).
+properly. This means installing Python 3.8 for x86/64 architectures.
+We support Python 3.7, 3.8, 3.9 and 3.10.
 
 See `prerequisites <https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#prerequisites>`_
 for detailed information on the support platforms and Python versions.
 
 There are a few common ways to `install ScanCode <https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html>`_.
 
-- **Installation as an application: Install Python 3.9, download a release archive, extract and run**. `This is the recommended installation method.
+- **Installation as an application: Install Python 3.8, download a release archive, extract and run**. `This is the recommended installation method.
   <https://scancode-toolkit.readthedocs.io/en/latest/getting-started/install.html#installation-as-an-application-downloading-releases>`_
 
 - `Development installation from source code using a git clone

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,6 +123,15 @@ jobs:
           test_suites:
               all: venv/bin/pytest -n 2 -vvs tests/scancode/test_cli.py
 
+    - template: etc/ci/azure-posix.yml
+      parameters:
+          job_name: macos12_cpython
+          image_name: macos-12
+          python_versions: ['3.7', '3.8', '3.9', '3.10']
+          python_architecture: x64
+          test_suites:
+              all: venv/bin/pytest -n 2 -vvs tests/scancode/test_cli.py
+
     - template: etc/ci/azure-win.yml
       parameters:
           job_name: win2019_cpython_1
@@ -214,6 +223,14 @@ jobs:
       parameters:
           job_name: macos11_cpython_latest_from_pip
           image_name: macos-11
+          python_versions: ['3.7', '3.8', '3.9', '3.10']
+          test_suites:
+              all: venv/bin/pip install --upgrade-strategy eager --force-reinstall --upgrade -e .[dev] && venv/bin/pytest -n 2 -vvs tests/scancode/test_cli.py
+
+    - template: etc/ci/azure-posix.yml
+      parameters:
+          job_name: macos12_cpython_latest_from_pip
+          image_name: macos-12
           python_versions: ['3.7', '3.8', '3.9', '3.10']
           test_suites:
               all: venv/bin/pip install --upgrade-strategy eager --force-reinstall --upgrade -e .[dev] && venv/bin/pytest -n 2 -vvs tests/scancode/test_cli.py

--- a/configure
+++ b/configure
@@ -141,15 +141,16 @@ CLI_ARGS=$1
 # Defaults. Change these variables to customize this script
 ################################
 
-EXTRAS="packages"
-
+BASE=".[packages]"
+BASE_DEV=".[packages,testing]"
 if [[ $OSTYPE == 'darwin'* ]]; then
-    EXTRAS=""
+    BASE="."
+    BASE_DEV=".[testing]"
 fi
 
 # Requirement arguments passed to pip and used by default or with --dev.
-REQUIREMENTS="--editable .[$EXTRAS] --constraint requirements.txt --constraint requirements-linux.txt"
-DEV_REQUIREMENTS="--editable .[$EXTRAS,testing] --constraint requirements.txt --constraint requirements-linux.txt --constraint requirements-dev.txt"
+REQUIREMENTS="--editable $BASE --constraint requirements.txt --constraint requirements-linux.txt"
+DEV_REQUIREMENTS="--editable $BASE_DEV --constraint requirements.txt --constraint requirements-linux.txt --constraint requirements-dev.txt"
 DOCS_REQUIREMENTS="--editable .[docs] --constraint requirements.txt"
 
 # where we create a virtualenv

--- a/configure
+++ b/configure
@@ -141,9 +141,15 @@ CLI_ARGS=$1
 # Defaults. Change these variables to customize this script
 ################################
 
+EXTRAS="packages"
+
+if [[ $OSTYPE == 'darwin'* ]]; then
+    EXTRAS=""
+fi
+
 # Requirement arguments passed to pip and used by default or with --dev.
-REQUIREMENTS="--editable .[packages] --constraint requirements.txt"
-DEV_REQUIREMENTS="--editable .[testing,packages] --constraint requirements.txt --constraint requirements-dev.txt"
+REQUIREMENTS="--editable .[$EXTRAS] --constraint requirements.txt --constraint requirements-linux.txt"
+DEV_REQUIREMENTS="--editable .[$EXTRAS,testing] --constraint requirements.txt --constraint requirements-linux.txt --constraint requirements-dev.txt"
 DOCS_REQUIREMENTS="--editable .[docs] --constraint requirements.txt"
 
 # where we create a virtualenv

--- a/etc/release/scancode_release_tests.py
+++ b/etc/release/scancode_release_tests.py
@@ -54,6 +54,11 @@ def run_app_smoke_tests(app_archive):
 
     os.chdir(extract_loc)
 
+    print(f"Configuring scancode for release: {app_archive}")
+    run_command([
+        os.path.join(extract_loc, "configure"),
+    ])
+
     # minimal tests: update when new scans are available
     args = [
         os.path.join(extract_loc, "scancode"),

--- a/etc/release/scancode_release_tests.py
+++ b/etc/release/scancode_release_tests.py
@@ -9,27 +9,24 @@
 # See https://aboutcode.org for more information about nexB OSS projects.
 #
 
-import hashlib
 import os
 import shutil
 import subprocess
 import sys
 
-# TODO: also test a pip install with a find-links option to our new PyPI repo
 
-
-def run_pypi_smoke_tests(pypi_archive):
+def run_pypi_smoke_tests(pypi_archive, venv_prefix="venv/bin/"):
     """
     Run basic install and "smoke" scancode tests for a PyPI archive.
     """
     # archive is either a wheel or an sdist as in
     # scancode_toolkit-21.1.21-py3-none-any.whl or scancode-toolkit-21.1.21.tar.gz
-    run_command(["pip", "install", pypi_archive + "[full]"])
+    run_command([venv_prefix + "pip", "install", pypi_archive + "[full]"])
 
     with open("some.file", "w") as sf:
         sf.write("license: gpl-2.0")
 
-    run_command(["scancode", "-clipeu", "--json-pp", "-", "some.file"])
+    run_command([venv_prefix + "scancode", "-clipeu", "--json-pp", "-", "some.file"])
 
 
 def run_app_smoke_tests(app_archive):
@@ -42,13 +39,15 @@ def run_app_smoke_tests(app_archive):
     # We split the name on "_" to extract the laft hand side which is name of
     # the root directory inside the archive e.g. "scancode-toolkit-21.1.21"
     # where the archive gest extracted
-    extract_dir, _, _py_ver_ext = app_archive.partition("_")
+
+    _base, _, fn = app_archive.partition("/")
+    extract_dir, _, _py_ver_ext = fn.partition("_")
+    print("run_app_smoke_tests: cwd:", os.getcwd())
+    print("run_app_smoke_tests:", "extracting archive:", app_archive, "to:", extract_dir)
     shutil.unpack_archive(app_archive)
-    print()
-    print("cwd:", os.getcwd())
 
     extract_loc = os.path.normpath(os.path.abspath(os.path.expanduser(extract_dir)))
-    print("extract_loc:", extract_loc)
+    print("run_app_smoke_tests: extract_loc:", extract_loc)
     for f in os.listdir(extract_loc):
         print("  ", f)
     print()
@@ -58,20 +57,38 @@ def run_app_smoke_tests(app_archive):
     # minimal tests: update when new scans are available
     args = [
         os.path.join(extract_loc, "scancode"),
-        "-clipeu",
+        "--license",
+        "--license-text",
+        "--license-clarity-score",
+
+        "--copyright",
+        "--info",
+        "--email",
+        "--url",
+        "--generated",
+
+        "--package",
+        "--system-package",
+
+        "--summary",
+        "--tallies",
         "--classify",
+        "--consolidate",
+
         "--verbose",
-        "--json",
-        "test_scan.json",
-        "--csv",
-        "test_scan.csv",
-        "--html",
-        "test_scan.html",
-        "--spdx-tv",
-        "test_scan.spdx",
-        "--json-pp",
-        "-",
-        os.path.join(extract_loc, "apache-2.0.LICENSE"),
+
+        "--yaml", "test_scan.yml",
+        "--json", "test_scan.json",
+        "--json-lines", "test_scan.json-lines",
+        "--csv", "test_scan.csv",
+        "--html", "test_scan.html",
+        "--cyclonedx", "test_scan.cdx",
+        "--cyclonedx-xml", "test_scan.cdx.xml",
+        "--spdx-tv", "test_scan.spdx",
+
+        "--debian", "test_scan.debian.copyright",
+        "--json-pp", "-",
+        "apache-2.0.LICENSE"
     ]
 
     print(f"Testing scancode release: {app_archive}")
@@ -100,18 +117,14 @@ def run_command(args):
 
 if __name__ == "__main__":
     args = sys.argv[1:]
-    action, archive, sha_arch, sha_py = args
-
-    with open(archive, "rb") as arch:
-        current_sha_arch = hashlib.sha256(arch.read()).hexdigest()
-        assert current_sha_arch == sha_arch
-
-    with open(__file__, "rb") as py:
-        current_sha_py = hashlib.sha256(py.read()).hexdigest()
-        assert current_sha_py == sha_py
+    action = args[0]
+    archive = args[1]
 
     if action == "pypi":
-        run_pypi_smoke_tests(archive)
-    else:
-        # action =='app':
+        venv_prefix = args[2]
+        run_pypi_smoke_tests(archive, venv_prefix)
+    elif action == 'app':
         run_app_smoke_tests(archive)
+    else:
+        raise Exception("Usage: scancode_release_tests.py <pypi or app> <archive-to-test>")
+

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -1,3 +1,3 @@
 packagedcode-msitools==0.101.210706
-regipy==3.0.2
+regipy==3.1.0
 rpm-inspector-rpm==4.16.1.3.210404

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -1,0 +1,4 @@
+libfwsi-python==20220123
+packagedcode-msitools==0.101.210706
+regipy==3.0.2
+rpm-inspector-rpm==4.16.1.3.210404

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -1,4 +1,3 @@
-libfwsi-python==20220123
 packagedcode-msitools==0.101.210706
 regipy==3.0.2
 rpm-inspector-rpm==4.16.1.3.210404

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,13 +34,11 @@ jaraco.functools==3.5.1
 javaproperties==0.8.1
 Jinja2==3.1.2
 jsonstreams==0.6.0
-libfwsi-python==20220123
 license-expression==30.0.0
 lxml==4.9.1
 MarkupSafe==2.1.1
 more-itertools==8.13.0
 normality==2.3.3
-packagedcode-msitools==0.101.210706
 packageurl-python==0.10.0
 packaging==21.3
 parameter-expansion-patched==0.3.1
@@ -61,9 +59,7 @@ pyparsing==3.0.9
 pytz==2022.1
 PyYAML==6.0
 rdflib==6.2.0
-regipy==3.0.2
 requests==2.28.1
-rpm-inspector-rpm==4.16.1.3.210404
 saneyaml==0.5.2
 six==1.16.0
 soupsieve==2.3.2.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,6 +68,7 @@ text-unidecode==1.3
 toml==0.10.2
 typecode==30.0.0
 typecode-libmagic==5.39.210531
+typing-extensions==4.3.0
 urllib3==1.26.11
 urlpy==0.5
 wcwidth==0.2.5

--- a/setup-mini.cfg
+++ b/setup-mini.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = scancode-toolkit-mini
-version = 31.0.0rc5
+version = 31.0.0rc6
 license = Apache-2.0 AND CC-BY-4.0 AND LicenseRef-scancode-other-permissive AND LicenseRef-scancode-other-copyleft
 
 # description must be on ONE line https://github.com/pypa/setuptools/issues/1390

--- a/setup-mini.cfg
+++ b/setup-mini.cfg
@@ -139,7 +139,7 @@ docs =
 # linux-only package handling
 packages =
     rpm_inspector_rpm >= 4.16.1.3; platform_system == 'Linux'
-    regipy >= 2.0.0; platform_system == 'Linux'
+    regipy >= 3.1.0; platform_system == 'Linux'
     packagedcode_msitools >= 0.101.210706; platform_system == 'Linux'
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = scancode-toolkit
-version = 31.0.0rc5
+version = 31.0.0rc6
 license = Apache-2.0 AND CC-BY-4.0 AND LicenseRef-scancode-other-permissive AND LicenseRef-scancode-other-copyleft
 
 # description must be on ONE line https://github.com/pypa/setuptools/issues/1390

--- a/setup.cfg
+++ b/setup.cfg
@@ -139,7 +139,7 @@ docs =
 # linux-only package handling
 packages =
     rpm_inspector_rpm >= 4.16.1.3; platform_system == 'Linux'
-    regipy >= 2.0.0; platform_system == 'Linux'
+    regipy >= 3.1.0; platform_system == 'Linux'
     packagedcode_msitools >= 0.101.210706; platform_system == 'Linux'
 
 

--- a/src/packagedcode/__init__.py
+++ b/src/packagedcode/__init__.py
@@ -9,6 +9,7 @@
 
 import attr
 
+from commoncode.system import on_linux
 from packagedcode import about
 from packagedcode import alpine
 from packagedcode import bower
@@ -29,7 +30,6 @@ from packagedcode import haxe
 from packagedcode import jar_manifest
 from packagedcode import maven
 from packagedcode import misc
-from packagedcode import msi
 from packagedcode import npm
 from packagedcode import nuget
 from packagedcode import opam
@@ -41,7 +41,10 @@ from packagedcode import rpm
 from packagedcode import rubygems
 from packagedcode import win_pe
 from packagedcode import windows
-from packagedcode import win_reg
+
+if on_linux:
+    from packagedcode import msi
+    from packagedcode import win_reg
 
 # Note: the order matters: from the most to the least specific parser.
 # a handler classes MUST be added to this list to be active
@@ -137,9 +140,6 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     misc.NsisInstallerHandler,
     misc.SharArchiveHandler,
     misc.SquashfsImageHandler,
-
-    msi.MsiInstallerHandler,
-
     npm.NpmPackageJsonHandler,
     npm.NpmPackageLockJsonHandler,
     npm.NpmShrinkwrapJsonHandler,
@@ -197,6 +197,10 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     win_pe.WindowsExecutableHandler,
 ]
 
+if on_linux:
+    APPLICATION_PACKAGE_DATAFILE_HANDLERS += [
+        msi.MsiInstallerHandler,
+    ]
 
 SYSTEM_PACKAGE_DATAFILE_HANDLERS = [
     alpine.AlpineInstalledDatabaseHandler,
@@ -211,15 +215,18 @@ SYSTEM_PACKAGE_DATAFILE_HANDLERS = [
     debian.DebianInstalledFilelistHandler,
     debian.DebianInstalledMd5sumFilelistHandler,
     debian.DebianInstalledStatusDatabaseHandler,
-
-    rpm.RpmInstalledBdbDatabaseHandler,
-    rpm.RpmInstalledSqliteDatabaseHandler,
-    rpm.RpmInstalledNdbDatabaseHandler,
-
-    win_reg.InstalledProgramFromDockerSoftwareDeltaHandler,
-    win_reg.InstalledProgramFromDockerFilesSoftwareHandler,
-    win_reg.InstalledProgramFromDockerUtilityvmSoftwareHandler,
 ]
+
+if on_linux:
+    SYSTEM_PACKAGE_DATAFILE_HANDLERS += [
+        rpm.RpmInstalledBdbDatabaseHandler,
+        rpm.RpmInstalledSqliteDatabaseHandler,
+        rpm.RpmInstalledNdbDatabaseHandler,
+
+        win_reg.InstalledProgramFromDockerSoftwareDeltaHandler,
+        win_reg.InstalledProgramFromDockerFilesSoftwareHandler,
+        win_reg.InstalledProgramFromDockerUtilityvmSoftwareHandler,
+    ]
 
 ALL_DATAFILE_HANDLERS= (
     APPLICATION_PACKAGE_DATAFILE_HANDLERS + [

--- a/src/scancode_config.py
+++ b/src/scancode_config.py
@@ -77,10 +77,10 @@ def _create_dir(location):
 
 # in case package is not installed or we do not have setutools/pkg_resources
 # on hand fall back to this version
-__version__ = '31.0.0rc5'
+__version__ = '31.0.0rc6'
 
 # used to warn user when the version is out of date
-__release_date__ = datetime.datetime(2022, 7, 28)
+__release_date__ = datetime.datetime(2022, 8, 13)
 
 # See https://github.com/nexB/scancode-toolkit/issues/2653 for more information
 # on the data format version


### PR DESCRIPTION
Some release archves where missing critical wheels.
The solution is to:

* ensure that we have effectively missing wheels published and made
available from our PyPI repo when building a release

* Improve the fetch_thirdparty script to fall back on fetching a
source distribution when no wheel is found. Fail loudly if neither a
wheel not an sdist is found. Also accept special cases of packages with
no wheels and packages with no sources.

* Ensure that some source-only packages are always included as sources

* Add release smoke tests and run then for each wheel, sdist and app
  archive on supported OS and Python versions combinations

* Move Linux-only requirements to theur own requirement file.

* Enable Linux-only package inspectors on Linux only.

* Run base tests on macos 12

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->


<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
