### PR TITLE
Fix-up the category of the 'ms-cla' license

### DIFF
--- a/src/licensedcode/data/licenses/ms-cla.LICENSE
+++ b/src/licensedcode/data/licenses/ms-cla.LICENSE
@@ -2,7 +2,7 @@
 key: ms-cla
 short_name: MS Contribution License Agreement (CLA)
 name: Microsoft Contribution License Agreement (CLA)
-category: Patent License
+category: CLA
 owner: Microsoft
 homepage_url: https://cla.microsoft.com
 spdx_license_key: LicenseRef-scancode-ms-cla


### PR DESCRIPTION
The license is a Contributor License Agreement, not a Patent License.

Fixes #3317.
