### PR TITLE
Remove deprecated images from CI and release-script

### DIFF
--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -235,7 +235,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-12]
         pyver: ["3.9", "3.10"]
-        # os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11, macos-12]
+        # os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
         # pyver: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
@@ -324,7 +324,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         pyver: [3.8]
 
     steps:
@@ -362,7 +362,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-10.15, macos-11, macos-12]
+        os: [macos-11, macos-12]
         pyver: [3.8]
 
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,8 +80,8 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: ubuntu18_cpython
-          image_name: ubuntu-18.04
+          job_name: ubuntu22_cpython
+          image_name: ubuntu-22.04
           python_versions: ['3.7', '3.8', '3.9', '3.10']
           python_architecture: x64
           test_suites:
@@ -98,8 +98,8 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: macos1015_cpython_1
-          image_name: macos-10.15
+          job_name: macos12_cpython_1
+          image_name: macos-12
           python_versions: ['3.7', '3.8']
           python_architecture: x64
           test_suites:
@@ -107,8 +107,8 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: macos1015_cpython_2
-          image_name: macos-10.15
+          job_name: macos12_cpython_2
+          image_name: macos-12
           python_versions: ['3.9', '3.10']
           python_architecture: x64
           test_suites:
@@ -197,8 +197,8 @@ jobs:
 
     - template: etc/ci/azure-posix.yml
       parameters:
-          job_name: ubuntu18_cpython_latest_from_pip
-          image_name: ubuntu-18.04
+          job_name: ubuntu22_cpython_latest_from_pip
+          image_name: ubuntu-22.04
           python_versions: ['3.7', '3.8', '3.9', '3.10']
           test_suites:
               all: venv/bin/pip install --upgrade-strategy eager --force-reinstall --upgrade -e .[dev] && venv/bin/pytest -n 2 -vvs tests/scancode/test_cli.py
@@ -207,14 +207,6 @@ jobs:
       parameters:
           job_name: ubuntu20_cpython_latest_from_pip
           image_name: ubuntu-20.04
-          python_versions: ['3.7', '3.8', '3.9', '3.10']
-          test_suites:
-              all: venv/bin/pip install --upgrade-strategy eager --force-reinstall --upgrade -e .[dev] && venv/bin/pytest -n 2 -vvs tests/scancode/test_cli.py
-
-    - template: etc/ci/azure-posix.yml
-      parameters:
-          job_name: macos1015_cpython_latest_from_pip
-          image_name: macos-10.15
           python_versions: ['3.7', '3.8', '3.9', '3.10']
           test_suites:
               all: venv/bin/pip install --upgrade-strategy eager --force-reinstall --upgrade -e .[dev] && venv/bin/pytest -n 2 -vvs tests/scancode/test_cli.py


### PR DESCRIPTION
The following images are deprecated in GitHub actions and Azure DevOps:

* `ubuntu-18.04` : https://github.com/actions/runner-images/issues/6002
* `macos-10.15` : https://github.com/actions/runner-images/issues/5583

Due to this there was failing tests due to planned brownouts.

Signed-off-by: Ayan Sinha Mahapatra <ayansmahapatra@gmail.com>

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
