### PR TITLE
Replace gemfileparser with gemfileparser2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ fasteners==0.17.3
 fingerprints==1.0.3
 ftfy==6.1.1
 future==0.18.2
-gemfileparser==0.8.0
+gemfileparser2==0.9.0
 html5lib==1.1
 idna==3.3
 importlib-metadata==4.12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ install_requires =
     fasteners
     fingerprints >= 0.6.0
     ftfy >=  6.0.0
-    gemfileparser >= 0.7.0
+    gemfileparser2 >= 0.9.0
     html5lib
     importlib_metadata
     intbitset >= 3.0.0


### PR DESCRIPTION
This PR bumps replaces the use of gemfileparser with gemfileparser2 v0.9.0. gemfileparser2 is a nexB-owned fork of gemfileparser, using this fork helps us fix issues with gemfileparser faster as we can make releases as needed. This update should also fix #3088.