### PR TITLE
Fix #3157 by changing `CFG_BIN_DIR`

### DIFF
--- a/configure
+++ b/configure
@@ -116,7 +116,7 @@ _canonicalize_file_path() {
 CFG_BIN="$( realpath "${BASH_SOURCE[0]}" )"
 CFG_ROOT_DIR="$( cd "$( dirname "${CFG_BIN}" )" && pwd )"
 
-CFG_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/bin
+CFG_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/local/bin
 
 # force relaunching under X86-64 architecture on macOS M1/ARM 
 if [[ $OSTYPE == 'darwin'* && $(uname -m) == 'arm64' && $(sysctl -in sysctl.proc_translated) == 0 ]]; then
@@ -172,7 +172,7 @@ VIRTUALENV_PYZ_URL=https://bootstrap.pypa.io/virtualenv.pyz
 ################################
 # Current directory where this script lives
 CFG_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-CFG_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/bin
+CFG_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/local/bin
 
 
 ################################

--- a/configure
+++ b/configure
@@ -116,7 +116,10 @@ _canonicalize_file_path() {
 CFG_BIN="$( realpath "${BASH_SOURCE[0]}" )"
 CFG_ROOT_DIR="$( cd "$( dirname "${CFG_BIN}" )" && pwd )"
 
-CFG_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/local/bin
+# On some environments, the bin directory may lie inside the local directory.
+# In those cases, CFG_BIN_DIR will be assigned $CFG_LOCAL_BIN_DIR.
+CFG_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/bin
+CFG_LOCAL_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/local/bin
 
 # force relaunching under X86-64 architecture on macOS M1/ARM 
 if [[ $OSTYPE == 'darwin'* && $(uname -m) == 'arm64' && $(sysctl -in sysctl.proc_translated) == 0 ]]; then
@@ -172,7 +175,8 @@ VIRTUALENV_PYZ_URL=https://bootstrap.pypa.io/virtualenv.pyz
 ################################
 # Current directory where this script lives
 CFG_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-CFG_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/local/bin
+CFG_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/bin
+CFG_LOCAL_BIN_DIR=$CFG_ROOT_DIR/$VIRTUALENV_DIR/local/bin
 
 
 ################################
@@ -218,7 +222,7 @@ create_virtualenv() {
     # included either by default. The virtualenv.pyz app cures all these issues.
 
     VENV_DIR="$1"
-    if [ ! -f "$CFG_BIN_DIR/python" ]; then
+    if [[ ! -f "$CFG_BIN_DIR/python" && ! -f "$CFG_LOCAL_BIN_DIR/python" ]]; then
 
         mkdir -p "$CFG_ROOT_DIR/$VENV_DIR"
 
@@ -236,6 +240,10 @@ create_virtualenv() {
             --no-vcs-ignore \
             $CFG_QUIET \
             "$CFG_ROOT_DIR/$VENV_DIR"
+    fi
+
+    if [[ ! -f "$CFG_BIN_DIR/python" && -f "$CFG_LOCAL_BIN_DIR/python" ]]; then
+        CFG_BIN_DIR=$CFG_LOCAL_BIN_DIR
     fi
 }
 


### PR DESCRIPTION
The older value of `CFG_BIN_DIR` was `$CFG_ROOT_DIR/$VIRTUALENV_DIR/bin`. However, as mentioned in #3157, the bin directory actually was in `$CFG_ROOT_DIR/$VIRTUALENV_DIR/local/bin`.

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #3157 

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->

Signed-off-by: Abhishek Kumar <abhi.kr.2100@gmail.com>