### PR TITLE
3396 update get license detections and expression

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -136,7 +136,7 @@ testing =
     pytest-rerunfailures
 
 docs =
-    Sphinx >= 4.3.0
+    Sphinx == 5.3.0
     sphinx_rtd_theme >= 0.5.1
     docutils < 0.17
     doc8

--- a/src/packagedcode/models.py
+++ b/src/packagedcode/models.py
@@ -869,11 +869,16 @@ class PackageData(IdentifiablePackageData):
         if not self.extracted_license_statement:
             return [], None
 
-        return get_license_detections_and_expression(
-            extracted_license_statement=self.extracted_license_statement,
+        if self.datasource_id:
             default_relation_license=get_default_relation_license(
                 datasource_id=self.datasource_id,
-            ),
+            )
+        else:
+            default_relation_license = 'AND'
+
+        return get_license_detections_and_expression(
+            extracted_license_statement=self.extracted_license_statement,
+            default_relation_license=default_relation_license
         )
 
 

--- a/tests/packagedcode/test_package_models.py
+++ b/tests/packagedcode/test_package_models.py
@@ -225,3 +225,20 @@ class TestModels(PackageTester):
             for package_uid in for_packages:
                 normalized_package_uid = purl_with_fake_uuid(package_uid)
                 assert normalized_package_uid == test_package_uid
+
+    def test_create_package_not_handled_by_packagedcode(self):
+        extracted_license_statement = [
+            'gpl',
+            'GNU General Public License version 2.0 (GPLv2)',
+        ]
+        package = PackageData(
+            type='sourceforge',
+            name='openstunts',
+            copyright='Copyright (c) openstunts project',
+            extracted_license_statement=extracted_license_statement,
+        )
+        # Test generated fields
+        assert package.purl == 'pkg:sourceforge/openstunts'
+        assert package.holder == 'openstunts project'
+        assert package.declared_license_expression == 'gpl-1.0-plus AND gpl-2.0'
+        assert package.declared_license_expression_spdx == 'GPL-1.0-or-later AND GPL-2.0-only'


### PR DESCRIPTION
This PR introduces the fix by @AyanSinhaMahapatra in `PackageData.get_license_detections_and_expression()` where a default value for `default_relation_license` is set when a `PackageData` object does not have a `datasource_id` value.

I've also pinned Sphinx to 5.3.0 to avoid the docs test failures.