### PR TITLE
setup: Use packaging version <22

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ install_requires =
     lxml >= 4.9.1
     MarkupSafe >= 1.0
     packageurl_python >= 0.9.0
-    packaging >= 21.0.0
+    packaging < 22.0.0
     # use temp advanced patched release
     parameter-expansion-patched >= 0.3.1
     pdfminer.six >= 20200101


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Same locking version is used in requirements. If we do not lock, the 22.0 removed Legacy version, the error I am seeing:
`ImportError: cannot import name 'LegacyVersion' from 'packaging.version'`

I verified packaging version 22.0 what was breaking there, it really removed LegacyVersion, we should lock to < 22.0.

Requirements (txt files in the root) have the version properly locked (using exact 21 version match), not certain why setup config has different version match.  I also wonder why this has not been reported so far, have I missed anything?

See https://github.com/ARMmbed/mbed-os/pull/15357 (we got license check job failing since few days ago).

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [ ] Commits are in uniquely-named feature branch and has no merge conflicts 📁

<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
