### PR TITLE
Replace list comprehension with a generator

### DIFF
--- a/src/licensedcode/match_set.py
+++ b/src/licensedcode/match_set.py
@@ -149,7 +149,7 @@ def high_tids_set_subset(tids_set, len_legalese):
     """
     Return a subset of a set of token ids that are only legalese tokens.
     """
-    return intbitset([i for i in tids_set if i < len_legalese])
+    return intbitset(i for i in tids_set if i < len_legalese)
 
 
 def high_tids_multiset_subset(mset, len_legalese):


### PR DESCRIPTION
This avoids allocating a potentially long list.

While working on the next version of [Software Heritage's license dataset](https://annex.softwareheritage.org/public/dataset/license-blobs/2021-03-23/), I noticed calls to `scancode.api.get_license()` calls spent a lot of time in this function.

Avoiding the list materialization seems to make  `scancode.api.get_license()` take 40 to 50% less time overall

Signed-off-by: Valentin Lorentz <vlorentz@softwareheritage.org>

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁