### PR TITLE
Bump commoncode version to 31.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ chardet==5.0.0
 charset-normalizer==2.1.0
 click==8.1.3
 colorama==0.4.5
-commoncode==31.0.0
+commoncode==31.0.2
 construct==2.10.68
 container-inspector==31.1.0
 cryptography==37.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ install_requires =
     chardet >= 3.0.0
     click >= 6.7, !=7.0
     colorama >= 0.3.9
-    commoncode >= 31.0.0
+    commoncode >= 31.0.2
     container-inspector >= 31.0.0
     debian-inspector >= 31.0.0
     dparse2 >= 0.7.0


### PR DESCRIPTION
This PR updates setup.cfg and requirements.txt to pin `commoncode` dependency to version 31.0.2