### PR TITLE
Fix #3250: Invalid SPDX with empty file: no SHA1

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -44,6 +44,7 @@ The following organizations or individuals have contributed to ScanCode:
 - Lemo Shi @lemoshi
 - Li Ha @linexb
 - Mankaran Singh @MankaranSingh
+- Marc-Etienne Vargenau @vargenau
 - Martin Petkov @MartinPetkov
 - Maximilian Huber @maxhbr 
 - Michael Herzog @mjherzog

--- a/src/formattedcode/output_spdx.py
+++ b/src/formattedcode/output_spdx.py
@@ -284,7 +284,10 @@ def write_spdx(
         file_entry = File(
             spdx_id=f'SPDXRef-{sid}',
             name=name)
-        file_entry.set_checksum(Checksum(ChecksumAlgorithm.SHA1, file_data.get('sha1') or ''))
+        if file_data.get('file_type') == 'empty':
+            file_entry.set_checksum(Checksum(ChecksumAlgorithm.SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709"))
+        else:
+            file_entry.set_checksum(Checksum(ChecksumAlgorithm.SHA1, file_data.get('sha1') or ''))
 
         file_license_detections = file_data.get('license_detections')
         license_matches = get_matches_from_detection_mappings(file_license_detections)

--- a/tests/formattedcode/test_output_spdx.py
+++ b/tests/formattedcode/test_output_spdx.py
@@ -346,7 +346,6 @@ def test_output_spdx_rdf_can_handle_non_ascii_paths():
         results = res.read()
     assert 'han/据.svg' in results
 
-
 def test_output_spdx_tv_can_handle_non_ascii_paths():
     test_file = test_env.get_test_loc('spdx/unicode.json')
     result_file = test_env.get_temp_file(extension='spdx', file_name='test_spdx')
@@ -354,3 +353,11 @@ def test_output_spdx_tv_can_handle_non_ascii_paths():
     with io.open(result_file, encoding='utf-8') as res:
         results = res.read()
     assert 'han/据.svg' in results
+
+def test_output_spdx_tv_sh1_of_empty_file():
+    test_dir = test_env.get_test_loc('spdx/empty/scan/somefile')
+    result_file = test_env.get_temp_file(extension='spdx', file_name='test_spdx')
+    run_scan_click([test_dir, '-clip', '--spdx-tv', result_file])
+    with io.open(result_file, encoding='utf-8') as res:
+        results = res.read()
+    assert 'FileChecksum: SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709' in results


### PR DESCRIPTION
Fixes #3250

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>
