### PR TITLE
Yield package before assigning to resource

### DIFF
--- a/src/packagedcode/about.py
+++ b/src/packagedcode/about.py
@@ -118,16 +118,16 @@ class AboutFileHandler(models.DatafileHandler):
                 package_data=package_data,
                 datafile_path=datafile_path,
             )
-            package_uid = package.package_uid
-
-            # NOTE: we do not attach files to the Package level. Instead we
-            # update `for_package` in the file
-            package_adder(package_uid, resource, codebase)
 
             if not package.license_expression:
                 package.license_expression = cls.compute_normalized_license(package)
 
             yield package
+
+            package_uid = package.package_uid
+            # NOTE: we do not attach files to the Package level. Instead we
+            # update `for_package` in the file
+            package_adder(package_uid, resource, codebase)
 
             if resource.has_parent() and package_data.file_references:
                 parent_resource = resource.parent(codebase)

--- a/src/packagedcode/alpine.py
+++ b/src/packagedcode/alpine.py
@@ -97,7 +97,6 @@ class AlpineInstalledDatabaseHandler(models.DatafileHandler):
             # path is found and processed: remove it, so we can check if we
             # found all of them
             del file_references_by_path[res.path]
-            package_adder(package_uid, res, codebase)
             resources.append(res)
 
         # if we have left over file references, add these to extra data
@@ -106,7 +105,9 @@ class AlpineInstalledDatabaseHandler(models.DatafileHandler):
             package.extra_data['missing_file_references'] = missing
 
         yield package
-        yield from resources
+        for res in resources:
+            package_adder(package_uid, res, codebase)
+            yield res
 
         dependent_packages = package_data.dependencies
         if dependent_packages:

--- a/src/packagedcode/rpm.py
+++ b/src/packagedcode/rpm.py
@@ -201,7 +201,6 @@ class BaseRpmInstalledDatabaseHandler(models.DatafileHandler):
                 if package_uid:
                     # path is found and processed: remove it, so we can check if we
                     # found all of them
-                    package_adder(package_uid, res, codebase)
                     resources.append(res)
 
         # if we have left over file references, add these to extra data
@@ -224,7 +223,9 @@ class BaseRpmInstalledDatabaseHandler(models.DatafileHandler):
                     dep.namespace = namespace
                 yield dep
 
-        yield from resources
+        for resource in resources:
+            package_adder(package_uid, resource, codebase)
+            yield resource
 
 
 # TODO: add dependencies!!!


### PR DESCRIPTION
This PR modifies `AboutFileHandler.assemble()` to yield a package before assigning it to a Resource. This fixes the issue reported at https://github.com/nexB/scancode.io/issues/530