### PR TITLE
Correct purl type for cocoapods #3081

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,13 @@ Package detection:
 
   https://github.com/nexB/scancode-toolkit/issues/3083
 
+- Fix issue where we were returning incorrect purl package ``type`` for cocoapods.
+  ``pods`` was being returned  as a purl type for cocoapods, it should be
+  ``cocoapods`` instead.
+  https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#cocoapods
+
+  https://github.com/nexB/scancode-toolkit/issues/3081
+
 License detection:
 ~~~~~~~~~~~~~~~~~~~
 

--- a/src/packagedcode/cocoapods.py
+++ b/src/packagedcode/cocoapods.py
@@ -194,7 +194,7 @@ class BasePodHandler(models.DatafileHandler):
 class PodspecHandler(BasePodHandler):
     datasource_id = 'cocoapods_podspec'
     path_patterns = ('*.podspec',)
-    default_package_type = 'pods'
+    default_package_type = 'cocoapods'
     default_primary_language = 'Objective-C'
     description = 'Cocoapods .podspec'
     documentation_url = 'https://guides.cocoapods.org/syntax/podspec.html'
@@ -266,7 +266,7 @@ class PodspecHandler(BasePodHandler):
 class PodfileHandler(PodspecHandler):
     datasource_id = 'cocoapods_podfile'
     path_patterns = ('*Podfile',)
-    default_package_type = 'pods'
+    default_package_type = 'cocoapods'
     default_primary_language = 'Objective-C'
     description = 'Cocoapods Podfile'
     documentation_url = 'https://guides.cocoapods.org/using/the-podfile.html'
@@ -275,7 +275,7 @@ class PodfileHandler(PodspecHandler):
 class PodfileLockHandler(BasePodHandler):
     datasource_id = 'cocoapods_podfile_lock'
     path_patterns = ('*Podfile.lock',)
-    default_package_type = 'pods'
+    default_package_type = 'cocoapods'
     default_primary_language = 'Objective-C'
     description = 'Cocoapods Podfile.lock'
     documentation_url = 'https://guides.cocoapods.org/using/the-podfile.html'
@@ -336,7 +336,7 @@ class PodfileLockHandler(BasePodHandler):
 class PodspecJsonHandler(models.DatafileHandler):
     datasource_id = 'cocoapods_podspec_json'
     path_patterns = ('*.podspec.json',)
-    default_package_type = 'pods'
+    default_package_type = 'cocoapods'
     default_primary_language = 'Objective-C'
     description = 'Cocoapods .podspec.json'
     documentation_url = 'https://guides.cocoapods.org/syntax/podspec.html'
@@ -523,14 +523,14 @@ def parse_dep_requirements(dep):
 
     For example:
 
-    >>> expected = PackageURL.from_string('pkg:pods/OHHTTPStubs@9.0.0'), '9.0.0'
+    >>> expected = PackageURL.from_string('pkg:cocoapods/OHHTTPStubs@9.0.0'), '9.0.0'
     >>> assert parse_dep_requirements('OHHTTPStubs (9.0.0)') == expected
 
-    >>> expected = PackageURL.from_string('pkg:pods/OHHTTPStubs/NSURLSession'), None
+    >>> expected = PackageURL.from_string('pkg:cocoapods/OHHTTPStubs/NSURLSession'), None
     >>> result = parse_dep_requirements('OHHTTPStubs/NSURLSession')
     >>> assert result == expected, result
 
-    >>> expected = PackageURL.from_string('pkg:pods/AFNetworking/Serialization@3.0.4'), '= 3.0.4'
+    >>> expected = PackageURL.from_string('pkg:cocoapods/AFNetworking/Serialization@3.0.4'), '= 3.0.4'
     >>> result = parse_dep_requirements(' AFNetworking/Serialization (= 3.0.4) ')
     >>> assert result == expected, result
     """
@@ -552,7 +552,7 @@ def parse_dep_requirements(dep):
         namespace = None
 
     purl = PackageURL(
-        type='pods',
+        type='cocoapods',
         namespace=namespace,
         name=name,
         version=version,

--- a/tests/packagedcode/data/cocoapods/assemble/many-podspecs-expected.json
+++ b/tests/packagedcode/data/cocoapods/assemble/many-podspecs-expected.json
@@ -1,7 +1,7 @@
 {
   "dependencies": [
     {
-      "purl": "pkg:pods/AWSCore@2.27.0",
+      "purl": "pkg:cocoapods/AWSCore@2.27.0",
       "extracted_requirement": "2.27.0",
       "scope": "requires",
       "is_runtime": false,
@@ -9,13 +9,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/AWSCore@2.27.0?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/AWSCore@2.27.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "many-podspecs/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/CwlCatchException@2.1.1",
+      "purl": "pkg:cocoapods/CwlCatchException@2.1.1",
       "extracted_requirement": "2.1.1",
       "scope": "requires",
       "is_runtime": false,
@@ -23,13 +23,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/CwlCatchException@2.1.1?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/CwlCatchException@2.1.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "many-podspecs/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/CwlCatchExceptionSupport@2.1.1",
+      "purl": "pkg:cocoapods/CwlCatchExceptionSupport@2.1.1",
       "extracted_requirement": "2.1.1",
       "scope": "requires",
       "is_runtime": false,
@@ -37,13 +37,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/CwlCatchExceptionSupport@2.1.1?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/CwlCatchExceptionSupport@2.1.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "many-podspecs/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/CwlMachBadInstructionHandler@2.1.0",
+      "purl": "pkg:cocoapods/CwlMachBadInstructionHandler@2.1.0",
       "extracted_requirement": "2.1.0",
       "scope": "requires",
       "is_runtime": false,
@@ -51,13 +51,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/CwlMachBadInstructionHandler@2.1.0?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/CwlMachBadInstructionHandler@2.1.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "many-podspecs/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/CwlPosixPreconditionTesting@2.1.0",
+      "purl": "pkg:cocoapods/CwlPosixPreconditionTesting@2.1.0",
       "extracted_requirement": "2.1.0",
       "scope": "requires",
       "is_runtime": false,
@@ -65,13 +65,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/CwlPosixPreconditionTesting@2.1.0?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/CwlPosixPreconditionTesting@2.1.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "many-podspecs/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/CwlPreconditionTesting@2.1.0",
+      "purl": "pkg:cocoapods/CwlPreconditionTesting@2.1.0",
       "extracted_requirement": "2.1.0",
       "scope": "requires",
       "is_runtime": false,
@@ -79,13 +79,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/CwlPreconditionTesting@2.1.0?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/CwlPreconditionTesting@2.1.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "many-podspecs/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/SwiftFormat/CLI@0.44.17",
+      "purl": "pkg:cocoapods/SwiftFormat/CLI@0.44.17",
       "extracted_requirement": "0.44.17",
       "scope": "requires",
       "is_runtime": false,
@@ -93,13 +93,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/SwiftFormat/CLI@0.44.17?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/SwiftFormat/CLI@0.44.17?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "many-podspecs/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/SwiftLint@0.46.2",
+      "purl": "pkg:cocoapods/SwiftLint@0.46.2",
       "extracted_requirement": "0.46.2",
       "scope": "requires",
       "is_runtime": false,
@@ -107,15 +107,15 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/SwiftLint@0.46.2?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/SwiftLint@0.46.2?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "many-podspecs/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     }
   ],
   "packages": [
     {
-      "type": "pods",
+      "type": "cocoapods",
       "namespace": null,
       "name": "CoreMLPredictionsPlugin",
       "version": "$AMPLIFY_VERSION",
@@ -153,17 +153,17 @@
       "repository_homepage_url": "https://cocoapods.org/pods/CoreMLPredictionsPlugin",
       "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
       "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/b/1/e/CoreMLPredictionsPlugin/$AMPLIFY_VERSION/CoreMLPredictionsPlugin.podspec.json",
-      "package_uid": "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "package_uid": "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "many-podspecs/CoreMLPredictionsPlugin.podspec"
       ],
       "datasource_ids": [
         "cocoapods_podspec"
       ],
-      "purl": "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION"
+      "purl": "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION"
     },
     {
-      "type": "pods",
+      "type": "cocoapods",
       "namespace": null,
       "name": "Amplify",
       "version": "$AMPLIFY_VERSION",
@@ -201,17 +201,17 @@
       "repository_homepage_url": "https://cocoapods.org/pods/Amplify",
       "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
       "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/9/c/5/Amplify/$AMPLIFY_VERSION/Amplify.podspec.json",
-      "package_uid": "pkg:pods/Amplify@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "package_uid": "pkg:cocoapods/Amplify@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "many-podspecs/Amplify.podspec"
       ],
       "datasource_ids": [
         "cocoapods_podspec"
       ],
-      "purl": "pkg:pods/Amplify@%24AMPLIFY_VERSION"
+      "purl": "pkg:cocoapods/Amplify@%24AMPLIFY_VERSION"
     },
     {
-      "type": "pods",
+      "type": "cocoapods",
       "namespace": null,
       "name": "AmplifyPlugins",
       "version": "$AMPLIFY_VERSION",
@@ -249,17 +249,17 @@
       "repository_homepage_url": "https://cocoapods.org/pods/AmplifyPlugins",
       "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
       "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/5/1/8/AmplifyPlugins/$AMPLIFY_VERSION/AmplifyPlugins.podspec.json",
-      "package_uid": "pkg:pods/AmplifyPlugins@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "package_uid": "pkg:cocoapods/AmplifyPlugins@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "many-podspecs/AmplifyPlugins.podspec"
       ],
       "datasource_ids": [
         "cocoapods_podspec"
       ],
-      "purl": "pkg:pods/AmplifyPlugins@%24AMPLIFY_VERSION"
+      "purl": "pkg:cocoapods/AmplifyPlugins@%24AMPLIFY_VERSION"
     },
     {
-      "type": "pods",
+      "type": "cocoapods",
       "namespace": null,
       "name": "AmplifyTestCommon",
       "version": "$AMPLIFY_VERSION",
@@ -297,17 +297,17 @@
       "repository_homepage_url": "https://cocoapods.org/pods/AmplifyTestCommon",
       "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
       "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/1/4/f/AmplifyTestCommon/$AMPLIFY_VERSION/AmplifyTestCommon.podspec.json",
-      "package_uid": "pkg:pods/AmplifyTestCommon@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "package_uid": "pkg:cocoapods/AmplifyTestCommon@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "many-podspecs/AmplifyTestCommon.podspec"
       ],
       "datasource_ids": [
         "cocoapods_podspec"
       ],
-      "purl": "pkg:pods/AmplifyTestCommon@%24AMPLIFY_VERSION"
+      "purl": "pkg:cocoapods/AmplifyTestCommon@%24AMPLIFY_VERSION"
     },
     {
-      "type": "pods",
+      "type": "cocoapods",
       "namespace": null,
       "name": "AWSPluginsCore",
       "version": "$AMPLIFY_VERSION",
@@ -345,17 +345,17 @@
       "repository_homepage_url": "https://cocoapods.org/pods/AWSPluginsCore",
       "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
       "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/c/7/7/AWSPluginsCore/$AMPLIFY_VERSION/AWSPluginsCore.podspec.json",
-      "package_uid": "pkg:pods/AWSPluginsCore@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "package_uid": "pkg:cocoapods/AWSPluginsCore@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "many-podspecs/AWSPluginsCore.podspec"
       ],
       "datasource_ids": [
         "cocoapods_podspec"
       ],
-      "purl": "pkg:pods/AWSPluginsCore@%24AMPLIFY_VERSION"
+      "purl": "pkg:cocoapods/AWSPluginsCore@%24AMPLIFY_VERSION"
     },
     {
-      "type": "pods",
+      "type": "cocoapods",
       "namespace": null,
       "name": "AWSPredictionsPlugin",
       "version": "$AMPLIFY_VERSION",
@@ -393,14 +393,14 @@
       "repository_homepage_url": "https://cocoapods.org/pods/AWSPredictionsPlugin",
       "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
       "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/5/6/0/AWSPredictionsPlugin/$AMPLIFY_VERSION/AWSPredictionsPlugin.podspec.json",
-      "package_uid": "pkg:pods/AWSPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "package_uid": "pkg:cocoapods/AWSPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "many-podspecs/AWSPredictionsPlugin.podspec"
       ],
       "datasource_ids": [
         "cocoapods_podspec"
       ],
-      "purl": "pkg:pods/AWSPredictionsPlugin@%24AMPLIFY_VERSION"
+      "purl": "pkg:cocoapods/AWSPredictionsPlugin@%24AMPLIFY_VERSION"
     }
   ],
   "files": [
@@ -416,7 +416,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": "AWSPluginsCore",
           "version": "$AMPLIFY_VERSION",
@@ -457,11 +457,11 @@
           "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
           "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/c/7/7/AWSPluginsCore/$AMPLIFY_VERSION/AWSPluginsCore.podspec.json",
           "datasource_id": "cocoapods_podspec",
-          "purl": "pkg:pods/AWSPluginsCore@%24AMPLIFY_VERSION"
+          "purl": "pkg:cocoapods/AWSPluginsCore@%24AMPLIFY_VERSION"
         }
       ],
       "for_packages": [
-        "pkg:pods/AWSPluginsCore@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/AWSPluginsCore@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -470,7 +470,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": "AWSPredictionsPlugin",
           "version": "$AMPLIFY_VERSION",
@@ -511,11 +511,11 @@
           "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
           "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/5/6/0/AWSPredictionsPlugin/$AMPLIFY_VERSION/AWSPredictionsPlugin.podspec.json",
           "datasource_id": "cocoapods_podspec",
-          "purl": "pkg:pods/AWSPredictionsPlugin@%24AMPLIFY_VERSION"
+          "purl": "pkg:cocoapods/AWSPredictionsPlugin@%24AMPLIFY_VERSION"
         }
       ],
       "for_packages": [
-        "pkg:pods/AWSPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/AWSPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -524,7 +524,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": "Amplify",
           "version": "$AMPLIFY_VERSION",
@@ -565,11 +565,11 @@
           "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
           "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/9/c/5/Amplify/$AMPLIFY_VERSION/Amplify.podspec.json",
           "datasource_id": "cocoapods_podspec",
-          "purl": "pkg:pods/Amplify@%24AMPLIFY_VERSION"
+          "purl": "pkg:cocoapods/Amplify@%24AMPLIFY_VERSION"
         }
       ],
       "for_packages": [
-        "pkg:pods/Amplify@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/Amplify@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -578,7 +578,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": "AmplifyPlugins",
           "version": "$AMPLIFY_VERSION",
@@ -619,11 +619,11 @@
           "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
           "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/5/1/8/AmplifyPlugins/$AMPLIFY_VERSION/AmplifyPlugins.podspec.json",
           "datasource_id": "cocoapods_podspec",
-          "purl": "pkg:pods/AmplifyPlugins@%24AMPLIFY_VERSION"
+          "purl": "pkg:cocoapods/AmplifyPlugins@%24AMPLIFY_VERSION"
         }
       ],
       "for_packages": [
-        "pkg:pods/AmplifyPlugins@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/AmplifyPlugins@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -632,7 +632,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": "AmplifyTestCommon",
           "version": "$AMPLIFY_VERSION",
@@ -673,11 +673,11 @@
           "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
           "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/1/4/f/AmplifyTestCommon/$AMPLIFY_VERSION/AmplifyTestCommon.podspec.json",
           "datasource_id": "cocoapods_podspec",
-          "purl": "pkg:pods/AmplifyTestCommon@%24AMPLIFY_VERSION"
+          "purl": "pkg:cocoapods/AmplifyTestCommon@%24AMPLIFY_VERSION"
         }
       ],
       "for_packages": [
-        "pkg:pods/AmplifyTestCommon@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/AmplifyTestCommon@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -686,7 +686,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": "CoreMLPredictionsPlugin",
           "version": "$AMPLIFY_VERSION",
@@ -727,11 +727,11 @@
           "repository_download_url": "https://github.com/aws-amplify/amplify-ios/archive/refs/tags/$AMPLIFY_VERSION.zip",
           "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/b/1/e/CoreMLPredictionsPlugin/$AMPLIFY_VERSION/CoreMLPredictionsPlugin.podspec.json",
           "datasource_id": "cocoapods_podspec",
-          "purl": "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION"
+          "purl": "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION"
         }
       ],
       "for_packages": [
-        "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -740,7 +740,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": null,
           "version": null,
@@ -777,7 +777,7 @@
         }
       ],
       "for_packages": [
-        "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -786,7 +786,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": null,
           "version": null,
@@ -816,7 +816,7 @@
           "extra_data": {},
           "dependencies": [
             {
-              "purl": "pkg:pods/AWSCore@2.27.0",
+              "purl": "pkg:cocoapods/AWSCore@2.27.0",
               "extracted_requirement": "2.27.0",
               "scope": "requires",
               "is_runtime": false,
@@ -826,7 +826,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/CwlCatchException@2.1.1",
+              "purl": "pkg:cocoapods/CwlCatchException@2.1.1",
               "extracted_requirement": "2.1.1",
               "scope": "requires",
               "is_runtime": false,
@@ -836,7 +836,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/CwlCatchExceptionSupport@2.1.1",
+              "purl": "pkg:cocoapods/CwlCatchExceptionSupport@2.1.1",
               "extracted_requirement": "2.1.1",
               "scope": "requires",
               "is_runtime": false,
@@ -846,7 +846,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/CwlMachBadInstructionHandler@2.1.0",
+              "purl": "pkg:cocoapods/CwlMachBadInstructionHandler@2.1.0",
               "extracted_requirement": "2.1.0",
               "scope": "requires",
               "is_runtime": false,
@@ -856,7 +856,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/CwlPosixPreconditionTesting@2.1.0",
+              "purl": "pkg:cocoapods/CwlPosixPreconditionTesting@2.1.0",
               "extracted_requirement": "2.1.0",
               "scope": "requires",
               "is_runtime": false,
@@ -866,7 +866,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/CwlPreconditionTesting@2.1.0",
+              "purl": "pkg:cocoapods/CwlPreconditionTesting@2.1.0",
               "extracted_requirement": "2.1.0",
               "scope": "requires",
               "is_runtime": false,
@@ -876,7 +876,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/SwiftFormat/CLI@0.44.17",
+              "purl": "pkg:cocoapods/SwiftFormat/CLI@0.44.17",
               "extracted_requirement": "0.44.17",
               "scope": "requires",
               "is_runtime": false,
@@ -886,7 +886,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/SwiftLint@0.46.2",
+              "purl": "pkg:cocoapods/SwiftLint@0.46.2",
               "extracted_requirement": "0.46.2",
               "scope": "requires",
               "is_runtime": false,
@@ -904,7 +904,7 @@
         }
       ],
       "for_packages": [
-        "pkg:pods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/CoreMLPredictionsPlugin@%24AMPLIFY_VERSION?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },

--- a/tests/packagedcode/data/cocoapods/assemble/multiple-podspec-expected.json
+++ b/tests/packagedcode/data/cocoapods/assemble/multiple-podspec-expected.json
@@ -1,7 +1,7 @@
 {
   "dependencies": [
     {
-      "purl": "pkg:pods/boost@1.76.0",
+      "purl": "pkg:cocoapods/boost@1.76.0",
       "extracted_requirement": "1.76.0",
       "scope": "requires",
       "is_runtime": false,
@@ -9,13 +9,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/boost@1.76.0?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/boost@1.76.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "multiple-podspec/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/Yoga@1.14.0",
+      "purl": "pkg:cocoapods/Yoga@1.14.0",
       "extracted_requirement": "1.14.0",
       "scope": "requires",
       "is_runtime": false,
@@ -23,13 +23,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/Yoga@1.14.0?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/Yoga@1.14.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "multiple-podspec/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/YogaKit@1.18.1",
+      "purl": "pkg:cocoapods/YogaKit@1.18.1",
       "extracted_requirement": "1.18.1",
       "scope": "requires",
       "is_runtime": false,
@@ -37,15 +37,15 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/YogaKit@1.18.1?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/YogaKit@1.18.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "multiple-podspec/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     }
   ],
   "packages": [
     {
-      "type": "pods",
+      "type": "cocoapods",
       "namespace": null,
       "name": "RxDataSources",
       "version": "4.0.1",
@@ -83,17 +83,17 @@
       "repository_homepage_url": "https://cocoapods.org/pods/RxDataSources",
       "repository_download_url": "https://github.com/RxSwiftCommunity/RxDataSources/archive/refs/tags/4.0.1.zip",
       "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/9/a/4/RxDataSources/4.0.1/RxDataSources.podspec.json",
-      "package_uid": "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "package_uid": "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "multiple-podspec/RxDataSources.podspec"
       ],
       "datasource_ids": [
         "cocoapods_podspec"
       ],
-      "purl": "pkg:pods/RxDataSources@4.0.1"
+      "purl": "pkg:cocoapods/RxDataSources@4.0.1"
     },
     {
-      "type": "pods",
+      "type": "cocoapods",
       "namespace": null,
       "name": "Differentiator",
       "version": "4.0.1",
@@ -131,14 +131,14 @@
       "repository_homepage_url": "https://cocoapods.org/pods/Differentiator",
       "repository_download_url": "https://github.com/RxSwiftCommunity/RxDataSources/archive/refs/tags/4.0.1.zip",
       "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/5/9/8/Differentiator/4.0.1/Differentiator.podspec.json",
-      "package_uid": "pkg:pods/Differentiator@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "package_uid": "pkg:cocoapods/Differentiator@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "multiple-podspec/Differentiator.podspec"
       ],
       "datasource_ids": [
         "cocoapods_podspec"
       ],
-      "purl": "pkg:pods/Differentiator@4.0.1"
+      "purl": "pkg:cocoapods/Differentiator@4.0.1"
     }
   ],
   "files": [
@@ -154,7 +154,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": "Differentiator",
           "version": "4.0.1",
@@ -195,11 +195,11 @@
           "repository_download_url": "https://github.com/RxSwiftCommunity/RxDataSources/archive/refs/tags/4.0.1.zip",
           "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/5/9/8/Differentiator/4.0.1/Differentiator.podspec.json",
           "datasource_id": "cocoapods_podspec",
-          "purl": "pkg:pods/Differentiator@4.0.1"
+          "purl": "pkg:cocoapods/Differentiator@4.0.1"
         }
       ],
       "for_packages": [
-        "pkg:pods/Differentiator@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/Differentiator@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -208,7 +208,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": null,
           "version": null,
@@ -245,7 +245,7 @@
         }
       ],
       "for_packages": [
-        "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -254,7 +254,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": null,
           "version": null,
@@ -284,7 +284,7 @@
           "extra_data": {},
           "dependencies": [
             {
-              "purl": "pkg:pods/boost@1.76.0",
+              "purl": "pkg:cocoapods/boost@1.76.0",
               "extracted_requirement": "1.76.0",
               "scope": "requires",
               "is_runtime": false,
@@ -294,7 +294,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/Yoga@1.14.0",
+              "purl": "pkg:cocoapods/Yoga@1.14.0",
               "extracted_requirement": "1.14.0",
               "scope": "requires",
               "is_runtime": false,
@@ -304,7 +304,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/YogaKit@1.18.1",
+              "purl": "pkg:cocoapods/YogaKit@1.18.1",
               "extracted_requirement": "1.18.1",
               "scope": "requires",
               "is_runtime": false,
@@ -322,7 +322,7 @@
         }
       ],
       "for_packages": [
-        "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -331,7 +331,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": "RxDataSources",
           "version": "4.0.1",
@@ -372,11 +372,11 @@
           "repository_download_url": "https://github.com/RxSwiftCommunity/RxDataSources/archive/refs/tags/4.0.1.zip",
           "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/9/a/4/RxDataSources/4.0.1/RxDataSources.podspec.json",
           "datasource_id": "cocoapods_podspec",
-          "purl": "pkg:pods/RxDataSources@4.0.1"
+          "purl": "pkg:cocoapods/RxDataSources@4.0.1"
         }
       ],
       "for_packages": [
-        "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     }

--- a/tests/packagedcode/data/cocoapods/assemble/single-podspec-expected.json
+++ b/tests/packagedcode/data/cocoapods/assemble/single-podspec-expected.json
@@ -1,7 +1,7 @@
 {
   "dependencies": [
     {
-      "purl": "pkg:pods/boost@1.76.0",
+      "purl": "pkg:cocoapods/boost@1.76.0",
       "extracted_requirement": "1.76.0",
       "scope": "requires",
       "is_runtime": false,
@@ -9,13 +9,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/boost@1.76.0?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/boost@1.76.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "single-podspec/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/Yoga@1.14.0",
+      "purl": "pkg:cocoapods/Yoga@1.14.0",
       "extracted_requirement": "1.14.0",
       "scope": "requires",
       "is_runtime": false,
@@ -23,13 +23,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/Yoga@1.14.0?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/Yoga@1.14.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "single-podspec/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/YogaKit@1.18.1",
+      "purl": "pkg:cocoapods/YogaKit@1.18.1",
       "extracted_requirement": "1.18.1",
       "scope": "requires",
       "is_runtime": false,
@@ -37,15 +37,15 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/YogaKit@1.18.1?uuid=fixed-uid-done-for-testing-5642512d1758",
-      "for_package_uid": "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/YogaKit@1.18.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_path": "single-podspec/Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     }
   ],
   "packages": [
     {
-      "type": "pods",
+      "type": "cocoapods",
       "namespace": null,
       "name": "RxDataSources",
       "version": "4.0.1",
@@ -83,14 +83,14 @@
       "repository_homepage_url": "https://cocoapods.org/pods/RxDataSources",
       "repository_download_url": "https://github.com/RxSwiftCommunity/RxDataSources/archive/refs/tags/4.0.1.zip",
       "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/9/a/4/RxDataSources/4.0.1/RxDataSources.podspec.json",
-      "package_uid": "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "package_uid": "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "single-podspec/RxDataSources.podspec"
       ],
       "datasource_ids": [
         "cocoapods_podspec"
       ],
-      "purl": "pkg:pods/RxDataSources@4.0.1"
+      "purl": "pkg:cocoapods/RxDataSources@4.0.1"
     }
   ],
   "files": [
@@ -106,7 +106,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": null,
           "version": null,
@@ -143,7 +143,7 @@
         }
       ],
       "for_packages": [
-        "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -152,7 +152,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": null,
           "version": null,
@@ -182,7 +182,7 @@
           "extra_data": {},
           "dependencies": [
             {
-              "purl": "pkg:pods/boost@1.76.0",
+              "purl": "pkg:cocoapods/boost@1.76.0",
               "extracted_requirement": "1.76.0",
               "scope": "requires",
               "is_runtime": false,
@@ -192,7 +192,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/Yoga@1.14.0",
+              "purl": "pkg:cocoapods/Yoga@1.14.0",
               "extracted_requirement": "1.14.0",
               "scope": "requires",
               "is_runtime": false,
@@ -202,7 +202,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/YogaKit@1.18.1",
+              "purl": "pkg:cocoapods/YogaKit@1.18.1",
               "extracted_requirement": "1.18.1",
               "scope": "requires",
               "is_runtime": false,
@@ -220,7 +220,7 @@
         }
       ],
       "for_packages": [
-        "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     },
@@ -229,7 +229,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": "RxDataSources",
           "version": "4.0.1",
@@ -270,11 +270,11 @@
           "repository_download_url": "https://github.com/RxSwiftCommunity/RxDataSources/archive/refs/tags/4.0.1.zip",
           "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/9/a/4/RxDataSources/4.0.1/RxDataSources.podspec.json",
           "datasource_id": "cocoapods_podspec",
-          "purl": "pkg:pods/RxDataSources@4.0.1"
+          "purl": "pkg:cocoapods/RxDataSources@4.0.1"
         }
       ],
       "for_packages": [
-        "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     }

--- a/tests/packagedcode/data/cocoapods/assemble/solo/Podfile-expected.json
+++ b/tests/packagedcode/data/cocoapods/assemble/solo/Podfile-expected.json
@@ -7,7 +7,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": null,
           "version": null,

--- a/tests/packagedcode/data/cocoapods/assemble/solo/Podfile.lock-expected.json
+++ b/tests/packagedcode/data/cocoapods/assemble/solo/Podfile.lock-expected.json
@@ -1,7 +1,7 @@
 {
   "dependencies": [
     {
-      "purl": "pkg:pods/boost@1.76.0",
+      "purl": "pkg:cocoapods/boost@1.76.0",
       "extracted_requirement": "1.76.0",
       "scope": "requires",
       "is_runtime": false,
@@ -9,13 +9,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/boost@1.76.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/boost@1.76.0?uuid=fixed-uid-done-for-testing-5642512d1758",
       "for_package_uid": null,
       "datafile_path": "Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/Yoga@1.14.0",
+      "purl": "pkg:cocoapods/Yoga@1.14.0",
       "extracted_requirement": "1.14.0",
       "scope": "requires",
       "is_runtime": false,
@@ -23,13 +23,13 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/Yoga@1.14.0?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/Yoga@1.14.0?uuid=fixed-uid-done-for-testing-5642512d1758",
       "for_package_uid": null,
       "datafile_path": "Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
     },
     {
-      "purl": "pkg:pods/YogaKit@1.18.1",
+      "purl": "pkg:cocoapods/YogaKit@1.18.1",
       "extracted_requirement": "1.18.1",
       "scope": "requires",
       "is_runtime": false,
@@ -37,7 +37,7 @@
       "is_resolved": true,
       "resolved_package": {},
       "extra_data": {},
-      "dependency_uid": "pkg:pods/YogaKit@1.18.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "dependency_uid": "pkg:cocoapods/YogaKit@1.18.1?uuid=fixed-uid-done-for-testing-5642512d1758",
       "for_package_uid": null,
       "datafile_path": "Podfile.lock",
       "datasource_id": "cocoapods_podfile_lock"
@@ -50,7 +50,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": null,
           "version": null,
@@ -80,7 +80,7 @@
           "extra_data": {},
           "dependencies": [
             {
-              "purl": "pkg:pods/boost@1.76.0",
+              "purl": "pkg:cocoapods/boost@1.76.0",
               "extracted_requirement": "1.76.0",
               "scope": "requires",
               "is_runtime": false,
@@ -90,7 +90,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/Yoga@1.14.0",
+              "purl": "pkg:cocoapods/Yoga@1.14.0",
               "extracted_requirement": "1.14.0",
               "scope": "requires",
               "is_runtime": false,
@@ -100,7 +100,7 @@
               "extra_data": {}
             },
             {
-              "purl": "pkg:pods/YogaKit@1.18.1",
+              "purl": "pkg:cocoapods/YogaKit@1.18.1",
               "extracted_requirement": "1.18.1",
               "scope": "requires",
               "is_runtime": false,

--- a/tests/packagedcode/data/cocoapods/assemble/solo/RxDataSources.podspec-expected.json
+++ b/tests/packagedcode/data/cocoapods/assemble/solo/RxDataSources.podspec-expected.json
@@ -2,7 +2,7 @@
   "dependencies": [],
   "packages": [
     {
-      "type": "pods",
+      "type": "cocoapods",
       "namespace": null,
       "name": "RxDataSources",
       "version": "4.0.1",
@@ -40,14 +40,14 @@
       "repository_homepage_url": "https://cocoapods.org/pods/RxDataSources",
       "repository_download_url": "https://github.com/RxSwiftCommunity/RxDataSources/archive/refs/tags/4.0.1.zip",
       "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/9/a/4/RxDataSources/4.0.1/RxDataSources.podspec.json",
-      "package_uid": "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "package_uid": "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "RxDataSources.podspec"
       ],
       "datasource_ids": [
         "cocoapods_podspec"
       ],
-      "purl": "pkg:pods/RxDataSources@4.0.1"
+      "purl": "pkg:cocoapods/RxDataSources@4.0.1"
     }
   ],
   "files": [
@@ -56,7 +56,7 @@
       "type": "file",
       "package_data": [
         {
-          "type": "pods",
+          "type": "cocoapods",
           "namespace": null,
           "name": "RxDataSources",
           "version": "4.0.1",
@@ -97,11 +97,11 @@
           "repository_download_url": "https://github.com/RxSwiftCommunity/RxDataSources/archive/refs/tags/4.0.1.zip",
           "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/9/a/4/RxDataSources/4.0.1/RxDataSources.podspec.json",
           "datasource_id": "cocoapods_podspec",
-          "purl": "pkg:pods/RxDataSources@4.0.1"
+          "purl": "pkg:cocoapods/RxDataSources@4.0.1"
         }
       ],
       "for_packages": [
-        "pkg:pods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
+        "pkg:cocoapods/RxDataSources@4.0.1?uuid=fixed-uid-done-for-testing-5642512d1758"
       ],
       "scan_errors": []
     }

--- a/tests/packagedcode/data/cocoapods/podfile.lock/braintree_ios_Podfile.lock.expected.json
+++ b/tests/packagedcode/data/cocoapods/podfile.lock/braintree_ios_Podfile.lock.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "pods",
+    "type": "cocoapods",
     "namespace": null,
     "name": null,
     "version": null,
@@ -30,7 +30,7 @@
     "extra_data": {},
     "dependencies": [
       {
-        "purl": "pkg:pods/Expecta@1.0.6",
+        "purl": "pkg:cocoapods/Expecta@1.0.6",
         "extracted_requirement": "1.0.6",
         "scope": "requires",
         "is_runtime": false,
@@ -40,7 +40,7 @@
         "extra_data": {}
       },
       {
-        "purl": "pkg:pods/InAppSettingsKit@3.1.4",
+        "purl": "pkg:cocoapods/InAppSettingsKit@3.1.4",
         "extracted_requirement": "3.1.4",
         "scope": "requires",
         "is_runtime": false,
@@ -50,7 +50,7 @@
         "extra_data": {}
       },
       {
-        "purl": "pkg:pods/OCMock@3.7.1",
+        "purl": "pkg:cocoapods/OCMock@3.7.1",
         "extracted_requirement": "3.7.1",
         "scope": "requires",
         "is_runtime": false,
@@ -60,7 +60,7 @@
         "extra_data": {}
       },
       {
-        "purl": "pkg:pods/OHHTTPStubs@9.0.0",
+        "purl": "pkg:cocoapods/OHHTTPStubs@9.0.0",
         "extracted_requirement": "9.0.0",
         "scope": "requires",
         "is_runtime": false,
@@ -70,7 +70,7 @@
         "extra_data": {}
       },
       {
-        "purl": "pkg:pods/OHHTTPStubs/Core@9.0.0",
+        "purl": "pkg:cocoapods/OHHTTPStubs/Core@9.0.0",
         "extracted_requirement": "9.0.0",
         "scope": "requires",
         "is_runtime": false,
@@ -80,7 +80,7 @@
         "extra_data": {}
       },
       {
-        "purl": "pkg:pods/OHHTTPStubs/Default@9.0.0",
+        "purl": "pkg:cocoapods/OHHTTPStubs/Default@9.0.0",
         "extracted_requirement": "9.0.0",
         "scope": "requires",
         "is_runtime": false,
@@ -90,7 +90,7 @@
         "extra_data": {}
       },
       {
-        "purl": "pkg:pods/OHHTTPStubs/JSON@9.0.0",
+        "purl": "pkg:cocoapods/OHHTTPStubs/JSON@9.0.0",
         "extracted_requirement": "9.0.0",
         "scope": "requires",
         "is_runtime": false,
@@ -100,7 +100,7 @@
         "extra_data": {}
       },
       {
-        "purl": "pkg:pods/OHHTTPStubs/NSURLSession@9.0.0",
+        "purl": "pkg:cocoapods/OHHTTPStubs/NSURLSession@9.0.0",
         "extracted_requirement": "9.0.0",
         "scope": "requires",
         "is_runtime": false,
@@ -110,7 +110,7 @@
         "extra_data": {}
       },
       {
-        "purl": "pkg:pods/OHHTTPStubs/OHPathHelpers@9.0.0",
+        "purl": "pkg:cocoapods/OHHTTPStubs/OHPathHelpers@9.0.0",
         "extracted_requirement": "9.0.0",
         "scope": "requires",
         "is_runtime": false,
@@ -120,7 +120,7 @@
         "extra_data": {}
       },
       {
-        "purl": "pkg:pods/Specta@1.0.7",
+        "purl": "pkg:cocoapods/Specta@1.0.7",
         "extracted_requirement": "1.0.7",
         "scope": "requires",
         "is_runtime": false,
@@ -130,7 +130,7 @@
         "extra_data": {}
       },
       {
-        "purl": "pkg:pods/xcbeautify@0.8.1",
+        "purl": "pkg:cocoapods/xcbeautify@0.8.1",
         "extracted_requirement": "0.8.1",
         "scope": "requires",
         "is_runtime": false,

--- a/tests/packagedcode/data/cocoapods/podspec.json/FirebaseAnalytics.podspec.json.expected.json
+++ b/tests/packagedcode/data/cocoapods/podspec.json/FirebaseAnalytics.podspec.json.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "pods",
+    "type": "cocoapods",
     "namespace": null,
     "name": "FirebaseAnalytics",
     "version": "8.1.1",
@@ -41,6 +41,6 @@
     "repository_download_url": "https://firebase.google.com/features/analytics//archive/8.1.1.zip",
     "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/e/2/1/FirebaseAnalytics/8.1.1/FirebaseAnalytics.podspec.json",
     "datasource_id": "cocoapods_podspec_json",
-    "purl": "pkg:pods/FirebaseAnalytics@8.1.1"
+    "purl": "pkg:cocoapods/FirebaseAnalytics@8.1.1"
   }
 ]

--- a/tests/packagedcode/data/cocoapods/podspec/BadgeHub.podspec.expected.json
+++ b/tests/packagedcode/data/cocoapods/podspec/BadgeHub.podspec.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "pods",
+    "type": "cocoapods",
     "namespace": null,
     "name": "BadgeHub",
     "version": "0.1.1",
@@ -41,6 +41,6 @@
     "repository_download_url": "https://github.com/jogendra/BadgeHub/archive/refs/tags/0.1.1.zip",
     "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/7/b/b/BadgeHub/0.1.1/BadgeHub.podspec.json",
     "datasource_id": "cocoapods_podspec",
-    "purl": "pkg:pods/BadgeHub@0.1.1"
+    "purl": "pkg:cocoapods/BadgeHub@0.1.1"
   }
 ]

--- a/tests/packagedcode/data/cocoapods/podspec/LoadingShimmer.podspec.expected.json
+++ b/tests/packagedcode/data/cocoapods/podspec/LoadingShimmer.podspec.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "pods",
+    "type": "cocoapods",
     "namespace": null,
     "name": "LoadingShimmer",
     "version": "1.0.3",
@@ -41,6 +41,6 @@
     "repository_download_url": "https://github.com/jogendra/LoadingShimmer/archive/refs/tags/1.0.3.zip",
     "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/7/6/8/LoadingShimmer/1.0.3/LoadingShimmer.podspec.json",
     "datasource_id": "cocoapods_podspec",
-    "purl": "pkg:pods/LoadingShimmer@1.0.3"
+    "purl": "pkg:cocoapods/LoadingShimmer@1.0.3"
   }
 ]

--- a/tests/packagedcode/data/cocoapods/podspec/PayTabsSDK.podspec.expected.json
+++ b/tests/packagedcode/data/cocoapods/podspec/PayTabsSDK.podspec.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "pods",
+    "type": "cocoapods",
     "namespace": null,
     "name": "PayTabsSDK",
     "version": "6.1.18",
@@ -41,6 +41,6 @@
     "repository_download_url": "https://github.com/paytabscom/paytabs-ios-library-sample/archive/refs/tags/6.1.18.zip",
     "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/b/5/f/PayTabsSDK/6.1.18/PayTabsSDK.podspec.json",
     "datasource_id": "cocoapods_podspec",
-    "purl": "pkg:pods/PayTabsSDK@6.1.18"
+    "purl": "pkg:cocoapods/PayTabsSDK@6.1.18"
   }
 ]

--- a/tests/packagedcode/data/cocoapods/podspec/RxDataSources.podspec.expected.json
+++ b/tests/packagedcode/data/cocoapods/podspec/RxDataSources.podspec.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "pods",
+    "type": "cocoapods",
     "namespace": null,
     "name": "RxDataSources",
     "version": "4.0.1",
@@ -41,6 +41,6 @@
     "repository_download_url": "https://github.com/RxSwiftCommunity/RxDataSources/archive/refs/tags/4.0.1.zip",
     "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/9/a/4/RxDataSources/4.0.1/RxDataSources.podspec.json",
     "datasource_id": "cocoapods_podspec",
-    "purl": "pkg:pods/RxDataSources@4.0.1"
+    "purl": "pkg:cocoapods/RxDataSources@4.0.1"
   }
 ]

--- a/tests/packagedcode/data/cocoapods/podspec/Starscream.podspec.expected.json
+++ b/tests/packagedcode/data/cocoapods/podspec/Starscream.podspec.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "pods",
+    "type": "cocoapods",
     "namespace": null,
     "name": "Starscream",
     "version": "4.0.3",
@@ -48,6 +48,6 @@
     "repository_download_url": "https://github.com/daltoniam/Starscream/archive/refs/tags/4.0.3.zip",
     "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/2/2/f/Starscream/4.0.3/Starscream.podspec.json",
     "datasource_id": "cocoapods_podspec",
-    "purl": "pkg:pods/Starscream@4.0.3"
+    "purl": "pkg:cocoapods/Starscream@4.0.3"
   }
 ]

--- a/tests/packagedcode/data/cocoapods/podspec/SwiftLib.podspec.expected.json
+++ b/tests/packagedcode/data/cocoapods/podspec/SwiftLib.podspec.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "pods",
+    "type": "cocoapods",
     "namespace": null,
     "name": "SwiftLib",
     "version": "0.0.1",
@@ -41,6 +41,6 @@
     "repository_download_url": "https://github.com/alizainprasla/swiftlib/archive/refs/tags/0.0.1.zip",
     "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/c/9/1/SwiftLib/0.0.1/SwiftLib.podspec.json",
     "datasource_id": "cocoapods_podspec",
-    "purl": "pkg:pods/SwiftLib@0.0.1"
+    "purl": "pkg:cocoapods/SwiftLib@0.0.1"
   }
 ]

--- a/tests/packagedcode/data/cocoapods/podspec/flutter_paytabs_bridge.podspec.expected.json
+++ b/tests/packagedcode/data/cocoapods/podspec/flutter_paytabs_bridge.podspec.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "pods",
+    "type": "cocoapods",
     "namespace": null,
     "name": "flutter_paytabs_bridge",
     "version": "2.2.5",
@@ -41,6 +41,6 @@
     "repository_download_url": "./archive/refs/tags/2.2.5.zip",
     "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/5/1/4/flutter_paytabs_bridge/2.2.5/flutter_paytabs_bridge.podspec.json",
     "datasource_id": "cocoapods_podspec",
-    "purl": "pkg:pods/flutter_paytabs_bridge@2.2.5"
+    "purl": "pkg:cocoapods/flutter_paytabs_bridge@2.2.5"
   }
 ]

--- a/tests/packagedcode/data/cocoapods/podspec/kmmWebSocket.podspec.expected.json
+++ b/tests/packagedcode/data/cocoapods/podspec/kmmWebSocket.podspec.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "pods",
+    "type": "cocoapods",
     "namespace": null,
     "name": "kmmWebSocket",
     "version": "1.0.1",
@@ -41,6 +41,6 @@
     "repository_download_url": "Not Published/archive/refs/tags/1.0.1.zip",
     "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/2/3/c/kmmWebSocket/1.0.1/kmmWebSocket.podspec.json",
     "datasource_id": "cocoapods_podspec",
-    "purl": "pkg:pods/kmmWebSocket@1.0.1"
+    "purl": "pkg:cocoapods/kmmWebSocket@1.0.1"
   }
 ]

--- a/tests/packagedcode/data/cocoapods/podspec/nanopb.podspec.expected.json
+++ b/tests/packagedcode/data/cocoapods/podspec/nanopb.podspec.expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "pods",
+    "type": "cocoapods",
     "namespace": null,
     "name": "nanopb",
     "version": "1.30905.0",
@@ -41,6 +41,6 @@
     "repository_download_url": "https://github.com/nanopb/nanopb/archive/refs/tags/1.30905.0.zip",
     "api_data_url": "https://raw.githubusercontent.com/CocoaPods/Specs/blob/master/Specs/6/1/e/nanopb/1.30905.0/nanopb.podspec.json",
     "datasource_id": "cocoapods_podspec",
-    "purl": "pkg:pods/nanopb@1.30905.0"
+    "purl": "pkg:cocoapods/nanopb@1.30905.0"
   }
 ]

--- a/tests/packagedcode/data/plugin/help.txt
+++ b/tests/packagedcode/data/plugin/help.txt
@@ -139,6 +139,34 @@ Package type:  chrome
   description:       Chrome extension
   path_patterns:    '*.crx'
 --------------------------------------------
+Package type:  cocoapods
+  datasource_id:     cocoapods_podfile
+  documentation URL: https://guides.cocoapods.org/using/the-podfile.html
+  primary language:  Objective-C
+  description:       Cocoapods Podfile
+  path_patterns:    '*Podfile'
+--------------------------------------------
+Package type:  cocoapods
+  datasource_id:     cocoapods_podfile_lock
+  documentation URL: https://guides.cocoapods.org/using/the-podfile.html
+  primary language:  Objective-C
+  description:       Cocoapods Podfile.lock
+  path_patterns:    '*Podfile.lock'
+--------------------------------------------
+Package type:  cocoapods
+  datasource_id:     cocoapods_podspec
+  documentation URL: https://guides.cocoapods.org/syntax/podspec.html
+  primary language:  Objective-C
+  description:       Cocoapods .podspec
+  path_patterns:    '*.podspec'
+--------------------------------------------
+Package type:  cocoapods
+  datasource_id:     cocoapods_podspec_json
+  documentation URL: https://guides.cocoapods.org/syntax/podspec.html
+  primary language:  Objective-C
+  description:       Cocoapods .podspec.json
+  path_patterns:    '*.podspec.json'
+--------------------------------------------
 Package type:  composer
   datasource_id:     php_composer_json
   documentation URL: https://getcomposer.org/doc/04-schema.md
@@ -572,34 +600,6 @@ Package type:  opam
   primary language:  Ocaml
   description:       Ocaml Opam file
   path_patterns:    '*opam'
---------------------------------------------
-Package type:  pods
-  datasource_id:     cocoapods_podfile
-  documentation URL: https://guides.cocoapods.org/using/the-podfile.html
-  primary language:  Objective-C
-  description:       Cocoapods Podfile
-  path_patterns:    '*Podfile'
---------------------------------------------
-Package type:  pods
-  datasource_id:     cocoapods_podfile_lock
-  documentation URL: https://guides.cocoapods.org/using/the-podfile.html
-  primary language:  Objective-C
-  description:       Cocoapods Podfile.lock
-  path_patterns:    '*Podfile.lock'
---------------------------------------------
-Package type:  pods
-  datasource_id:     cocoapods_podspec
-  documentation URL: https://guides.cocoapods.org/syntax/podspec.html
-  primary language:  Objective-C
-  description:       Cocoapods .podspec
-  path_patterns:    '*.podspec'
---------------------------------------------
-Package type:  pods
-  datasource_id:     cocoapods_podspec_json
-  documentation URL: https://guides.cocoapods.org/syntax/podspec.html
-  primary language:  Objective-C
-  description:       Cocoapods .podspec.json
-  path_patterns:    '*.podspec.json'
 --------------------------------------------
 Package type:  pubspec
   datasource_id:     pubspec_lock


### PR DESCRIPTION
* Modify purl type for cocoapods packages and deps from `pods` to the correct type `cocoapods`.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
