### PR TITLE
Detect wurfl commercial license

### DIFF
--- a/etc/scripts/licenses/buildrules.py
+++ b/etc/scripts/licenses/buildrules.py
@@ -79,7 +79,7 @@ def load_data(location="00-new-licenses.txt"):
     Load rules metadata  and text from file at ``location``. Return a list of
     RuleData.
     """
-    with io.open(location, encoding="utf-8") as o:
+    with open(location) as o:
         lines = o.read().splitlines(False)
 
     rules = []
@@ -262,7 +262,7 @@ def cli(licenses_file):
             print(existing_msg.format(**locals()))
             continue
         else:
-            print(f"Adding new rule: {identifier}")
+            print(f"Adding new rule: file://{identifier}")
             rl = models.update_ignorables(rulerec, verbose=False)
             rl.dump(rules_data_dir=models.rules_data_dir)
 

--- a/src/licensedcode/data/rules/commercial-license_80.RULE
+++ b/src/licensedcode/data/rules/commercial-license_80.RULE
@@ -1,0 +1,11 @@
+---
+license_expression: commercial-license
+is_license_notice: yes
+notes: Seen in wurfl.h https://github.com/haproxy/haproxy/commit/cd9b9bd3e47cb2814eaab6c07d1facf222f013a9#diff-be9afa6e330d524179c2f689a4858fd7645bb3d1f05e54871b962f829f2580e8
+---
+
+This software package is the property of ScientiaMobile Inc. and is licensed
+commercially according to a contract between the Licensee and ScientiaMobile Inc. (Licensor).
+If you represent the Licensee, please refer to the licensing agreement which has been signed
+between the two parties. If you do not represent the Licensee, you are not authorized to use
+this software in any way.

--- a/src/licensedcode/data/rules/commercial-license_81.RULE
+++ b/src/licensedcode/data/rules/commercial-license_81.RULE
@@ -1,0 +1,8 @@
+---
+license_expression: commercial-license
+is_license_notice: yes
+relevance: 100
+notes: Seen in wurfl.h https://github.com/haproxy/haproxy/commit/cd9b9bd3e47cb2814eaab6c07d1facf222f013a9#diff-be9afa6e330d524179c2f689a4858fd7645bb3d1f05e54871b962f829f2580e8
+---
+
+software package is the property

--- a/src/licensedcode/data/rules/commercial-license_82.RULE
+++ b/src/licensedcode/data/rules/commercial-license_82.RULE
@@ -1,0 +1,8 @@
+---
+license_expression: commercial-license
+is_license_notice: yes
+relevance: 100
+notes: Seen in wurfl.h https://github.com/haproxy/haproxy/commit/cd9b9bd3e47cb2814eaab6c07d1facf222f013a9#diff-be9afa6e330d524179c2f689a4858fd7645bb3d1f05e54871b962f829f2580e8
+---
+
+licensed commercially

--- a/src/licensedcode/data/rules/commercial-license_83.RULE
+++ b/src/licensedcode/data/rules/commercial-license_83.RULE
@@ -1,0 +1,8 @@
+---
+license_expression: commercial-license
+is_license_notice: yes
+relevance: 100
+notes: Seen in wurfl.h https://github.com/haproxy/haproxy/commit/cd9b9bd3e47cb2814eaab6c07d1facf222f013a9#diff-be9afa6e330d524179c2f689a4858fd7645bb3d1f05e54871b962f829f2580e8
+---
+
+licensed commercially according to a contract

--- a/src/licensedcode/data/rules/commercial-license_84.RULE
+++ b/src/licensedcode/data/rules/commercial-license_84.RULE
@@ -1,0 +1,8 @@
+---
+license_expression: commercial-license
+is_license_notice: yes
+relevance: 100
+notes: Seen in wurfl.h https://github.com/haproxy/haproxy/commit/cd9b9bd3e47cb2814eaab6c07d1facf222f013a9#diff-be9afa6e330d524179c2f689a4858fd7645bb3d1f05e54871b962f829f2580e8
+---
+
+refer to the licensing agreement which has been signed

--- a/src/licensedcode/data/rules/commercial-license_85.RULE
+++ b/src/licensedcode/data/rules/commercial-license_85.RULE
@@ -1,0 +1,8 @@
+---
+license_expression: commercial-license
+is_license_notice: yes
+relevance: 100
+notes: Seen in wurfl.h https://github.com/haproxy/haproxy/commit/cd9b9bd3e47cb2814eaab6c07d1facf222f013a9#diff-be9afa6e330d524179c2f689a4858fd7645bb3d1f05e54871b962f829f2580e8
+---
+
+you are not authorized to use this software in any way.

--- a/src/licensedcode/data/rules/commercial-license_86.RULE
+++ b/src/licensedcode/data/rules/commercial-license_86.RULE
@@ -1,0 +1,8 @@
+---
+license_expression: commercial-license
+is_license_notice: yes
+relevance: 100
+notes: Seen in wurfl.h https://github.com/haproxy/haproxy/commit/cd9b9bd3e47cb2814eaab6c07d1facf222f013a9#diff-be9afa6e330d524179c2f689a4858fd7645bb3d1f05e54871b962f829f2580e8
+---
+
+not authorized to use this software

--- a/src/licensedcode/models.py
+++ b/src/licensedcode/models.py
@@ -425,20 +425,13 @@ class License:
          - the license data as YAML frontmatter
          - the license text
         """
-
-        def write(location, byte_string):
-            # we write as binary because rules and licenses texts and data are
-            # UTF-8-encoded bytes
-            with io.open(location, 'wb') as of:
-                of.write(byte_string)
-
         metadata = self.to_dict()
-        content = self.text.encode('utf-8')
+        content = self.text
         rule_post = FrontmatterPost(content=content, handler=SaneYAMLHandler(), **metadata)
-        output_string = dumps_frontmatter(post=rule_post)
-
+        output = dumps_frontmatter(post=rule_post)
         license_file = self.license_file(licenses_data_dir=licenses_data_dir)
-        write(license_file, output_string.encode('utf-8'))
+        with open(license_file, 'w') as of:
+            of.write(output)
 
     def load(self, license_file, check_consistency=True):
         """
@@ -2078,19 +2071,14 @@ class Rule(BasicRule):
         if self.is_from_license or self.is_synthetic:
             return
 
-        def write(location, byte_string):
-            # we write as binary because rules and licenses texts and data are
-            # UTF-8-encoded bytes
-            with io.open(location, 'wb') as of:
-                of.write(byte_string)
-
         rule_file = self.rule_file(rules_data_dir=rules_data_dir)
 
         metadata = self.to_dict()
-        content = self.text.encode('utf-8')
+        content = self.text
         rule_post = FrontmatterPost(content=content, handler=SaneYAMLHandler(), **metadata)
-        output_string = dumps_frontmatter(post=rule_post)
-        write(rule_file, output_string.encode('utf-8'))
+        output = dumps_frontmatter(post=rule_post)
+        with open(rule_file, 'w') as of:
+            of.write(output)
 
     def load(self, rule_file, with_checks=True):
         """

--- a/src/scancode/cli_test_utils.py
+++ b/src/scancode/cli_test_utils.py
@@ -137,13 +137,8 @@ output:
 
 
 def get_opts(options):
-    try:
-        return ' '.join(options)
-    except:
-        try:
-            return b' '.join(options)
-        except:
-            return b' '.join(map(repr, options))
+    opts = [o if isinstance(o, str) else repr(o) for o in options]
+    return ' '.join(opts)
 
 
 WINDOWS_CI_TIMEOUT = '222.2'

--- a/tests/licensedcode/data/datadriven/lic4/wurfl.h
+++ b/tests/licensedcode/data/datadriven/lic4/wurfl.h
@@ -1,0 +1,17 @@
+/*
+ * InFuze C API - HAPROXY Dummy library version of include
+ *
+ * Copyright (c) ScientiaMobile, Inc.
+ * http://www.scientiamobile.com
+ *
+ * This software package is the property of ScientiaMobile Inc. and is licensed
+ * commercially according to a contract between the Licensee and ScientiaMobile Inc. (Licensor).
+ * If you represent the Licensee, please refer to the licensing agreement which has been signed
+ * between the two parties. If you do not represent the Licensee, you are not authorized to use
+ * this software in any way.
+ *
+ */
+
+#ifndef _WURFL_H_
+#define _WURFL_H_
+

--- a/tests/licensedcode/data/datadriven/lic4/wurfl.h.yml
+++ b/tests/licensedcode/data/datadriven/lic4/wurfl.h.yml
@@ -1,0 +1,3 @@
+license_expressions:
+  - commercial-license
+


### PR DESCRIPTION
This PR add rules to properly detect a wurlf commercial license
in haproxy for #3162

See also upstream issue reported at https://github.com/haproxy/haproxy/issues/1948

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
