### PR TITLE
Correctly assign `path_ref` when partitioning `path_ref` in `PythonInstalledWheelMetadataFile.assign_package_to_resources()`

### DIFF
--- a/src/packagedcode/pypi.py
+++ b/src/packagedcode/pypi.py
@@ -342,7 +342,7 @@ class PythonInstalledWheelMetadataFile(BasePypiHandler):
                 cannot_resolve = False
                 ref_resource = None
                 while path_ref.startswith('..'):
-                    _, _, path_ref.partition('../')
+                    _, _, path_ref = path_ref.partition('../')
                     ref_resource = site_packages.parent(codebase)
                     if not ref_resource:
                         cannot_resolve = True


### PR DESCRIPTION
This PR fixes a typo in `PythonInstalledWheelMetadataFile.assign_package_to_resources()`. The variable `path_ref` was not being assigned correctly and `PythonInstalledWheelMetadataFile.assign_package_to_resources()` would fail during Package assembly.