### PR TITLE
Build app archives for all python versions

### DIFF
--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -439,6 +439,9 @@ jobs:
       - smoke_test_install_and_run_app_archives_on_windows
       - smoke_test_install_and_run_app_archives_on_macos
       - build_scancode_for_release_source
+      - build_scancode_for_release_windows
+      - build_scancode_for_release_linux
+      - build_scancode_for_release_macos
 
     runs-on: ubuntu-20.04
     defaults:
@@ -454,22 +457,94 @@ jobs:
           name: source_app
           path: dist
 
-      - name: Download a single artifact macos_app
+      - name: Download a single artifact macos_app for python 3.7
         uses: actions/download-artifact@v3
         with:
-          name: macos_app
+          name: macos_app_py_3.7
           path: dist
 
-      - name: Download a single artifact linux_app
+      - name: Download a single artifact macos_app for python 3.8
         uses: actions/download-artifact@v3
         with:
-          name: linux_app
+          name: macos_app_py_3.8
           path: dist
 
-      - name: Download a single artifact windows_app
+      - name: Download a single artifact macos_app for python 3.9
         uses: actions/download-artifact@v3
         with:
-          name: windows_app
+          name: macos_app_py_3.9
+          path: dist
+
+      - name: Download a single artifact macos_app for python 3.10
+        uses: actions/download-artifact@v3
+        with:
+          name: macos_app_py_3.10
+          path: dist
+
+      - name: Download a single artifact macos_app for python 3.11
+        uses: actions/download-artifact@v3
+        with:
+          name: macos_app_py_3.11
+          path: dist
+
+      - name: Download a single artifact linux_app for python 3.7
+        uses: actions/download-artifact@v3
+        with:
+          name: linux_app_py_3.7
+          path: dist
+
+      - name: Download a single artifact linux_app for python 3.8
+        uses: actions/download-artifact@v3
+        with:
+          name: linux_app_py_3.8
+          path: dist
+
+      - name: Download a single artifact linux_app for python 3.9
+        uses: actions/download-artifact@v3
+        with:
+          name: linux_app_py_3.9
+          path: dist
+
+      - name: Download a single artifact linux_app for python 3.10
+        uses: actions/download-artifact@v3
+        with:
+          name: linux_app_py_3.10
+          path: dist
+
+      - name: Download a single artifact linux_app for python 3.11
+        uses: actions/download-artifact@v3
+        with:
+          name: linux_app_py_3.11
+          path: dist
+
+      - name: Download a single artifact windows_app for python 3.7
+        uses: actions/download-artifact@v3
+        with:
+          name: windows_app_py_3.7
+          path: dist
+
+      - name: Download a single artifact windows_app for python 3.8
+        uses: actions/download-artifact@v3
+        with:
+          name: windows_app_py_3.8
+          path: dist
+
+      - name: Download a single artifact windows_app for python 3.9
+        uses: actions/download-artifact@v3
+        with:
+          name: windows_app_py_3.9
+          path: dist
+
+      - name: Download a single artifact windows_app for python 3.10
+        uses: actions/download-artifact@v3
+        with:
+          name: windows_app_py_3.10
+          path: dist
+
+      - name: Download a single artifact windows_app for python 3.11
+        uses: actions/download-artifact@v3
+        with:
+          name: windows_app_py_3.11
           path: dist
 
       - name: Mock GH release

--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Build linux app archive
         run: etc/release/scancode-create-release-app-linux.sh ${{ matrix.pyver }}
 
-      - name: Collect built linux app for python {{ matrix.pyver }}
+      - name: Collect built linux app for python ${{ matrix.pyver }}
         uses: actions/upload-artifact@v3
         with:
           name: linux_app_py_${{ matrix.pyver }}
@@ -147,7 +147,7 @@ jobs:
       - name: Build mac app archive
         run: etc/release/scancode-create-release-app-macos.sh ${{ matrix.pyver }}
 
-      - name: Collect built mac app for python {{ matrix.pyver }}
+      - name: Collect built mac app for python ${{ matrix.pyver }}
         uses: actions/upload-artifact@v3
         with:
           name: macos_app_py_${{ matrix.pyver }}
@@ -181,7 +181,7 @@ jobs:
       - name: Build windows app archive
         run: etc/release/scancode-create-release-app-windows.sh ${{ matrix.pyver }}
 
-      - name: Collect built windows app for python {{ matrix.pyver }}
+      - name: Collect built windows app for python ${{ matrix.pyver }}
         uses: actions/upload-artifact@v3
         with:
           name: windows_app_py_${{ matrix.pyver }}

--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-       pyver: ["3.7", "3.8", "3.9", "3.10"]
+       pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -99,22 +99,24 @@ jobs:
 
     strategy:
       fail-fast: true
+      matrix:
+       pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
+      - name: Set up Python on ${{ matrix.pyver }}
         uses: actions/setup-python@v1
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.pyver }} 
 
       - name: Build linux app archive
-        run: etc/release/scancode-create-release-app-linux.sh
+        run: etc/release/scancode-create-release-app-linux.sh ${{ matrix.pyver }}
 
-      - name: Collect built linux app
+      - name: Collect built linux app for python {{ matrix.pyver }}
         uses: actions/upload-artifact@v3
         with:
-          name: linux_app
+          name: linux_app_py_${{ matrix.pyver }}
           path: release/*
 
 
@@ -131,22 +133,24 @@ jobs:
 
     strategy:
       fail-fast: true
+      matrix:
+       pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
+      - name: Set up Python on ${{ matrix.pyver }}
         uses: actions/setup-python@v1
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.pyver }} 
 
       - name: Build mac app archive
-        run: etc/release/scancode-create-release-app-macos.sh
+        run: etc/release/scancode-create-release-app-macos.sh ${{ matrix.pyver }}
 
-      - name: Collect built mac app
+      - name: Collect built mac app for python {{ matrix.pyver }}
         uses: actions/upload-artifact@v3
         with:
-          name: macos_app
+          name: macos_app_py_${{ matrix.pyver }}
           path: release/*
 
 
@@ -160,24 +164,27 @@ jobs:
     defaults:
       run:
         shell: bash
+
     strategy:
       fail-fast: true
+      matrix:
+       pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
+      - name: Set up Python on ${{ matrix.pyver }}
         uses: actions/setup-python@v1
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.pyver }} 
 
       - name: Build windows app archive
-        run: etc/release/scancode-create-release-app-windows.sh
+        run: etc/release/scancode-create-release-app-windows.sh ${{ matrix.pyver }}
 
-      - name: Collect built windows app
+      - name: Collect built windows app for python {{ matrix.pyver }}
         uses: actions/upload-artifact@v3
         with:
-          name: windows_app
+          name: windows_app_py_${{ matrix.pyver }}
           path: release/*
 
 
@@ -229,7 +236,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
-        pyver: ["3.7", "3.8", "3.9", "3.10"]
+        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -275,7 +282,7 @@ jobs:
       fail-fast: true
       matrix:
        os: [windows-2019, windows-2022]
-       pyver: ["3.7", "3.8", "3.9", "3.10"]
+       pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -320,7 +327,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-        pyver: [3.8]
+        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -330,10 +337,10 @@ jobs:
         with:
           python-version: ${{ matrix.pyver }}
 
-      - name: Download a single artifact linux_app
+      - name: Download a single artifact linux_app_py_${{ matrix.pyver }}
         uses: actions/download-artifact@v3
         with:
-          name: linux_app
+          name: linux_app_py_${{ matrix.pyver }}
           path: dist
 
       - name: test install app archive
@@ -361,7 +368,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [macos-11, macos-12]
-        pyver: [3.8]
+        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -371,10 +378,10 @@ jobs:
         with:
           python-version: ${{ matrix.pyver }}
 
-      - name: Download a single artifact macos_app
+      - name: Download a single artifact macos_app_py_${{ matrix.pyver }}
         uses: actions/download-artifact@v3
         with:
-          name: macos_app
+          name: macos_app_py_${{ matrix.pyver }}
           path: dist
 
       - name: test install app archive
@@ -402,7 +409,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [windows-2019, windows-2022]
-        pyver: [3.8]
+        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -412,10 +419,10 @@ jobs:
         with:
           python-version: ${{ matrix.pyver }}
 
-      - name: Download a single artifact windows_app
+      - name: Download a single artifact windows_app_py_${{ matrix.pyver }}
         uses: actions/download-artifact@v3
         with:
-          name: windows_app
+          name: windows_app_py_${{ matrix.pyver }}
           path: dist
 
       - name: test install app archive
@@ -491,7 +498,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dist_names: ["wheels-3.7", "wheels-3.8", "wheels-3.9", "wheels-3.10", sdists]
+        dist_names: ["wheels-3.7", "wheels-3.8", "wheels-3.9", "wheels-3.10", "wheels-3.11", sdists]
 
     steps:
       - name: Set up Python

--- a/etc/release/scancode-create-release-app-linux.sh
+++ b/etc/release/scancode-create-release-app-linux.sh
@@ -18,8 +18,8 @@ set -e
 
 
 operating_system=linux
-python_dot_version=3.8
-python_version=38
+python_dot_version=$1
+python_version=${python_dot_version//.}
 python_exe="python$python_dot_version"
 release_dir=scancode-toolkit-$(git describe --tags)
 

--- a/etc/release/scancode-create-release-app-macos.sh
+++ b/etc/release/scancode-create-release-app-macos.sh
@@ -18,8 +18,8 @@ set -e
 
 
 operating_system=macos
-python_dot_version=3.8
-python_version=38
+python_dot_version=$1
+python_version=${python_dot_version//.}
 python_exe="python3"
 release_dir=scancode-toolkit-$(git describe --tags)
 

--- a/etc/release/scancode-create-release-app-windows.sh
+++ b/etc/release/scancode-create-release-app-windows.sh
@@ -17,8 +17,8 @@ set -e
 #set -x
 
 operating_system=windows
-python_dot_version=3.8
-python_version=38
+python_dot_version=$1
+python_version=${python_dot_version//.}
 python_exe="py -$python_dot_version"
 release_dir=scancode-toolkit-$(git describe --tags)
 

--- a/etc/scripts/utils_thirdparty.py
+++ b/etc/scripts/utils_thirdparty.py
@@ -115,13 +115,14 @@ TRACE_DEEP = False
 TRACE_ULTRA_DEEP = False
 
 # Supported environments
-PYTHON_VERSIONS = "37", "38", "39", "310"
+PYTHON_VERSIONS = "37", "38", "39", "310", "311"
 
 PYTHON_DOT_VERSIONS_BY_VER = {
     "37": "3.7",
     "38": "3.8",
     "39": "3.9",
     "310": "3.10",
+    "311": "3.11",
 }
 
 
@@ -137,6 +138,7 @@ ABIS_BY_PYTHON_VERSION = {
     "38": ["cp38", "cp38m", "abi3"],
     "39": ["cp39", "cp39m", "abi3"],
     "310": ["cp310", "cp310m", "abi3"],
+    "311": ["cp311", "cp311m", "abi3"],
 }
 
 PLATFORMS_BY_OS = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ Jinja2==3.1.2
 jsonstreams==0.6.0
 license-expression==30.0.0
 lxml==4.9.2
-MarkupSafe==2.1.1
+MarkupSafe==2.1.2
 more-itertools==8.13.0
 normality==2.3.3
 packageurl-python==0.10.0

--- a/setup-mini.cfg
+++ b/setup-mini.cfg
@@ -87,7 +87,7 @@ install_requires =
     jsonstreams >= 0.5.0
     license_expression >= 30.0.0
     lxml >= 4.9.2
-    MarkupSafe >= 1.0
+    MarkupSafe >= 2.1.2
     packageurl_python >= 0.9.0
     packvers >= 21.0.0
     # use temp advanced patched release

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ install_requires =
     jsonstreams >= 0.5.0
     license_expression >= 30.0.0
     lxml >= 4.9.2
-    MarkupSafe >= 1.0
+    MarkupSafe >= 2.1.2
     packageurl_python >= 0.9.0
     packvers >= 21.0.0
     # use temp advanced patched release


### PR DESCRIPTION
Fixes #3124 
Fixes #3215 
Fixes #3235 

* Builds app archives for python 3.7-3.11 for linux/mac/windows
* Modifies app archive creation script to pass python version as variable
* Publishes python 3.11 wheel
* smoke test install and scan for all python versions in linux/mac/windows
* Update utils_thirdparty.py with python 3.11 support
* updates https://github.com/nexB/thirdparty-packages with new lxml/MarkupSafe wheels having py311 support

Signed-off-by: Ayan Sinha Mahapatra <ayansmahapatra@gmail.com>

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

