### PR TITLE
Fix issues in `PythonInstalledWheelMetadataFile.assign_package_to_resources()`

### DIFF
--- a/src/packagedcode/models.py
+++ b/src/packagedcode/models.py
@@ -805,9 +805,12 @@ def compute_normalized_license(declared_license, expression_symbols=None):
 
 def add_to_package(package_uid, resource, codebase):
     """
-    Append `package_uid` to `resource.for_packages`, if the attribute exists.
+    Append `package_uid` to `resource.for_packages`, if the attribute exists and
+    `package_uid` is not already in `resource.for_packages`.
     """
     if hasattr(resource, 'for_packages') and isinstance(resource.for_packages, list):
+        if package_uid in resource.for_packages:
+            return
         resource.for_packages.append(package_uid)
         resource.save(codebase)
 

--- a/src/packagedcode/pypi.py
+++ b/src/packagedcode/pypi.py
@@ -316,7 +316,7 @@ class PythonInstalledWheelMetadataFile(BasePypiHandler):
         Assign files to package for an installed wheel. This requires a bit
         of navigation around as the files can be in multiple places.
         """
-        site_packages = resource.parent(codebase).parent(codebase).parent(codebase)
+        site_packages = resource.parent(codebase).parent(codebase)
         if not site_packages:
             return
         package_data = resource.package_data

--- a/src/packagedcode/pypi.py
+++ b/src/packagedcode/pypi.py
@@ -342,7 +342,7 @@ class PythonInstalledWheelMetadataFile(BasePypiHandler):
                 cannot_resolve = False
                 ref_resource = None
                 while path_ref.startswith('..'):
-                    _, _, path_ref.partition('../')
+                    _, _, path_ref = path_ref.partition('../')
                     ref_resource = site_packages.parent(codebase)
                     if not ref_resource:
                         cannot_resolve = True

--- a/tests/packagedcode/data/debian/basic-rootfs-expected.json
+++ b/tests/packagedcode/data/debian/basic-rootfs-expected.json
@@ -319,7 +319,6 @@
         }
       ],
       "for_packages": [
-        "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758",
         "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []

--- a/tests/packagedcode/data/debian/debian-container-layer.tar.xz.get-installed-expected.json
+++ b/tests/packagedcode/data/debian/debian-container-layer.tar.xz.get-installed-expected.json
@@ -359,58 +359,6 @@
           }
         ],
         "for_packages": [
-          "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758",
-          "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758"
-        ],
-        "scan_errors": []
-      },
-      {
-        "path": "debian-container-layer.tar.xz/usr/share/doc/libndp0/copyright",
-        "type": "file",
-        "package_data": [
-          {
-            "type": "deb",
-            "namespace": null,
-            "name": "libndp0",
-            "version": null,
-            "qualifiers": {},
-            "subpath": null,
-            "primary_language": null,
-            "description": null,
-            "release_date": null,
-            "parties": [],
-            "keywords": [],
-            "homepage_url": null,
-            "download_url": null,
-            "size": null,
-            "sha1": null,
-            "md5": null,
-            "sha256": null,
-            "sha512": null,
-            "bug_tracking_url": null,
-            "code_view_url": null,
-            "vcs_url": null,
-            "copyright": "Copyright 2013 Jiri Pirko <jiri@resnulli.us>\nCopyright 2014 Andrew Ayer <agwa@andrewayer.name>",
-            "license_expression": "(lgpl-2.1-plus AND lgpl-2.1-plus AND lgpl-2.1) AND (lgpl-2.1-plus AND lgpl-2.1-plus AND lgpl-2.1)",
-            "declared_license": [
-              "LGPL-2.1+",
-              "LGPL-2.1+",
-              "LGPL-2.1+"
-            ],
-            "notice_text": null,
-            "source_packages": [],
-            "file_references": [],
-            "extra_data": {},
-            "dependencies": [],
-            "repository_homepage_url": null,
-            "repository_download_url": null,
-            "api_data_url": null,
-            "datasource_id": "debian_copyright_in_package",
-            "purl": "pkg:deb/libndp0"
-          }
-        ],
-        "for_packages": [
-          "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758",
           "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758"
         ],
         "scan_errors": []

--- a/tests/packagedcode/data/debian/debian-container-layer.tar.xz.scan-expected.json
+++ b/tests/packagedcode/data/debian/debian-container-layer.tar.xz.scan-expected.json
@@ -333,7 +333,6 @@
         }
       ],
       "for_packages": [
-        "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758",
         "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []

--- a/tests/packagedcode/data/plugin/get_installed_packages-expected.json
+++ b/tests/packagedcode/data/plugin/get_installed_packages-expected.json
@@ -359,58 +359,6 @@
           }
         ],
         "for_packages": [
-          "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758",
-          "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758"
-        ],
-        "scan_errors": []
-      },
-      {
-        "path": "basic-rootfs.tar.gz/usr/share/doc/libndp0/copyright",
-        "type": "file",
-        "package_data": [
-          {
-            "type": "deb",
-            "namespace": null,
-            "name": "libndp0",
-            "version": null,
-            "qualifiers": {},
-            "subpath": null,
-            "primary_language": null,
-            "description": null,
-            "release_date": null,
-            "parties": [],
-            "keywords": [],
-            "homepage_url": null,
-            "download_url": null,
-            "size": null,
-            "sha1": null,
-            "md5": null,
-            "sha256": null,
-            "sha512": null,
-            "bug_tracking_url": null,
-            "code_view_url": null,
-            "vcs_url": null,
-            "copyright": "Copyright 2013 Jiri Pirko <jiri@resnulli.us>\nCopyright 2014 Andrew Ayer <agwa@andrewayer.name>",
-            "license_expression": "(lgpl-2.1-plus AND lgpl-2.1-plus AND lgpl-2.1) AND (lgpl-2.1-plus AND lgpl-2.1-plus AND lgpl-2.1)",
-            "declared_license": [
-              "LGPL-2.1+",
-              "LGPL-2.1+",
-              "LGPL-2.1+"
-            ],
-            "notice_text": null,
-            "source_packages": [],
-            "file_references": [],
-            "extra_data": {},
-            "dependencies": [],
-            "repository_homepage_url": null,
-            "repository_download_url": null,
-            "api_data_url": null,
-            "datasource_id": "debian_copyright_in_package",
-            "purl": "pkg:deb/libndp0"
-          }
-        ],
-        "for_packages": [
-          "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758",
           "pkg:deb/libndp0@1.4-2ubuntu0.16.04.1?architecture=amd64&uuid=fixed-uid-done-for-testing-5642512d1758"
         ],
         "scan_errors": []

--- a/tests/packagedcode/data/pypi/site-packages/site-packages-expected.json
+++ b/tests/packagedcode/data/pypi/site-packages/site-packages-expected.json
@@ -254,14 +254,18 @@
       "path": "lib/python3.9/site-packages/click-8.0.4.dist-info/INSTALLER",
       "type": "file",
       "package_data": [],
-      "for_packages": [],
+      "for_packages": [
+        "pkg:pypi/click@8.0.4?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
       "scan_errors": []
     },
     {
       "path": "lib/python3.9/site-packages/click-8.0.4.dist-info/LICENSE.rst",
       "type": "file",
       "package_data": [],
-      "for_packages": [],
+      "for_packages": [
+        "pkg:pypi/click@8.0.4?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
       "scan_errors": []
     },
     {
@@ -736,28 +740,36 @@
       "path": "lib/python3.9/site-packages/click-8.0.4.dist-info/RECORD",
       "type": "file",
       "package_data": [],
-      "for_packages": [],
+      "for_packages": [
+        "pkg:pypi/click@8.0.4?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
       "scan_errors": []
     },
     {
       "path": "lib/python3.9/site-packages/click-8.0.4.dist-info/WHEEL",
       "type": "file",
       "package_data": [],
-      "for_packages": [],
+      "for_packages": [
+        "pkg:pypi/click@8.0.4?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
       "scan_errors": []
     },
     {
       "path": "lib/python3.9/site-packages/click-8.0.4.dist-info/top_level.txt",
       "type": "file",
       "package_data": [],
-      "for_packages": [],
+      "for_packages": [
+        "pkg:pypi/click@8.0.4?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
       "scan_errors": []
     },
     {
       "path": "lib/python3.9/site-packages/click/core.py",
       "type": "file",
       "package_data": [],
-      "for_packages": [],
+      "for_packages": [
+        "pkg:pypi/click@8.0.4?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
       "scan_errors": []
     },
     {

--- a/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted-expected.json
+++ b/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted-expected.json
@@ -1,0 +1,368 @@
+{
+  "dependencies": [
+    {
+      "purl": "pkg:pypi/dask",
+      "extracted_requirement": "dask[delayed]<2023.0.0,>=2022.7.1",
+      "scope": "install",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_resolved": false,
+      "resolved_package": {},
+      "extra_data": {},
+      "dependency_uid": "pkg:pypi/dask?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_path": "daglib_wheel_extracted/daglib-0.6.0.dist-info/METADATA",
+      "datasource_id": "pypi_wheel_metadata"
+    },
+    {
+      "purl": "pkg:pypi/graphviz",
+      "extracted_requirement": "graphviz<0.21,>=0.20; extra == \"graphviz\"",
+      "scope": "graphviz",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_resolved": false,
+      "resolved_package": {},
+      "extra_data": {},
+      "dependency_uid": "pkg:pypi/graphviz?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_path": "daglib_wheel_extracted/daglib-0.6.0.dist-info/METADATA",
+      "datasource_id": "pypi_wheel_metadata"
+    },
+    {
+      "purl": "pkg:pypi/ipycytoscape",
+      "extracted_requirement": "ipycytoscape<2.0.0,>=1.3.3; extra == \"ipycytoscape\"",
+      "scope": "ipycytoscape",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_resolved": false,
+      "resolved_package": {},
+      "extra_data": {},
+      "dependency_uid": "pkg:pypi/ipycytoscape?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_path": "daglib_wheel_extracted/daglib-0.6.0.dist-info/METADATA",
+      "datasource_id": "pypi_wheel_metadata"
+    },
+    {
+      "purl": "pkg:pypi/networkx",
+      "extracted_requirement": "networkx<3.0.0,>=2.8.5",
+      "scope": "install",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_resolved": false,
+      "resolved_package": {},
+      "extra_data": {},
+      "dependency_uid": "pkg:pypi/networkx?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_path": "daglib_wheel_extracted/daglib-0.6.0.dist-info/METADATA",
+      "datasource_id": "pypi_wheel_metadata"
+    }
+  ],
+  "packages": [
+    {
+      "type": "pypi",
+      "namespace": null,
+      "name": "daglib",
+      "version": "0.6.0",
+      "qualifiers": {},
+      "subpath": null,
+      "primary_language": "Python",
+      "description": "# \u2697\ufe0f Daglib - Lightweight DAG composition framework\n\n[![PyPI version](https://badge.fury.io/py/daglib.svg)](https://badge.fury.io/py/daglib)\n[![PyPI - Downloads](https://img.shields.io/pypi/dm/daglib)](https://pypi.org/project/daglib/)\n[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/daglib.svg)](https://pypi.org/project/daglib/)\n[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)\n[![Checked with mypy](https://img.shields.io/badge/mypy-checked-blue.svg)](https://mypy.readthedocs.io/en/stable/)\n[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)\n\nDaglib is a lightweight, embeddable parallel task execution library used for turning pure Python functions into executable task graphs.\n\n# Installation\n\nCore\n\n```shell\npip install daglib\n```\n\nWith visualizations enabled\n\n```shell\npip install 'daglib[graphviz]'  # static visualizations\n# or\npip install 'daglib[ipycytoscape]'  # interactive visulizations\n```\n\n# Create your first DAG\n\n\n```python\nimport daglib\n\ndag = daglib.Dag()\n\n\n@dag.task()\ndef task_1a():\n    return \"Hello\"\n\n\n@dag.task()\ndef task_1b():\n    return \"world!\"\n\n\n@dag.task()\ndef task_2(task_1a, task_1b):\n    return f\"{task_1a}, {task_1b}\"\n\n\ndag.run()\n```\n\n\n\n\n    'Hello, world!'\n\n\n\n# Beyond the \"Hello, world!\" example\n\nFor a more involved example, we will create a small pipeline that takes data from four source tables and creates a single reporting table. The data is driver-level information from the current 2022 Formula 1 season. The output will be a pivot table for team-level metrics.\n\n## Source Tables\n\n1. Team - Team of driver\n2. Points - Current total Driver's World Championship points for each driver for the season\n3. Wins - Current number of wins for each driver for the season\n4. Podiums - Current number of times the driver finished in the top 3 for the season\n\n\n```python\nimport pandas as pd\nimport daglib\n\n# Ignore. Used to render the DataFrame correctly in the README\npd.set_option(\"display.notebook_repr_html\", False)\n\ndag = daglib.Dag()\n\n\n@dag.task()\ndef team():\n    return pd.DataFrame(dict(\n        driver=[\"Max\", \"Charles\", \"Lewis\", \"Sergio\", \"Carlos\", \"George\"],\n        team=[\"Red Bull\", \"Ferrari\", \"Mercedes\", \"Red Bull\", \"Ferrari\", \"Mercedes\"],\n    )).set_index(\"driver\")\n\n\n@dag.task()\ndef points():\n    return pd.DataFrame(dict(\n        driver=[\"Max\", \"Charles\", \"Lewis\", \"Sergio\", \"Carlos\", \"George\"],\n        points=[258, 178, 146, 173, 156, 158]\n    )).set_index(\"driver\")\n\n\n@dag.task()\ndef wins():\n    return pd.DataFrame(dict(\n        driver=[\"Max\", \"Charles\", \"Lewis\", \"Sergio\", \"Carlos\", \"George\"],\n        wins=[8, 3, 0, 1, 1, 0]\n    )).set_index(\"driver\")\n\n\n@dag.task()\ndef podiums():\n    return pd.DataFrame(dict(\n        driver=[\"Max\", \"Charles\", \"Lewis\", \"Sergio\", \"Carlos\", \"George\"],\n        podiums=[10, 5, 6, 6, 6, 5]\n    )).set_index(\"driver\")\n\n\n@dag.task()\ndef driver_metrics(team, points, wins, podiums):\n    return team.join(points).join(wins).join(podiums)\n\n\n@dag.task()\ndef team_metrics(driver_metrics):\n    return driver_metrics.groupby(\"team\").sum().sort_values(\"points\", ascending=False)\n\n\ndag.run()\n```\n\n\n\n\n              points  wins  podiums\n    team\n    Red Bull     431     9       16\n    Ferrari      334     4       11\n    Mercedes     304     0       11\n\n\n\n## Task Graph Visualization\n\nThe DAG we created above will create a task graph that looks like the following\n\n![task graph](https://storage.googleapis.com/daglib-image-assets/example-dag.png)",
+      "release_date": null,
+      "parties": [
+        {
+          "type": "person",
+          "role": "author",
+          "name": "Michael Harris",
+          "email": "mharris@luabase.com",
+          "url": null
+        }
+      ],
+      "keywords": [
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10"
+      ],
+      "homepage_url": "https://github.com/mharrisb1/daglib",
+      "download_url": null,
+      "size": null,
+      "sha1": null,
+      "md5": null,
+      "sha256": null,
+      "sha512": null,
+      "bug_tracking_url": null,
+      "code_view_url": null,
+      "vcs_url": "https://github.com/mharrisb1/daglib",
+      "copyright": null,
+      "license_expression": "mit AND mit",
+      "declared_license": {
+        "license": "MIT",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License"
+        ]
+      },
+      "notice_text": null,
+      "source_packages": [],
+      "extra_data": {
+        "Documentation": "https://mharrisb1.github.io/daglib/"
+      },
+      "repository_homepage_url": "https://pypi.org/project/daglib",
+      "repository_download_url": "https://pypi.org/packages/source/d/daglib/daglib-0.6.0.tar.gz",
+      "api_data_url": "https://pypi.org/pypi/daglib/0.6.0/json",
+      "package_uid": "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_paths": [
+        "daglib_wheel_extracted/daglib-0.6.0.dist-info/METADATA"
+      ],
+      "datasource_ids": [
+        "pypi_wheel_metadata"
+      ],
+      "purl": "pkg:pypi/daglib@0.6.0"
+    }
+  ],
+  "files": [
+    {
+      "path": "daglib_wheel_extracted",
+      "type": "directory",
+      "package_data": [],
+      "for_packages": [],
+      "scan_errors": []
+    },
+    {
+      "path": "daglib_wheel_extracted/daglib",
+      "type": "directory",
+      "package_data": [],
+      "for_packages": [],
+      "scan_errors": []
+    },
+    {
+      "path": "daglib_wheel_extracted/daglib-0.6.0.dist-info",
+      "type": "directory",
+      "package_data": [],
+      "for_packages": [],
+      "scan_errors": []
+    },
+    {
+      "path": "daglib_wheel_extracted/daglib-0.6.0.dist-info/LICENSE",
+      "type": "file",
+      "package_data": [],
+      "for_packages": [
+        "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
+      "scan_errors": []
+    },
+    {
+      "path": "daglib_wheel_extracted/daglib-0.6.0.dist-info/METADATA",
+      "type": "file",
+      "package_data": [
+        {
+          "type": "pypi",
+          "namespace": null,
+          "name": "daglib",
+          "version": "0.6.0",
+          "qualifiers": {},
+          "subpath": null,
+          "primary_language": "Python",
+          "description": "# \u2697\ufe0f Daglib - Lightweight DAG composition framework\n\n[![PyPI version](https://badge.fury.io/py/daglib.svg)](https://badge.fury.io/py/daglib)\n[![PyPI - Downloads](https://img.shields.io/pypi/dm/daglib)](https://pypi.org/project/daglib/)\n[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/daglib.svg)](https://pypi.org/project/daglib/)\n[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)\n[![Checked with mypy](https://img.shields.io/badge/mypy-checked-blue.svg)](https://mypy.readthedocs.io/en/stable/)\n[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)\n\nDaglib is a lightweight, embeddable parallel task execution library used for turning pure Python functions into executable task graphs.\n\n# Installation\n\nCore\n\n```shell\npip install daglib\n```\n\nWith visualizations enabled\n\n```shell\npip install 'daglib[graphviz]'  # static visualizations\n# or\npip install 'daglib[ipycytoscape]'  # interactive visulizations\n```\n\n# Create your first DAG\n\n\n```python\nimport daglib\n\ndag = daglib.Dag()\n\n\n@dag.task()\ndef task_1a():\n    return \"Hello\"\n\n\n@dag.task()\ndef task_1b():\n    return \"world!\"\n\n\n@dag.task()\ndef task_2(task_1a, task_1b):\n    return f\"{task_1a}, {task_1b}\"\n\n\ndag.run()\n```\n\n\n\n\n    'Hello, world!'\n\n\n\n# Beyond the \"Hello, world!\" example\n\nFor a more involved example, we will create a small pipeline that takes data from four source tables and creates a single reporting table. The data is driver-level information from the current 2022 Formula 1 season. The output will be a pivot table for team-level metrics.\n\n## Source Tables\n\n1. Team - Team of driver\n2. Points - Current total Driver's World Championship points for each driver for the season\n3. Wins - Current number of wins for each driver for the season\n4. Podiums - Current number of times the driver finished in the top 3 for the season\n\n\n```python\nimport pandas as pd\nimport daglib\n\n# Ignore. Used to render the DataFrame correctly in the README\npd.set_option(\"display.notebook_repr_html\", False)\n\ndag = daglib.Dag()\n\n\n@dag.task()\ndef team():\n    return pd.DataFrame(dict(\n        driver=[\"Max\", \"Charles\", \"Lewis\", \"Sergio\", \"Carlos\", \"George\"],\n        team=[\"Red Bull\", \"Ferrari\", \"Mercedes\", \"Red Bull\", \"Ferrari\", \"Mercedes\"],\n    )).set_index(\"driver\")\n\n\n@dag.task()\ndef points():\n    return pd.DataFrame(dict(\n        driver=[\"Max\", \"Charles\", \"Lewis\", \"Sergio\", \"Carlos\", \"George\"],\n        points=[258, 178, 146, 173, 156, 158]\n    )).set_index(\"driver\")\n\n\n@dag.task()\ndef wins():\n    return pd.DataFrame(dict(\n        driver=[\"Max\", \"Charles\", \"Lewis\", \"Sergio\", \"Carlos\", \"George\"],\n        wins=[8, 3, 0, 1, 1, 0]\n    )).set_index(\"driver\")\n\n\n@dag.task()\ndef podiums():\n    return pd.DataFrame(dict(\n        driver=[\"Max\", \"Charles\", \"Lewis\", \"Sergio\", \"Carlos\", \"George\"],\n        podiums=[10, 5, 6, 6, 6, 5]\n    )).set_index(\"driver\")\n\n\n@dag.task()\ndef driver_metrics(team, points, wins, podiums):\n    return team.join(points).join(wins).join(podiums)\n\n\n@dag.task()\ndef team_metrics(driver_metrics):\n    return driver_metrics.groupby(\"team\").sum().sort_values(\"points\", ascending=False)\n\n\ndag.run()\n```\n\n\n\n\n              points  wins  podiums\n    team\n    Red Bull     431     9       16\n    Ferrari      334     4       11\n    Mercedes     304     0       11\n\n\n\n## Task Graph Visualization\n\nThe DAG we created above will create a task graph that looks like the following\n\n![task graph](https://storage.googleapis.com/daglib-image-assets/example-dag.png)",
+          "release_date": null,
+          "parties": [
+            {
+              "type": "person",
+              "role": "author",
+              "name": "Michael Harris",
+              "email": "mharris@luabase.com",
+              "url": null
+            }
+          ],
+          "keywords": [
+            "Intended Audience :: Developers",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.10"
+          ],
+          "homepage_url": "https://github.com/mharrisb1/daglib",
+          "download_url": null,
+          "size": null,
+          "sha1": null,
+          "md5": null,
+          "sha256": null,
+          "sha512": null,
+          "bug_tracking_url": null,
+          "code_view_url": null,
+          "vcs_url": "https://github.com/mharrisb1/daglib",
+          "copyright": null,
+          "license_expression": "mit AND mit",
+          "declared_license": {
+            "license": "MIT",
+            "classifiers": [
+              "License :: OSI Approved :: MIT License"
+            ]
+          },
+          "notice_text": null,
+          "source_packages": [],
+          "file_references": [
+            {
+              "path": "daglib/__init__.py",
+              "size": 72,
+              "sha1": null,
+              "md5": null,
+              "sha256": "cd90a1522c161cf60c8981d6a5a9348c732dd3532b2da2a3b508dd1e3a8a6773",
+              "sha512": null,
+              "extra_data": {}
+            },
+            {
+              "path": "daglib/dag.py",
+              "size": 2761,
+              "sha1": null,
+              "md5": null,
+              "sha256": "dbd566e03890a1c57ab5256ef696495193e6a9cf90ec4ba31d4ef10f8a8f25a6",
+              "sha512": null,
+              "extra_data": {}
+            },
+            {
+              "path": "daglib/task.py",
+              "size": 4531,
+              "sha1": null,
+              "md5": null,
+              "sha256": "a2e59ff7bf4853a38a8298fa8f8df4d41db0a38eb09132a392416bd89a7ec63d",
+              "sha512": null,
+              "extra_data": {}
+            },
+            {
+              "path": "daglib-0.6.0.dist-info/LICENSE",
+              "size": 1058,
+              "sha1": null,
+              "md5": null,
+              "sha256": "f9352835d15f73e2d01bae747b6ce3386a23be2fb73c06df799fba97a5bc98a2",
+              "sha512": null,
+              "extra_data": {}
+            },
+            {
+              "path": "daglib-0.6.0.dist-info/WHEEL",
+              "size": 83,
+              "sha1": null,
+              "md5": null,
+              "sha256": "0c0f3afe1e10c30cc6791a33eb6a35b2f62de641845e9a144ee4edc33a136f7d",
+              "sha512": null,
+              "extra_data": {}
+            },
+            {
+              "path": "daglib-0.6.0.dist-info/METADATA",
+              "size": 4493,
+              "sha1": null,
+              "md5": null,
+              "sha256": "f01ba45128006ed4748cef8bd1e7f66bd4b5f86f1a657e3f3e4fee3a4d328cf2",
+              "sha512": null,
+              "extra_data": {}
+            },
+            {
+              "path": "daglib-0.6.0.dist-info/RECORD",
+              "size": null,
+              "sha1": null,
+              "md5": null,
+              "sha256": null,
+              "sha512": null,
+              "extra_data": {}
+            }
+          ],
+          "extra_data": {
+            "Documentation": "https://mharrisb1.github.io/daglib/"
+          },
+          "dependencies": [
+            {
+              "purl": "pkg:pypi/dask",
+              "extracted_requirement": "dask[delayed]<2023.0.0,>=2022.7.1",
+              "scope": "install",
+              "is_runtime": true,
+              "is_optional": false,
+              "is_resolved": false,
+              "resolved_package": {},
+              "extra_data": {}
+            },
+            {
+              "purl": "pkg:pypi/graphviz",
+              "extracted_requirement": "graphviz<0.21,>=0.20; extra == \"graphviz\"",
+              "scope": "graphviz",
+              "is_runtime": true,
+              "is_optional": false,
+              "is_resolved": false,
+              "resolved_package": {},
+              "extra_data": {}
+            },
+            {
+              "purl": "pkg:pypi/ipycytoscape",
+              "extracted_requirement": "ipycytoscape<2.0.0,>=1.3.3; extra == \"ipycytoscape\"",
+              "scope": "ipycytoscape",
+              "is_runtime": true,
+              "is_optional": false,
+              "is_resolved": false,
+              "resolved_package": {},
+              "extra_data": {}
+            },
+            {
+              "purl": "pkg:pypi/networkx",
+              "extracted_requirement": "networkx<3.0.0,>=2.8.5",
+              "scope": "install",
+              "is_runtime": true,
+              "is_optional": false,
+              "is_resolved": false,
+              "resolved_package": {},
+              "extra_data": {}
+            }
+          ],
+          "repository_homepage_url": "https://pypi.org/project/daglib",
+          "repository_download_url": "https://pypi.org/packages/source/d/daglib/daglib-0.6.0.tar.gz",
+          "api_data_url": "https://pypi.org/pypi/daglib/0.6.0/json",
+          "datasource_id": "pypi_wheel_metadata",
+          "purl": "pkg:pypi/daglib@0.6.0"
+        }
+      ],
+      "for_packages": [
+        "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
+      "scan_errors": []
+    },
+    {
+      "path": "daglib_wheel_extracted/daglib-0.6.0.dist-info/RECORD",
+      "type": "file",
+      "package_data": [],
+      "for_packages": [
+        "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
+      "scan_errors": []
+    },
+    {
+      "path": "daglib_wheel_extracted/daglib-0.6.0.dist-info/WHEEL",
+      "type": "file",
+      "package_data": [],
+      "for_packages": [
+        "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
+      "scan_errors": []
+    },
+    {
+      "path": "daglib_wheel_extracted/daglib/__init__.py",
+      "type": "file",
+      "package_data": [],
+      "for_packages": [
+        "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
+      "scan_errors": []
+    },
+    {
+      "path": "daglib_wheel_extracted/daglib/dag.py",
+      "type": "file",
+      "package_data": [],
+      "for_packages": [
+        "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
+      "scan_errors": []
+    },
+    {
+      "path": "daglib_wheel_extracted/daglib/task.py",
+      "type": "file",
+      "package_data": [],
+      "for_packages": [
+        "pkg:pypi/daglib@0.6.0?uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
+      "scan_errors": []
+    }
+  ]
+}

--- a/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib-0.6.0.dist-info/LICENSE
+++ b/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib-0.6.0.dist-info/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2022 Michael Harris
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib-0.6.0.dist-info/METADATA
+++ b/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib-0.6.0.dist-info/METADATA
@@ -1,0 +1,168 @@
+Metadata-Version: 2.1
+Name: daglib
+Version: 0.6.0
+Summary: Lightweight DAG composition framework
+Home-page: https://github.com/mharrisb1/daglib
+License: MIT
+Author: Michael Harris
+Author-email: mharris@luabase.com
+Requires-Python: >=3.10,<4.0
+Classifier: Intended Audience :: Developers
+Classifier: License :: OSI Approved :: MIT License
+Classifier: Programming Language :: Python :: 3
+Classifier: Programming Language :: Python :: 3.10
+Provides-Extra: graphviz
+Provides-Extra: ipycytoscape
+Requires-Dist: dask[delayed] (>=2022.7.1,<2023.0.0)
+Requires-Dist: graphviz (>=0.20,<0.21); extra == "graphviz"
+Requires-Dist: ipycytoscape (>=1.3.3,<2.0.0); extra == "ipycytoscape"
+Requires-Dist: networkx (>=2.8.5,<3.0.0)
+Project-URL: Documentation, https://mharrisb1.github.io/daglib/
+Project-URL: Repository, https://github.com/mharrisb1/daglib
+Description-Content-Type: text/markdown
+
+# ⚗️ Daglib - Lightweight DAG composition framework
+
+[![PyPI version](https://badge.fury.io/py/daglib.svg)](https://badge.fury.io/py/daglib)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/daglib)](https://pypi.org/project/daglib/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/daglib.svg)](https://pypi.org/project/daglib/)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
+[![Checked with mypy](https://img.shields.io/badge/mypy-checked-blue.svg)](https://mypy.readthedocs.io/en/stable/)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+
+Daglib is a lightweight, embeddable parallel task execution library used for turning pure Python functions into executable task graphs.
+
+# Installation
+
+Core
+
+```shell
+pip install daglib
+```
+
+With visualizations enabled
+
+```shell
+pip install 'daglib[graphviz]'  # static visualizations
+# or
+pip install 'daglib[ipycytoscape]'  # interactive visulizations
+```
+
+# Create your first DAG
+
+
+```python
+import daglib
+
+dag = daglib.Dag()
+
+
+@dag.task()
+def task_1a():
+    return "Hello"
+
+
+@dag.task()
+def task_1b():
+    return "world!"
+
+
+@dag.task()
+def task_2(task_1a, task_1b):
+    return f"{task_1a}, {task_1b}"
+
+
+dag.run()
+```
+
+
+
+
+    'Hello, world!'
+
+
+
+# Beyond the "Hello, world!" example
+
+For a more involved example, we will create a small pipeline that takes data from four source tables and creates a single reporting table. The data is driver-level information from the current 2022 Formula 1 season. The output will be a pivot table for team-level metrics.
+
+## Source Tables
+
+1. Team - Team of driver
+2. Points - Current total Driver's World Championship points for each driver for the season
+3. Wins - Current number of wins for each driver for the season
+4. Podiums - Current number of times the driver finished in the top 3 for the season
+
+
+```python
+import pandas as pd
+import daglib
+
+# Ignore. Used to render the DataFrame correctly in the README
+pd.set_option("display.notebook_repr_html", False)
+
+dag = daglib.Dag()
+
+
+@dag.task()
+def team():
+    return pd.DataFrame(dict(
+        driver=["Max", "Charles", "Lewis", "Sergio", "Carlos", "George"],
+        team=["Red Bull", "Ferrari", "Mercedes", "Red Bull", "Ferrari", "Mercedes"],
+    )).set_index("driver")
+
+
+@dag.task()
+def points():
+    return pd.DataFrame(dict(
+        driver=["Max", "Charles", "Lewis", "Sergio", "Carlos", "George"],
+        points=[258, 178, 146, 173, 156, 158]
+    )).set_index("driver")
+
+
+@dag.task()
+def wins():
+    return pd.DataFrame(dict(
+        driver=["Max", "Charles", "Lewis", "Sergio", "Carlos", "George"],
+        wins=[8, 3, 0, 1, 1, 0]
+    )).set_index("driver")
+
+
+@dag.task()
+def podiums():
+    return pd.DataFrame(dict(
+        driver=["Max", "Charles", "Lewis", "Sergio", "Carlos", "George"],
+        podiums=[10, 5, 6, 6, 6, 5]
+    )).set_index("driver")
+
+
+@dag.task()
+def driver_metrics(team, points, wins, podiums):
+    return team.join(points).join(wins).join(podiums)
+
+
+@dag.task()
+def team_metrics(driver_metrics):
+    return driver_metrics.groupby("team").sum().sort_values("points", ascending=False)
+
+
+dag.run()
+```
+
+
+
+
+              points  wins  podiums
+    team
+    Red Bull     431     9       16
+    Ferrari      334     4       11
+    Mercedes     304     0       11
+
+
+
+## Task Graph Visualization
+
+The DAG we created above will create a task graph that looks like the following
+
+![task graph](https://storage.googleapis.com/daglib-image-assets/example-dag.png)
+

--- a/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib-0.6.0.dist-info/RECORD
+++ b/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib-0.6.0.dist-info/RECORD
@@ -1,0 +1,7 @@
+daglib/__init__.py,sha256=zZChUiwWHPYMiYHWpak0jHMt01MrLaKjtQjdHjqKZ3M,72
+daglib/dag.py,sha256=29Vm4DiQocV6tSVu9pZJUZPmqc-Q7EujHU7xD4qPJaY,2761
+daglib/task.py,sha256=ouWf979IU6OKgpj6j4301B2wo46wkTKjkkFr2Jp-xj0,4531
+daglib-0.6.0.dist-info/LICENSE,sha256=-TUoNdFfc-LQG650e2zjOGojvi-3PAbfeZ-6l6W8mKI,1058
+daglib-0.6.0.dist-info/WHEEL,sha256=DA86_h4QwwzGeRoz62o1svYt5kGEXpoUTuTtwzoTb30,83
+daglib-0.6.0.dist-info/METADATA,sha256=8BukUSgAbtR0jO-L0ef2a9S1-G8aZX4_Pk_uOk0yjPI,4493
+daglib-0.6.0.dist-info/RECORD,,

--- a/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib-0.6.0.dist-info/WHEEL
+++ b/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib-0.6.0.dist-info/WHEEL
@@ -1,0 +1,4 @@
+Wheel-Version: 1.0
+Generator: poetry 1.0.8
+Root-Is-Purelib: true
+Tag: py3-none-any

--- a/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib/__init__.py
+++ b/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib/__init__.py
@@ -1,0 +1,4 @@
+from .dag import Dag
+from .task import Task, Arg
+
+__version__ = "0.5.0"

--- a/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib/dag.py
+++ b/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib/dag.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Callable
+
+import networkx as nx
+from dask.delayed import Delayed
+from dask.optimization import cull
+
+from daglib.task import Task, Arg
+
+
+class Dag:
+    def __init__(self, name: str = uuid.uuid4().hex, description: str = "") -> None:
+        self.name = "".join(x for x in name if x.isalnum()).lower()
+        self.description = description
+        self._tasks_by_name: dict[str, Task] = {}
+        self.nxg = nx.DiGraph()
+
+    @property
+    def run_id(self) -> str:
+        return f"run_{uuid.uuid1().hex}"
+
+    def add_subdag(self, other: Dag) -> None:
+        self._tasks_by_name |= other._tasks_by_name
+
+    def register_task(self, task: Task) -> Task:
+        self._tasks_by_name[task.name] = task
+        return task
+
+    def register_task_from_function(
+        self, fn: Callable[..., Any], name: str | None = None, args: list[Arg] | None = None
+    ) -> Callable[..., Any]:
+        task = Task.from_function(fn, name=name, args=args)
+        self.register_task(task)
+        return fn
+
+    def task(self) -> Any:
+        def register(fn: Callable[..., Any]) -> Callable[..., Any]:
+            return self.register_task_from_function(fn)
+
+        return register
+
+    def _build_graph(self) -> None:
+        edges = [(self._tasks_by_name[arg.name], task) for task in self._tasks_by_name.values() for arg in task.args]
+        self.nxg = nx.DiGraph(edges)
+
+    @property
+    def _dsk(self) -> dict[str, tuple[Any, ...]]:
+        return {task.name: tuple([task.fn, *[arg.name for arg in task.args]]) for task in nx.topological_sort(self.nxg)}
+
+    @property
+    def _keys(self) -> list[str]:
+        return [task.name for task in self.nxg.nodes if not list(self.nxg.successors(task))]
+
+    def materialize(self, to_step: str | Callable[..., Any] | None = None, optimize: bool = False) -> Delayed:
+        self._build_graph()
+        keys: list[str] | str = self._keys
+        if len(keys) == 1:
+            keys = keys[0]
+        dsk = self._dsk
+        if to_step:
+            if callable(to_step):
+                keys = to_step.__name__
+            optimize = True
+        if optimize:
+            layers, _ = cull(dsk, keys)
+        return Delayed(keys, dsk)
+
+    def run(self, to_step: str | Callable[..., Any] | None = None, optimize: bool = False) -> Any:
+        return self.materialize(to_step, optimize).compute()
+
+    # noinspection PyShadowingBuiltins
+    def visualize(
+        self,
+        to_step: str | Callable[..., Any] | None = None,
+        optimize: bool = False,
+        filename: str | None = None,
+        format: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        return self.materialize(to_step, optimize).visualize(filename, format, **kwargs)

--- a/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib/task.py
+++ b/tests/packagedcode/data/pypi/unpacked_wheel/daglib_wheel_extracted/daglib/task.py
@@ -1,0 +1,145 @@
+from __future__ import annotations as _annotations  # avoids name conflict with constructor arg
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+
+@dataclass
+class Arg:
+    """Mutable argument dataclass. Used as an abstraction of a function argument
+    with a name, type, and default value."""
+
+    name: str
+    type: type | None = field(default=None)
+    default: Any | None = field(default=None)
+
+
+class Task:
+    """Mutable task object with chained setters"""
+
+    def __init__(
+        self,
+        fn: Callable[..., Any],
+        *,
+        name: str,
+        description: str | None = "",
+        annotations: dict[str, type] | None = None,
+        return_type: type | None = None,
+        defaults: tuple[Any, ...] = (),
+        args: list[Arg] | None = None,
+    ) -> None:
+        """
+
+        :param fn: Arbitrary function (can include lambda and partial functions)
+        :param name: Name of task
+        :param description: Description of task
+        :param annotations: Input and return value type annotations
+        :param return_type: Return type
+        :param defaults: Default values
+        :param args: Arguments for task
+        """
+        self._fn = fn
+        self._name = name
+        self._description = description
+        self._annotations = annotations if annotations else {}
+        self._return_type = return_type
+        self._defaults = defaults
+        self._args = args if args else []
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self.fn(*args, **kwargs)
+
+    @property
+    def fn(self) -> Callable[..., Any]:
+        return self._fn
+
+    def set_fn(self, fn: Callable[..., Any]) -> Task:
+        self._fn = fn
+        return self
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def set_name(self, name: str) -> Task:
+        self._name = name
+        return self
+
+    @property
+    def description(self) -> str | None:
+        return self._description
+
+    def set_description(self, description: str) -> Task:
+        self._description = description
+        return self
+
+    @property
+    def annotations(self) -> dict[str, type]:
+        return self._annotations
+
+    def set_annotations(self, annotations: dict[str, type]) -> Task:
+        self._annotations = annotations
+        return self
+
+    @property
+    def return_type(self) -> type | None:
+        return self._return_type
+
+    def set_return_type(self, return_type: type | None) -> Task:
+        self._return_type = return_type
+        return self
+
+    @property
+    def defaults(self) -> tuple[Any, ...]:
+        return self._defaults
+
+    def set_defaults(self, defaults: tuple[Any, ...]) -> Task:
+        self._defaults = defaults
+        return self
+
+    @property
+    def args(self) -> list[Arg]:
+        return self._args
+
+    def set_args(self, args: list[Arg]) -> Task:
+        self._args = args
+        return self
+
+    # noinspection PyUnresolvedReferences
+    @classmethod
+    def from_function(cls, fn: Callable[..., Any], name: str | None = None, args: list[Arg] | None = None) -> Task:
+        """
+        Create Task object from function. Values from function metadata will be passed to the Task
+        constructor.
+
+        :param fn: Arbitrary function (can include lambda and partial functions)
+        :param name: Optional name. If not provided then name will be grabbed from function metadata
+        :param args: Optional list of custom arguments. If not provided then args will be grabbed from function metadata
+        :return: Task object
+        """
+        name = fn.__name__ if not name else name
+        description = fn.__doc__
+        annotations = fn.__annotations__
+        return_type = annotations.get("return")
+        defaults = tuple(reversed(fn.__defaults__)) if fn.__defaults__ else tuple()  # type: ignore
+        if not args:
+            args = [Arg(n, None, None) for n in fn.__code__.co_varnames[: fn.__code__.co_argcount]]
+            for arg in args:
+                arg.type = annotations.get(arg.name)
+            for i, d in enumerate(defaults):
+                args[len(args) - 1 - i].default = d
+
+        return Task(
+            fn,
+            name=name,
+            description=description,
+            annotations=annotations,
+            return_type=return_type,
+            defaults=defaults,
+            args=args,
+        )
+
+    @classmethod
+    def from_object(cls, obj: Any, name: str) -> Task:
+        fn: Callable[[], Any] = lambda: obj
+        return Task.from_function(fn, name)

--- a/tests/packagedcode/test_package_models.py
+++ b/tests/packagedcode/test_package_models.py
@@ -182,6 +182,15 @@ class TestModels(PackageTester):
         )
         assert test_package.package_uid in test_resource.for_packages
 
+        # Test that we do not add a Package to a Resource if it is already there
+        assert len(test_resource.for_packages) == 1
+        models.add_to_package(
+            test_package.package_uid,
+            test_resource,
+            test_codebase
+        )
+        assert len(test_resource.for_packages) == 1
+
     def test_assembly_custom_package_adder(self):
         def test_package_adder(package_uid, resource, codebase):
             """

--- a/tests/packagedcode/test_pypi.py
+++ b/tests/packagedcode/test_pypi.py
@@ -57,6 +57,13 @@ class TestPyPiEndtoEnd(PackageTester):
         result = pypi.detect_version_attribute(test_loc)
         assert result == '22.0.4'
 
+    def test_package_scan_pypi_end_to_end_extracted_wheel(self):
+        test_dir = self.get_test_loc('pypi/unpacked_wheel/daglib_wheel_extracted/')
+        result_file = self.get_temp_file('json')
+        expected_file = self.get_test_loc('pypi/unpacked_wheel/daglib_wheel_extracted-expected.json')
+        run_scan_click(['--package', '--processes', '-1', test_dir, '--json-pp', result_file])
+        check_json_scan(expected_file, result_file, remove_uuid=True, regen=REGEN_TEST_FIXTURES)
+
 
 class TestPyPiDevelopEggInfoPkgInfo(PackageTester):
     test_data_dir = os.path.join(os.path.dirname(__file__), 'data')


### PR DESCRIPTION

This PR fixes a few issues in `PythonInstalledWheelMetadataFile.assign_package_to_resources()`:

- `PythonInstalledWheelMetadataFile.assign_package_to_resources()` would not correctly find the `site-packages` directory, as it called `.parent()` too many times on the datafile Resource.
- The variable `path_ref` was not being assigned correctly and `PythonInstalledWheelMetadataFile.assign_package_to_resources()` would fail during Package assembly.