### PR TITLE
Ensure MIT License is not mistakenly detected

### DIFF
--- a/src/licensedcode/data/rules/mit_761.RULE
+++ b/src/licensedcode/data/rules/mit_761.RULE
@@ -4,6 +4,6 @@ is_license_notice: yes
 relevance: 100
 ---
 
-Licensed under the MIT License (the "License");
+Licensed under the {{MIT License}} (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at the root of this project.


### PR DESCRIPTION
This PR fixes an inaccurate detection and requires the presence of "MIT License". 