### PR TITLE
Fixed restructuredtext bulleted list to use *

### DIFF
--- a/docs/source/explanations/overview.rst
+++ b/docs/source/explanations/overview.rst
@@ -29,7 +29,7 @@ Scan results are provided in various formats:
 
 * a JSON file simple or pretty-printed,
 * SPDX tag value or XML, RDF formats,
-*  CSV,
+* CSV,
 * a simple unformatted HTML file that can be opened in browser or as a spreadsheet.
 
 For each scanned file, the result contains:

--- a/docs/source/explanations/overview.rst
+++ b/docs/source/explanations/overview.rst
@@ -27,18 +27,18 @@ ScanCode-Toolkit performs the scan on a codebase in the following steps :
 
 Scan results are provided in various formats:
 
-- a JSON file simple or pretty-printed,
-- SPDX tag value or XML, RDF formats,
-- CSV,
-- a simple unformatted HTML file that can be opened in browser or as a spreadsheet.
+* a JSON file simple or pretty-printed,
+* SPDX tag value or XML, RDF formats,
+*  CSV,
+* a simple unformatted HTML file that can be opened in browser or as a spreadsheet.
 
 For each scanned file, the result contains:
 
-- its location in the codebase,
-- the detected licenses and copyright statements,
-- the start and end line numbers identifying where the license or copyright was found in the
+* its location in the codebase,
+* the detected licenses and copyright statements,
+* the start and end line numbers identifying where the license or copyright was found in the
   scanned file, and
-- reference information for the detected license.
+* reference information for the detected license.
 
 For archive extraction, ScanCode uses a combination of Python modules, 7zip and libarchive/bsdtar
 to detect archive types and extract these recursively.


### PR DESCRIPTION
It wasn't rendering right here: https://scancode-toolkit.readthedocs.io/en/stable/explanations/overview.html#how-does-scancode-detect-licenses

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
