### PR TITLE
Update doc to reference attrib in AbcTK

### DIFF
--- a/docs/source/how-to-guides/generate_attribution.rst
+++ b/docs/source/how-to-guides/generate_attribution.rst
@@ -1,0 +1,22 @@
+.. _generate_attribution:
+
+How To Generate Attribution from a ScanCode Scan
+================================================
+
+How To generate attribution from a ScanCode scan?
+-------------------------------------------------
+
+Users can use an Open Source Project "AboutCode Toolkit" to generate
+attrbution document from a ScanCode scan.
+
+Read more about AboutCode Toolkit here: https://aboutcode-toolkit.readthedocs.io/.
+
+Check out the code at https://github.com/nexB/aboutcode-toolkit
+
+Command in AboutCode Toolkit to generate attribution:
+https://aboutcode-toolkit.readthedocs.io/en/latest/reference.html#attrib.
+
+.. Attention::
+
+    The attribution requires the ScanCode scan to have at least the `--info`
+    and `--license` option flagged

--- a/docs/source/how-to-guides/index.rst
+++ b/docs/source/how-to-guides/index.rst
@@ -9,3 +9,4 @@
    add_new_license
    add_new_license_detection_rule
    install_new_license_plugin
+   generate_attribution


### PR DESCRIPTION
Only updated the documentation to reference attribution generation from a ScanCode scan with AboutCode Toolkit.

Signed-off-by: Chin Yeung Li <tli@nexb.com>