### PR TITLE
Do not set version to empty string in npm_api_url #3393

### DIFF
--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -801,7 +801,7 @@ def npm_api_url(namespace, name, version=None, registry='https://registry.npmjs.
 
     For example:
     >>> result = npm_api_url('@invisionag', 'eslint-config-ivx', '0.1.4', 'https://registry.yarnpkg.com')
-    >>> assert result == 'https://registry.yarnpkg.com/@invisionag%2feslint-config-ivx'
+    >>> assert result == 'https://registry.yarnpkg.com/@invisionag%2feslint-config-ivx/0.1.4'
 
     >>> assert npm_api_url(None, 'angular', '1.6.6') == 'https://registry.npmjs.org/angular/1.6.6'
 
@@ -812,8 +812,6 @@ def npm_api_url(namespace, name, version=None, registry='https://registry.npmjs.
             # this is a legacy wart: older registries used to always encode this /
             # FIXME: do NOT encode and use plain / instead
             ns_name = '%2f'.join([namespace, name])
-            # there is no version-specific URL for scoped packages
-            version = ''
         else:
             ns_name = name
 

--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -794,16 +794,17 @@ def npm_api_url(namespace, name, version=None, registry='https://registry.npmjs.
     Return a package API data URL given a namespace, name, version and a base
     registry URL.
 
-    Note that for scoped packages (with a namespace), the URL is not version
-    specific but contains the data for all versions as the default behvior of
-    the registries is to return nothing in this case. Special quoting rules are
-    applied for scoped npms.
+    Special quoting rules are applied for scoped npms.
 
     For example:
     >>> result = npm_api_url('@invisionag', 'eslint-config-ivx', '0.1.4', 'https://registry.yarnpkg.com')
     >>> assert result == 'https://registry.yarnpkg.com/@invisionag%2feslint-config-ivx/0.1.4'
 
+    >>> result = npm_api_url('@invisionag', 'eslint-config-ivx', 'https://registry.yarnpkg.com')
+    >>> assert result == 'https://registry.yarnpkg.com/@invisionag%2feslint-config-ivx'
+
     >>> assert npm_api_url(None, 'angular', '1.6.6') == 'https://registry.npmjs.org/angular/1.6.6'
+    >>> assert npm_api_url(None, 'angular') == 'https://registry.npmjs.org/angular'
 
     >>> assert not npm_api_url(None, None, None)
     """

--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -800,7 +800,7 @@ def npm_api_url(namespace, name, version=None, registry='https://registry.npmjs.
     >>> result = npm_api_url('@invisionag', 'eslint-config-ivx', '0.1.4', 'https://registry.yarnpkg.com')
     >>> assert result == 'https://registry.yarnpkg.com/@invisionag%2feslint-config-ivx/0.1.4'
 
-    >>> result = npm_api_url('@invisionag', 'eslint-config-ivx', 'https://registry.yarnpkg.com')
+    >>> result = npm_api_url('@invisionag', 'eslint-config-ivx', registry='https://registry.yarnpkg.com')
     >>> assert result == 'https://registry.yarnpkg.com/@invisionag%2feslint-config-ivx'
 
     >>> assert npm_api_url(None, 'angular', '1.6.6') == 'https://registry.npmjs.org/angular/1.6.6'

--- a/tests/packagedcode/data/npm/package-lock-v2-2/package-lock.json-expected
+++ b/tests/packagedcode/data/npm/package-lock-v2-2/package-lock.json-expected
@@ -176,7 +176,7 @@
           ],
           "repository_homepage_url": "https://www.npmjs.com/package/@szmarczak/http-timer",
           "repository_download_url": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
-          "api_data_url": "https://registry.npmjs.org/@szmarczak%2fhttp-timer",
+          "api_data_url": "https://registry.npmjs.org/@szmarczak%2fhttp-timer/1.1.2",
           "datasource_id": "npm_package_lock_json",
           "purl": "pkg:npm/%40szmarczak/http-timer@1.1.2"
         },

--- a/tests/packagedcode/data/npm/package-lock-v2/package-lock.json-expected
+++ b/tests/packagedcode/data/npm/package-lock-v2/package-lock.json-expected
@@ -165,7 +165,7 @@
           "dependencies": [],
           "repository_homepage_url": "https://www.npmjs.com/package/@sindresorhus/is",
           "repository_download_url": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-          "api_data_url": "https://registry.npmjs.org/@sindresorhus%2fis",
+          "api_data_url": "https://registry.npmjs.org/@sindresorhus%2fis/0.14.0",
           "datasource_id": "npm_package_lock_json",
           "purl": "pkg:npm/%40sindresorhus/is@0.14.0"
         },

--- a/tests/packagedcode/data/npm/private-and-yarn/scan.expected.json
+++ b/tests/packagedcode/data/npm/private-and-yarn/scan.expected.json
@@ -71,7 +71,7 @@
         ],
         "repository_homepage_url": "https://www.npmjs.com/package/@babel/runtime",
         "repository_download_url": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
-        "api_data_url": "https://registry.npmjs.org/@babel%2fruntime",
+        "api_data_url": "https://registry.npmjs.org/@babel%2fruntime/7.2.0",
         "datasource_id": "yarn_lock_v1",
         "purl": "pkg:npm/%40babel/runtime@7.2.0"
       },
@@ -197,7 +197,7 @@
         ],
         "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/api-designer",
         "repository_download_url": "https://registry.npmjs.org/@ballerina/api-designer/-/api-designer-0.99.0-RC3.tgz",
-        "api_data_url": "https://registry.npmjs.org/@ballerina%2fapi-designer",
+        "api_data_url": "https://registry.npmjs.org/@ballerina%2fapi-designer/0.99.0-RC3",
         "datasource_id": "yarn_lock_v1",
         "purl": "pkg:npm/%40ballerina/api-designer@0.99.0-RC3"
       },
@@ -313,7 +313,7 @@
         ],
         "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/ast-model",
         "repository_download_url": "https://registry.npmjs.org/@ballerina/ast-model/-/ast-model-0.99.0-RC3.tgz",
-        "api_data_url": "https://registry.npmjs.org/@ballerina%2fast-model",
+        "api_data_url": "https://registry.npmjs.org/@ballerina%2fast-model/0.99.0-RC3",
         "datasource_id": "yarn_lock_v1",
         "purl": "pkg:npm/%40ballerina/ast-model@0.99.0-RC3"
       },
@@ -379,7 +379,7 @@
         ],
         "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/ballerina-by-examples",
         "repository_download_url": "https://registry.npmjs.org/@ballerina/ballerina-by-examples/-/ballerina-by-examples-0.99.0-RC3.tgz",
-        "api_data_url": "https://registry.npmjs.org/@ballerina%2fballerina-by-examples",
+        "api_data_url": "https://registry.npmjs.org/@ballerina%2fballerina-by-examples/0.99.0-RC3",
         "datasource_id": "yarn_lock_v1",
         "purl": "pkg:npm/%40ballerina/ballerina-by-examples@0.99.0-RC3"
       },
@@ -505,7 +505,7 @@
         ],
         "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/diagram",
         "repository_download_url": "https://registry.npmjs.org/@ballerina/diagram/-/diagram-0.99.0-RC3.tgz",
-        "api_data_url": "https://registry.npmjs.org/@ballerina%2fdiagram",
+        "api_data_url": "https://registry.npmjs.org/@ballerina%2fdiagram/0.99.0-RC3",
         "datasource_id": "yarn_lock_v1",
         "purl": "pkg:npm/%40ballerina/diagram@0.99.0-RC3"
       },
@@ -621,7 +621,7 @@
         ],
         "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/distribution",
         "repository_download_url": "https://registry.npmjs.org/@ballerina/distribution/-/distribution-0.99.0-RC3.tgz",
-        "api_data_url": "https://registry.npmjs.org/@ballerina%2fdistribution",
+        "api_data_url": "https://registry.npmjs.org/@ballerina%2fdistribution/0.99.0-RC3",
         "datasource_id": "yarn_lock_v1",
         "purl": "pkg:npm/%40ballerina/distribution@0.99.0-RC3"
       },
@@ -717,7 +717,7 @@
         ],
         "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/documentation",
         "repository_download_url": "https://registry.npmjs.org/@ballerina/documentation/-/documentation-0.99.0-RC3.tgz",
-        "api_data_url": "https://registry.npmjs.org/@ballerina%2fdocumentation",
+        "api_data_url": "https://registry.npmjs.org/@ballerina%2fdocumentation/0.99.0-RC3",
         "datasource_id": "yarn_lock_v1",
         "purl": "pkg:npm/%40ballerina/documentation@0.99.0-RC3"
       },
@@ -772,7 +772,7 @@
         "dependencies": [],
         "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/font",
         "repository_download_url": "https://registry.npmjs.org/@ballerina/font/-/font-0.99.0-RC3.tgz",
-        "api_data_url": "https://registry.npmjs.org/@ballerina%2ffont",
+        "api_data_url": "https://registry.npmjs.org/@ballerina%2ffont/0.99.0-RC3",
         "datasource_id": "yarn_lock_v1",
         "purl": "pkg:npm/%40ballerina/font@0.99.0-RC3"
       },
@@ -1024,7 +1024,7 @@
                 ],
                 "repository_homepage_url": "https://www.npmjs.com/package/@babel/runtime",
                 "repository_download_url": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
-                "api_data_url": "https://registry.npmjs.org/@babel%2fruntime",
+                "api_data_url": "https://registry.npmjs.org/@babel%2fruntime/7.2.0",
                 "datasource_id": "yarn_lock_v1",
                 "purl": "pkg:npm/%40babel/runtime@7.2.0"
               },
@@ -1146,7 +1146,7 @@
                 ],
                 "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/api-designer",
                 "repository_download_url": "https://registry.npmjs.org/@ballerina/api-designer/-/api-designer-0.99.0-RC3.tgz",
-                "api_data_url": "https://registry.npmjs.org/@ballerina%2fapi-designer",
+                "api_data_url": "https://registry.npmjs.org/@ballerina%2fapi-designer/0.99.0-RC3",
                 "datasource_id": "yarn_lock_v1",
                 "purl": "pkg:npm/%40ballerina/api-designer@0.99.0-RC3"
               },
@@ -1258,7 +1258,7 @@
                 ],
                 "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/ast-model",
                 "repository_download_url": "https://registry.npmjs.org/@ballerina/ast-model/-/ast-model-0.99.0-RC3.tgz",
-                "api_data_url": "https://registry.npmjs.org/@ballerina%2fast-model",
+                "api_data_url": "https://registry.npmjs.org/@ballerina%2fast-model/0.99.0-RC3",
                 "datasource_id": "yarn_lock_v1",
                 "purl": "pkg:npm/%40ballerina/ast-model@0.99.0-RC3"
               },
@@ -1320,7 +1320,7 @@
                 ],
                 "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/ballerina-by-examples",
                 "repository_download_url": "https://registry.npmjs.org/@ballerina/ballerina-by-examples/-/ballerina-by-examples-0.99.0-RC3.tgz",
-                "api_data_url": "https://registry.npmjs.org/@ballerina%2fballerina-by-examples",
+                "api_data_url": "https://registry.npmjs.org/@ballerina%2fballerina-by-examples/0.99.0-RC3",
                 "datasource_id": "yarn_lock_v1",
                 "purl": "pkg:npm/%40ballerina/ballerina-by-examples@0.99.0-RC3"
               },
@@ -1442,7 +1442,7 @@
                 ],
                 "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/diagram",
                 "repository_download_url": "https://registry.npmjs.org/@ballerina/diagram/-/diagram-0.99.0-RC3.tgz",
-                "api_data_url": "https://registry.npmjs.org/@ballerina%2fdiagram",
+                "api_data_url": "https://registry.npmjs.org/@ballerina%2fdiagram/0.99.0-RC3",
                 "datasource_id": "yarn_lock_v1",
                 "purl": "pkg:npm/%40ballerina/diagram@0.99.0-RC3"
               },
@@ -1554,7 +1554,7 @@
                 ],
                 "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/distribution",
                 "repository_download_url": "https://registry.npmjs.org/@ballerina/distribution/-/distribution-0.99.0-RC3.tgz",
-                "api_data_url": "https://registry.npmjs.org/@ballerina%2fdistribution",
+                "api_data_url": "https://registry.npmjs.org/@ballerina%2fdistribution/0.99.0-RC3",
                 "datasource_id": "yarn_lock_v1",
                 "purl": "pkg:npm/%40ballerina/distribution@0.99.0-RC3"
               },
@@ -1646,7 +1646,7 @@
                 ],
                 "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/documentation",
                 "repository_download_url": "https://registry.npmjs.org/@ballerina/documentation/-/documentation-0.99.0-RC3.tgz",
-                "api_data_url": "https://registry.npmjs.org/@ballerina%2fdocumentation",
+                "api_data_url": "https://registry.npmjs.org/@ballerina%2fdocumentation/0.99.0-RC3",
                 "datasource_id": "yarn_lock_v1",
                 "purl": "pkg:npm/%40ballerina/documentation@0.99.0-RC3"
               },
@@ -1697,7 +1697,7 @@
                 "dependencies": [],
                 "repository_homepage_url": "https://www.npmjs.com/package/@ballerina/font",
                 "repository_download_url": "https://registry.npmjs.org/@ballerina/font/-/font-0.99.0-RC3.tgz",
-                "api_data_url": "https://registry.npmjs.org/@ballerina%2ffont",
+                "api_data_url": "https://registry.npmjs.org/@ballerina%2ffont/0.99.0-RC3",
                 "datasource_id": "yarn_lock_v1",
                 "purl": "pkg:npm/%40ballerina/font@0.99.0-RC3"
               },

--- a/tests/packagedcode/data/npm/scoped1/package.json.expected
+++ b/tests/packagedcode/data/npm/scoped1/package.json.expected
@@ -676,7 +676,7 @@
     ],
     "repository_homepage_url": "https://www.npmjs.com/package/@ionic/app-scripts",
     "repository_download_url": "https://registry.npmjs.org/@ionic/app-scripts/-/app-scripts-3.0.1-201710301651.tgz",
-    "api_data_url": "https://registry.npmjs.org/@ionic%2fapp-scripts",
+    "api_data_url": "https://registry.npmjs.org/@ionic%2fapp-scripts/3.0.1-201710301651",
     "datasource_id": "npm_package_json",
     "purl": "pkg:npm/%40ionic/app-scripts@3.0.1-201710301651"
   }

--- a/tests/packagedcode/data/npm/scoped2/package.json.expected
+++ b/tests/packagedcode/data/npm/scoped2/package.json.expected
@@ -186,7 +186,7 @@
     ],
     "repository_homepage_url": "https://www.npmjs.com/package/@invisionag/eslint-config-ivx",
     "repository_download_url": "https://registry.npmjs.org/@invisionag/eslint-config-ivx/-/eslint-config-ivx-0.0.2.tgz",
-    "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx",
+    "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx/0.0.2",
     "datasource_id": "npm_package_json",
     "purl": "pkg:npm/%40invisionag/eslint-config-ivx@0.0.2"
   }

--- a/tests/packagedcode/data/npm/yarn-lock/v1-complex/yarn.lock-expected
+++ b/tests/packagedcode/data/npm/yarn-lock/v1-complex/yarn.lock-expected
@@ -91,7 +91,7 @@
           ],
           "repository_homepage_url": "https://www.npmjs.com/package/@babel/code-frame",
           "repository_download_url": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "api_data_url": "https://registry.npmjs.org/@babel%2fcode-frame",
+          "api_data_url": "https://registry.npmjs.org/@babel%2fcode-frame/7.0.0",
           "datasource_id": "yarn_lock_v1",
           "purl": "pkg:npm/%40babel/code-frame@7.0.0"
         },
@@ -183,7 +183,7 @@
           ],
           "repository_homepage_url": "https://www.npmjs.com/package/@babel/core",
           "repository_download_url": "https://registry.npmjs.org/@babel/core/-/core-7.3.4.tgz",
-          "api_data_url": "https://registry.npmjs.org/@babel%2fcore",
+          "api_data_url": "https://registry.npmjs.org/@babel%2fcore/7.3.4",
           "datasource_id": "yarn_lock_v1",
           "purl": "pkg:npm/%40babel/core@7.3.4"
         },
@@ -245,7 +245,7 @@
           ],
           "repository_homepage_url": "https://www.npmjs.com/package/@babel/helper-annotate-as-pure",
           "repository_download_url": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-          "api_data_url": "https://registry.npmjs.org/@babel%2fhelper-annotate-as-pure",
+          "api_data_url": "https://registry.npmjs.org/@babel%2fhelper-annotate-as-pure/7.0.0",
           "datasource_id": "yarn_lock_v1",
           "purl": "pkg:npm/%40babel/helper-annotate-as-pure@7.0.0"
         },

--- a/tests/summarycode/data/score/basic-expected.json
+++ b/tests/summarycode/data/score/basic-expected.json
@@ -76,7 +76,7 @@
       "extra_data": {},
       "repository_homepage_url": "https://www.npmjs.com/package/@invisionag/eslint-config-ivx",
       "repository_download_url": "https://registry.npmjs.org/@invisionag/eslint-config-ivx/-/eslint-config-ivx-0.0.10.tgz",
-      "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx",
+      "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx/0.0.10",
       "package_uid": "pkg:npm/%40invisionag/eslint-config-ivx@0.0.10?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "basic/package.json"
@@ -684,7 +684,7 @@
           ],
           "repository_homepage_url": "https://www.npmjs.com/package/@invisionag/eslint-config-ivx",
           "repository_download_url": "https://registry.npmjs.org/@invisionag/eslint-config-ivx/-/eslint-config-ivx-0.0.10.tgz",
-          "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx",
+          "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx/0.0.10",
           "datasource_id": "npm_package_json",
           "purl": "pkg:npm/%40invisionag/eslint-config-ivx@0.0.10"
         }

--- a/tests/summarycode/data/score/inconsistent_licenses_copyleft-expected.json
+++ b/tests/summarycode/data/score/inconsistent_licenses_copyleft-expected.json
@@ -76,7 +76,7 @@
       "extra_data": {},
       "repository_homepage_url": "https://www.npmjs.com/package/@invisionag/eslint-config-ivx",
       "repository_download_url": "https://registry.npmjs.org/@invisionag/eslint-config-ivx/-/eslint-config-ivx-0.0.10.tgz",
-      "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx",
+      "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx/0.0.10",
       "package_uid": "pkg:npm/%40invisionag/eslint-config-ivx@0.0.10?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "inconsistent_licenses_copyleft/package.json"
@@ -689,7 +689,7 @@
           ],
           "repository_homepage_url": "https://www.npmjs.com/package/@invisionag/eslint-config-ivx",
           "repository_download_url": "https://registry.npmjs.org/@invisionag/eslint-config-ivx/-/eslint-config-ivx-0.0.10.tgz",
-          "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx",
+          "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx/0.0.10",
           "datasource_id": "npm_package_json",
           "purl": "pkg:npm/%40invisionag/eslint-config-ivx@0.0.10"
         }

--- a/tests/summarycode/data/score/no_license_or_copyright-expected.json
+++ b/tests/summarycode/data/score/no_license_or_copyright-expected.json
@@ -56,7 +56,7 @@
       "extra_data": {},
       "repository_homepage_url": "https://www.npmjs.com/package/@invisionag/eslint-config-ivx",
       "repository_download_url": "https://registry.npmjs.org/@invisionag/eslint-config-ivx/-/eslint-config-ivx-0.0.10.tgz",
-      "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx",
+      "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx/0.0.10",
       "package_uid": "pkg:npm/%40invisionag/eslint-config-ivx@0.0.10?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "no_license_or_copyright/package.json"
@@ -571,7 +571,7 @@
           ],
           "repository_homepage_url": "https://www.npmjs.com/package/@invisionag/eslint-config-ivx",
           "repository_download_url": "https://registry.npmjs.org/@invisionag/eslint-config-ivx/-/eslint-config-ivx-0.0.10.tgz",
-          "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx",
+          "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx/0.0.10",
           "datasource_id": "npm_package_json",
           "purl": "pkg:npm/%40invisionag/eslint-config-ivx@0.0.10"
         }

--- a/tests/summarycode/data/score/no_license_text-expected.json
+++ b/tests/summarycode/data/score/no_license_text-expected.json
@@ -76,7 +76,7 @@
       "extra_data": {},
       "repository_homepage_url": "https://www.npmjs.com/package/@invisionag/eslint-config-ivx",
       "repository_download_url": "https://registry.npmjs.org/@invisionag/eslint-config-ivx/-/eslint-config-ivx-0.0.10.tgz",
-      "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx",
+      "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx/0.0.10",
       "package_uid": "pkg:npm/%40invisionag/eslint-config-ivx@0.0.10?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "no_license_text/package.json"
@@ -629,7 +629,7 @@
           ],
           "repository_homepage_url": "https://www.npmjs.com/package/@invisionag/eslint-config-ivx",
           "repository_download_url": "https://registry.npmjs.org/@invisionag/eslint-config-ivx/-/eslint-config-ivx-0.0.10.tgz",
-          "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx",
+          "api_data_url": "https://registry.npmjs.org/@invisionag%2feslint-config-ivx/0.0.10",
           "datasource_id": "npm_package_json",
           "purl": "pkg:npm/%40invisionag/eslint-config-ivx@0.0.10"
         }

--- a/tests/summarycode/data/tallies/packages/expected.json
+++ b/tests/summarycode/data/tallies/packages/expected.json
@@ -211,7 +211,7 @@
       "extra_data": {},
       "repository_homepage_url": "https://www.npmjs.com/package/@ionic/app-scripts",
       "repository_download_url": "https://registry.npmjs.org/@ionic/app-scripts/-/app-scripts-3.0.1-201710301651.tgz",
-      "api_data_url": "https://registry.npmjs.org/@ionic%2fapp-scripts",
+      "api_data_url": "https://registry.npmjs.org/@ionic%2fapp-scripts/3.0.1-201710301651",
       "package_uid": "pkg:npm/%40ionic/app-scripts@3.0.1-201710301651?uuid=fixed-uid-done-for-testing-5642512d1758",
       "datafile_paths": [
         "scan/scoped1/package.json"
@@ -1971,7 +1971,7 @@
           ],
           "repository_homepage_url": "https://www.npmjs.com/package/@ionic/app-scripts",
           "repository_download_url": "https://registry.npmjs.org/@ionic/app-scripts/-/app-scripts-3.0.1-201710301651.tgz",
-          "api_data_url": "https://registry.npmjs.org/@ionic%2fapp-scripts",
+          "api_data_url": "https://registry.npmjs.org/@ionic%2fapp-scripts/3.0.1-201710301651",
           "datasource_id": "npm_package_json",
           "purl": "pkg:npm/%40ionic/app-scripts@3.0.1-201710301651"
         }


### PR DESCRIPTION
This PR updates `npm.npm_api_ur()` to allow us to properly create npm API URLs for namespaced packages with versions. Previously, if a namespace value was passed into `npm.npm_api_ur()`, the version value would automatically be set to an empty string.