### PR TITLE
Fix licenses data in summary plugin 

### DIFF
--- a/src/licensedcode/detection.py
+++ b/src/licensedcode/detection.py
@@ -810,6 +810,20 @@ class UniqueDetection:
         )
 
 
+def sort_unique_detections(license_detections):
+    """
+    Return a sorted list of UniqueDetection mappings from a unsorted list of the same.
+    These are sorted in alphabetical order of the license_expression (and same license
+    expressions are sorted by their detection_count in descending order, and then by their
+    UUID).
+    """
+
+    def by_expression_count(detection):
+        return detection["license_expression"], -detection["detection_count"], detection["identifier"]
+
+    return sorted(license_detections, key=by_expression_count)
+
+
 def get_detections_by_id(license_detections):
     """
     Get a dict(hashmap) where each item is: {detection.identifier: all_detections} where

--- a/src/licensedcode/plugin_license.py
+++ b/src/licensedcode/plugin_license.py
@@ -27,6 +27,7 @@ from licensedcode.detection import get_new_identifier_from_detections
 from licensedcode.detection import get_referenced_filenames
 from licensedcode.detection import DetectionCategory
 from licensedcode.detection import LicenseDetectionFromResult
+from licensedcode.detection import sort_unique_detections
 from licensedcode.detection import UniqueDetection
 from packagedcode.utils import combine_expressions
 from scancode.api import SCANCODE_LICENSEDB_URL
@@ -228,11 +229,13 @@ class LicenseScanner(ScanPlugin):
                 f'unique_license_detections: {unique_license_detections}',
             )
 
-        codebase.attributes.license_detections.extend([
+        unsorted_license_detections = [
             unique_detection.to_dict(license_diagnostics=license_diagnostics)
             for unique_detection in unique_license_detections
-        ])
-
+        ]
+        codebase.attributes.license_detections.extend(
+            sort_unique_detections(unsorted_license_detections)
+        )
 
 
 def add_referenced_filenames_license_matches_for_detections(resource, codebase):

--- a/tests/cluecode/data/copyrights/openoffice_org_report_builder_bin.copyright.yml
+++ b/tests/cluecode/data/copyrights/openoffice_org_report_builder_bin.copyright.yml
@@ -18,7 +18,7 @@ copyrights:
   - Copyright (c) 2002 France Telecom
   - Copyright (c) 1990-2003 Sleepycat Software
   - Copyright (c) 1990, 1993, 1994, 1995 The Regents of the University of California
-  - Copyright (c) 2003 by Bitstream, Inc. Cppyright
+  - Copyright (c) 2003 by Bitstream, Inc.
   - Copyright (c) 2006 by Tavmjong Bah
   - Copyright (c) 2007 Red Hat, Inc
   - Copyright (c) 2007 Red Hat, Inc.

--- a/tests/formattedcode/data/common/manifests-expected.json
+++ b/tests/formattedcode/data/common/manifests-expected.json
@@ -471,12 +471,22 @@
   ],
   "license_detections": [
     {
-      "identifier": "cddl_1_0-c6dbef4d-659c-289f-5ee9-1ca0278edad6",
-      "license_expression": "cddl-1.0",
+      "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
+      "license_expression": "apache-2.0",
+      "detection_count": 3
+    },
+    {
+      "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
+      "license_expression": "apache-2.0",
       "detection_count": 1
     },
     {
       "identifier": "cddl_1_0-9893b55c-3b2b-4ee8-a932-6c6c93a63fc5",
+      "license_expression": "cddl-1.0",
+      "detection_count": 1
+    },
+    {
+      "identifier": "cddl_1_0-c6dbef4d-659c-289f-5ee9-1ca0278edad6",
       "license_expression": "cddl-1.0",
       "detection_count": 1
     },
@@ -486,24 +496,9 @@
       "detection_count": 1
     },
     {
-      "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
-      "license_expression": "apache-2.0",
-      "detection_count": 1
-    },
-    {
-      "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
-      "license_expression": "apache-2.0",
-      "detection_count": 3
-    },
-    {
-      "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
-      "license_expression": "mit",
-      "detection_count": 1
-    },
-    {
-      "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
-      "license_expression": "mit",
-      "detection_count": 1
+      "identifier": "lgpl_3_0-272571eb-5e68-95b6-ddb0-71de2d8df321",
+      "license_expression": "lgpl-3.0",
+      "detection_count": 2
     },
     {
       "identifier": "lgpl_3_0-121be3c2-9c80-df84-d3da-8f674e4125c0",
@@ -516,13 +511,18 @@
       "detection_count": 1
     },
     {
-      "identifier": "lgpl_3_0-272571eb-5e68-95b6-ddb0-71de2d8df321",
-      "license_expression": "lgpl-3.0",
-      "detection_count": 2
-    },
-    {
       "identifier": "lgpl_3_0-38174920-e8ed-7bda-41ec-94df7380b7d5",
       "license_expression": "lgpl-3.0",
+      "detection_count": 1
+    },
+    {
+      "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
+      "license_expression": "mit",
+      "detection_count": 1
+    },
+    {
+      "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
+      "license_expression": "mit",
       "detection_count": 1
     }
   ],

--- a/tests/formattedcode/data/common/manifests-expected.jsonlines
+++ b/tests/formattedcode/data/common/manifests-expected.jsonlines
@@ -507,12 +507,22 @@
   {
     "license_detections": [
       {
-        "identifier": "cddl_1_0-c6dbef4d-659c-289f-5ee9-1ca0278edad6",
-        "license_expression": "cddl-1.0",
+        "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
+        "license_expression": "apache-2.0",
+        "detection_count": 3
+      },
+      {
+        "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
+        "license_expression": "apache-2.0",
         "detection_count": 1
       },
       {
         "identifier": "cddl_1_0-9893b55c-3b2b-4ee8-a932-6c6c93a63fc5",
+        "license_expression": "cddl-1.0",
+        "detection_count": 1
+      },
+      {
+        "identifier": "cddl_1_0-c6dbef4d-659c-289f-5ee9-1ca0278edad6",
         "license_expression": "cddl-1.0",
         "detection_count": 1
       },
@@ -522,24 +532,9 @@
         "detection_count": 1
       },
       {
-        "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
-        "license_expression": "apache-2.0",
-        "detection_count": 1
-      },
-      {
-        "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
-        "license_expression": "apache-2.0",
-        "detection_count": 3
-      },
-      {
-        "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
-        "license_expression": "mit",
-        "detection_count": 1
-      },
-      {
-        "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
-        "license_expression": "mit",
-        "detection_count": 1
+        "identifier": "lgpl_3_0-272571eb-5e68-95b6-ddb0-71de2d8df321",
+        "license_expression": "lgpl-3.0",
+        "detection_count": 2
       },
       {
         "identifier": "lgpl_3_0-121be3c2-9c80-df84-d3da-8f674e4125c0",
@@ -552,13 +547,18 @@
         "detection_count": 1
       },
       {
-        "identifier": "lgpl_3_0-272571eb-5e68-95b6-ddb0-71de2d8df321",
-        "license_expression": "lgpl-3.0",
-        "detection_count": 2
-      },
-      {
         "identifier": "lgpl_3_0-38174920-e8ed-7bda-41ec-94df7380b7d5",
         "license_expression": "lgpl-3.0",
+        "detection_count": 1
+      },
+      {
+        "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
+        "license_expression": "mit",
+        "detection_count": 1
+      },
+      {
+        "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
+        "license_expression": "mit",
         "detection_count": 1
       }
     ]

--- a/tests/formattedcode/data/common/manifests-expected.yaml
+++ b/tests/formattedcode/data/common/manifests-expected.yaml
@@ -47,13 +47,11 @@ summary:
   declared_holder:
   primary_language: Python
   other_license_expressions:
-    - value:
-      count: 1
-    - value: apache-2.0
-      count: 1
-    - value: cddl-1.0
-      count: 1
     - value: lgpl-3.0
+      count: 3
+    - value: apache-2.0
+      count: 2
+    - value: cddl-1.0
       count: 1
     - value: mit
       count: 1

--- a/tests/formattedcode/data/common/manifests-expected.yaml
+++ b/tests/formattedcode/data/common/manifests-expected.yaml
@@ -465,38 +465,38 @@ dependencies:
     datafile_path: manifests/npm-license-string/package.json
     datasource_id: npm_package_json
 license_detections:
-  - identifier: cddl_1_0-c6dbef4d-659c-289f-5ee9-1ca0278edad6
-    license_expression: cddl-1.0
+  - identifier: apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8
+    license_expression: apache-2.0
+    detection_count: 3
+  - identifier: apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0
+    license_expression: apache-2.0
     detection_count: 1
   - identifier: cddl_1_0-9893b55c-3b2b-4ee8-a932-6c6c93a63fc5
+    license_expression: cddl-1.0
+    detection_count: 1
+  - identifier: cddl_1_0-c6dbef4d-659c-289f-5ee9-1ca0278edad6
     license_expression: cddl-1.0
     detection_count: 1
   - identifier: cddl_1_0-ef82fc8c-50cb-6f35-1814-d2eb0bc13e83
     license_expression: cddl-1.0
     detection_count: 1
-  - identifier: apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0
-    license_expression: apache-2.0
-    detection_count: 1
-  - identifier: apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8
-    license_expression: apache-2.0
-    detection_count: 3
-  - identifier: mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee
-    license_expression: mit
-    detection_count: 1
-  - identifier: mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf
-    license_expression: mit
-    detection_count: 1
+  - identifier: lgpl_3_0-272571eb-5e68-95b6-ddb0-71de2d8df321
+    license_expression: lgpl-3.0
+    detection_count: 2
   - identifier: lgpl_3_0-121be3c2-9c80-df84-d3da-8f674e4125c0
     license_expression: lgpl-3.0
     detection_count: 1
   - identifier: lgpl_3_0-2db87bcf-56b4-9d7d-7075-2effae31c631
     license_expression: lgpl-3.0
     detection_count: 1
-  - identifier: lgpl_3_0-272571eb-5e68-95b6-ddb0-71de2d8df321
-    license_expression: lgpl-3.0
-    detection_count: 2
   - identifier: lgpl_3_0-38174920-e8ed-7bda-41ec-94df7380b7d5
     license_expression: lgpl-3.0
+    detection_count: 1
+  - identifier: mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee
+    license_expression: mit
+    detection_count: 1
+  - identifier: mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf
+    license_expression: mit
     detection_count: 1
 license_references:
   - key: apache-2.0

--- a/tests/formattedcode/data/yaml/package-and-licenses-expected.yaml
+++ b/tests/formattedcode/data/yaml/package-and-licenses-expected.yaml
@@ -47,8 +47,6 @@ summary:
   declared_holder: Example Corp.
   primary_language: Python
   other_license_expressions:
-    - value:
-      count: 1
     - value: apache-2.0 AND (apache-2.0 OR mit)
       count: 1
     - value: mit

--- a/tests/formattedcode/data/yaml/package-and-licenses-expected.yaml
+++ b/tests/formattedcode/data/yaml/package-and-licenses-expected.yaml
@@ -29,9 +29,9 @@ headers:
       system_environment:
         operating_system: linux
         cpu_architecture: 64
-        platform: Linux-5.14.0-1059-oem-x86_64-with-glibc2.29
-        platform_version: '#67-Ubuntu SMP Mon Mar 13 14:22:10 UTC 2023'
-        python_version: "3.8.10 (default, Mar 13 2023, 10:26:41) \n[GCC 9.4.0]"
+        platform: Linux-5.15.0-73-generic-x86_64-with-glibc2.29
+        platform_version: '#80~20.04.1-Ubuntu SMP Wed May 17 14:58:14 UTC 2023'
+        python_version: "3.8.10 (default, May 26 2023, 14:05:08) \n[GCC 9.4.0]"
       spdx_license_list_version: '3.20'
       files_count: 4
 summary:
@@ -121,18 +121,18 @@ packages:
     purl: pkg:pypi/codebase
 dependencies: []
 license_detections:
+  - identifier: apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0
+    license_expression: apache-2.0
+    detection_count: 2
   - identifier: apache_2_0-ab23f79b-ec38-9a8a-9b23-85059407f34d
     license_expression: apache-2.0
-    detection_count: 1
-  - identifier: mit-cacd5c0c-204a-85c2-affc-e4c125b2492a
-    license_expression: mit
     detection_count: 1
   - identifier: apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39
     license_expression: apache-2.0 AND (apache-2.0 OR mit)
     detection_count: 1
-  - identifier: apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0
-    license_expression: apache-2.0
-    detection_count: 2
+  - identifier: mit-cacd5c0c-204a-85c2-affc-e4c125b2492a
+    license_expression: mit
+    detection_count: 1
 license_references:
   - key: apache-2.0
     language: en

--- a/tests/licensedcode/data/licenses_reference_reporting/license-reference-works-with-clues.expected.json
+++ b/tests/licensedcode/data/licenses_reference_reporting/license-reference-works-with-clues.expected.json
@@ -1,38 +1,16 @@
 {
   "license_detections": [
     {
-      "identifier": "python-c496ccae-69a0-c5f8-a742-83bcd66bfe68",
-      "license_expression": "python",
+      "identifier": "bsd_new-35c287f1-5d41-52f8-399e-2391cd1b4b40",
+      "license_expression": "bsd-new",
       "detection_count": 1,
       "detection_log": []
     },
     {
-      "identifier": "other_copyleft_and_gpl_1_0_plus-2a634b9a-02ad-d5b9-47fc-e91c5eb24808",
-      "license_expression": "other-copyleft AND gpl-1.0-plus",
+      "identifier": "bsd_new-ccc98c3a-92d4-e7a3-e0ba-798328cb6b98",
+      "license_expression": "bsd-new",
       "detection_count": 1,
       "detection_log": []
-    },
-    {
-      "identifier": "python_and_python_cwi-dda7296c-6bc9-a87c-6fcd-8aa47c3484dc",
-      "license_expression": "python AND python-cwi",
-      "detection_count": 1,
-      "detection_log": []
-    },
-    {
-      "identifier": "bzip2_libbzip_2010-7158bcb2-a4d7-9815-17d2-1b1d0a6d5de2",
-      "license_expression": "bzip2-libbzip-2010",
-      "detection_count": 1,
-      "detection_log": [
-        "unknown-intro-followed-by-match"
-      ]
-    },
-    {
-      "identifier": "sleepycat-a7cd8833-ecc2-8ade-54d7-392befcce801",
-      "license_expression": "sleepycat",
-      "detection_count": 1,
-      "detection_log": [
-        "unknown-intro-followed-by-match"
-      ]
     },
     {
       "identifier": "bsd_simplified-7517fbd6-3fa4-e9f9-2167-c65251d77656",
@@ -44,20 +22,8 @@
       ]
     },
     {
-      "identifier": "bsd_new-ccc98c3a-92d4-e7a3-e0ba-798328cb6b98",
-      "license_expression": "bsd-new",
-      "detection_count": 1,
-      "detection_log": []
-    },
-    {
-      "identifier": "bsd_new-35c287f1-5d41-52f8-399e-2391cd1b4b40",
-      "license_expression": "bsd-new",
-      "detection_count": 1,
-      "detection_log": []
-    },
-    {
-      "identifier": "openssl_ssleay-238ad05e-bfde-df4c-6b5b-61ef3ec16843",
-      "license_expression": "openssl-ssleay",
+      "identifier": "bzip2_libbzip_2010-7158bcb2-a4d7-9815-17d2-1b1d0a6d5de2",
+      "license_expression": "bzip2-libbzip-2010",
       "detection_count": 1,
       "detection_log": [
         "unknown-intro-followed-by-match"
@@ -70,13 +36,47 @@
       "detection_log": []
     },
     {
+      "identifier": "openssl_ssleay-238ad05e-bfde-df4c-6b5b-61ef3ec16843",
+      "license_expression": "openssl-ssleay",
+      "detection_count": 1,
+      "detection_log": [
+        "unknown-intro-followed-by-match"
+      ]
+    },
+    {
+      "identifier": "other_copyleft_and_gpl_1_0_plus-2a634b9a-02ad-d5b9-47fc-e91c5eb24808",
+      "license_expression": "other-copyleft AND gpl-1.0-plus",
+      "detection_count": 1,
+      "detection_log": []
+    },
+    {
+      "identifier": "python-c496ccae-69a0-c5f8-a742-83bcd66bfe68",
+      "license_expression": "python",
+      "detection_count": 1,
+      "detection_log": []
+    },
+    {
+      "identifier": "python_and_python_cwi-dda7296c-6bc9-a87c-6fcd-8aa47c3484dc",
+      "license_expression": "python AND python-cwi",
+      "detection_count": 1,
+      "detection_log": []
+    },
+    {
+      "identifier": "sleepycat-a7cd8833-ecc2-8ade-54d7-392befcce801",
+      "license_expression": "sleepycat",
+      "detection_count": 1,
+      "detection_log": [
+        "unknown-intro-followed-by-match"
+      ]
+    },
+    {
       "identifier": "ssleay_windows-d3dabc12-d861-87db-b339-f73beba8703a",
       "license_expression": "ssleay-windows",
       "detection_count": 1,
       "detection_log": []
     },
     {
-      "identifier": "tcl-d865b2e8-435b-c54f-f19d-66d165a889ac",
+      "identifier": "tcl-75d8de8c-9cf0-d604-4b99-e03436ebfcd3",
       "license_expression": "tcl",
       "detection_count": 1,
       "detection_log": [
@@ -84,7 +84,7 @@
       ]
     },
     {
-      "identifier": "tcl-75d8de8c-9cf0-d604-4b99-e03436ebfcd3",
+      "identifier": "tcl-d865b2e8-435b-c54f-f19d-66d165a889ac",
       "license_expression": "tcl",
       "detection_count": 1,
       "detection_log": [

--- a/tests/licensedcode/data/plugin_license/license_reference/license-ref-see-copying.expected.json
+++ b/tests/licensedcode/data/plugin_license/license_reference/license-ref-see-copying.expected.json
@@ -1,18 +1,18 @@
 {
   "license_detections": [
     {
-      "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
-      "license_expression": "apache-2.0",
-      "detection_count": 1,
-      "detection_log": []
-    },
-    {
       "identifier": "apache-2.0-1c807a43-2040-70af-75aa-c343d5f2b90c",
       "license_expression": "apache-2.0",
       "detection_count": 1,
       "detection_log": [
         "unknown-reference-to-local-file"
       ]
+    },
+    {
+      "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
+      "license_expression": "apache-2.0",
+      "detection_count": 1,
+      "detection_log": []
     }
   ],
   "files": [

--- a/tests/licensedcode/data/plugin_license/license_reference/scan-ref.expected.json
+++ b/tests/licensedcode/data/plugin_license/license_reference/scan-ref.expected.json
@@ -1,18 +1,18 @@
 {
   "license_detections": [
     {
-      "identifier": "mit-6fc93e6a-0319-6943-7be7-2e20513a43e0",
-      "license_expression": "mit",
-      "detection_count": 1,
-      "detection_log": []
-    },
-    {
       "identifier": "mit-20c01557-97bd-0022-052e-56c5ed8465ea",
       "license_expression": "mit",
       "detection_count": 1,
       "detection_log": [
         "unknown-reference-to-local-file"
       ]
+    },
+    {
+      "identifier": "mit-6fc93e6a-0319-6943-7be7-2e20513a43e0",
+      "license_expression": "mit",
+      "detection_count": 1,
+      "detection_log": []
     }
   ],
   "files": [

--- a/tests/licensedcode/data/plugin_license/license_reference/scan-unknown-reference-copyright.expected.json
+++ b/tests/licensedcode/data/plugin_license/license_reference/scan-unknown-reference-copyright.expected.json
@@ -9,18 +9,18 @@
       ]
     },
     {
-      "identifier": "x11_xconsortium_veillard-b2601908-f03c-335c-5bbd-e72dc065c901",
-      "license_expression": "x11-xconsortium-veillard",
-      "detection_count": 1,
-      "detection_log": []
-    },
-    {
       "identifier": "x11-xconsortium-veillard-50c015bd-e4e1-c6fe-eb82-9551473dd8e1",
       "license_expression": "x11-xconsortium-veillard",
       "detection_count": 1,
       "detection_log": [
         "unknown-reference-to-local-file"
       ]
+    },
+    {
+      "identifier": "x11_xconsortium_veillard-b2601908-f03c-335c-5bbd-e72dc065c901",
+      "license_expression": "x11-xconsortium-veillard",
+      "detection_count": 1,
+      "detection_log": []
     }
   ],
   "files": [

--- a/tests/licensedcode/data/plugin_license/license_reference/unknown-ref-to-key-file-root.expected.json
+++ b/tests/licensedcode/data/plugin_license/license_reference/unknown-ref-to-key-file-root.expected.json
@@ -9,7 +9,7 @@
       ]
     },
     {
-      "identifier": "mit-d0a34f23-8c35-8874-a99f-6ed1e3b31f40",
+      "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
       "license_expression": "mit",
       "detection_count": 1,
       "detection_log": []
@@ -21,10 +21,12 @@
       "detection_log": []
     },
     {
-      "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
+      "identifier": "mit-ad99a349-2a14-9fe5-c6a6-366fd3b9067b",
       "license_expression": "mit",
       "detection_count": 1,
-      "detection_log": []
+      "detection_log": [
+        "unknown-reference-to-local-file"
+      ]
     },
     {
       "identifier": "mit-bdcba66f-6e80-f7bd-7994-748183fe5693",
@@ -33,12 +35,10 @@
       "detection_log": []
     },
     {
-      "identifier": "mit-ad99a349-2a14-9fe5-c6a6-366fd3b9067b",
+      "identifier": "mit-d0a34f23-8c35-8874-a99f-6ed1e3b31f40",
       "license_expression": "mit",
       "detection_count": 1,
-      "detection_log": [
-        "unknown-reference-to-local-file"
-      ]
+      "detection_log": []
     }
   ],
   "files": [

--- a/tests/licensedcode/data/plugin_license/package/package.expected.json
+++ b/tests/licensedcode/data/plugin_license/package/package.expected.json
@@ -112,12 +112,12 @@
   ],
   "license_detections": [
     {
-      "identifier": "mit-bdbee2a2-57b2-e502-e367-d613d7f6dda8",
+      "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
       "license_expression": "mit",
       "detection_count": 1
     },
     {
-      "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
+      "identifier": "mit-bdbee2a2-57b2-e502-e367-d613d7f6dda8",
       "license_expression": "mit",
       "detection_count": 1
     }

--- a/tests/licensedcode/data/plugin_license/scan/ffmpeg-license.expected.json
+++ b/tests/licensedcode/data/plugin_license/scan/ffmpeg-license.expected.json
@@ -1,8 +1,8 @@
 {
   "license_detections": [
     {
-      "identifier": "lgpl_2_1_plus_and_other_permissive_and_gpl_2_0_plus-666058ef-8c38-3b17-d8e7-448b304de833",
-      "license_expression": "lgpl-2.1-plus AND other-permissive AND gpl-2.0-plus",
+      "identifier": "gpl_1_0_plus-0211bbc4-784e-97fe-2ac1-f150ccba866e",
+      "license_expression": "gpl-1.0-plus",
       "detection_count": 1,
       "detection_log": []
     },
@@ -16,8 +16,14 @@
       ]
     },
     {
-      "identifier": "lgpl_3_0_and_lgpl_3_0_plus_and__lgpl_3_0_and_gpl_3_0-eb2232a5-2c4f-3fc9-a2ee-cdf40b20ae23",
-      "license_expression": "lgpl-3.0 AND lgpl-3.0-plus AND (lgpl-3.0 AND gpl-3.0)",
+      "identifier": "gpl_2_0_and_apache_2_0_and_lgpl_3_0_plus-c2393e5a-e531-304f-58a9-a6431d46d214",
+      "license_expression": "gpl-2.0 AND apache-2.0 AND lgpl-3.0-plus",
+      "detection_count": 1,
+      "detection_log": []
+    },
+    {
+      "identifier": "gpl_2_0_and_lgpl_2_0_plus_and_proprietary_license-45a8a75a-5b7e-5dbe-21f8-412756fac148",
+      "license_expression": "gpl-2.0 AND lgpl-2.0-plus AND proprietary-license",
       "detection_count": 1,
       "detection_log": []
     },
@@ -30,20 +36,14 @@
       ]
     },
     {
-      "identifier": "gpl_1_0_plus-0211bbc4-784e-97fe-2ac1-f150ccba866e",
-      "license_expression": "gpl-1.0-plus",
+      "identifier": "lgpl_2_1_plus_and_other_permissive_and_gpl_2_0_plus-666058ef-8c38-3b17-d8e7-448b304de833",
+      "license_expression": "lgpl-2.1-plus AND other-permissive AND gpl-2.0-plus",
       "detection_count": 1,
       "detection_log": []
     },
     {
-      "identifier": "gpl_2_0_and_apache_2_0_and_lgpl_3_0_plus-c2393e5a-e531-304f-58a9-a6431d46d214",
-      "license_expression": "gpl-2.0 AND apache-2.0 AND lgpl-3.0-plus",
-      "detection_count": 1,
-      "detection_log": []
-    },
-    {
-      "identifier": "gpl_2_0_and_lgpl_2_0_plus_and_proprietary_license-45a8a75a-5b7e-5dbe-21f8-412756fac148",
-      "license_expression": "gpl-2.0 AND lgpl-2.0-plus AND proprietary-license",
+      "identifier": "lgpl_3_0_and_lgpl_3_0_plus_and__lgpl_3_0_and_gpl_3_0-eb2232a5-2c4f-3fc9-a2ee-cdf40b20ae23",
+      "license_expression": "lgpl-3.0 AND lgpl-3.0-plus AND (lgpl-3.0 AND gpl-3.0)",
       "detection_count": 1,
       "detection_log": []
     }

--- a/tests/licensedcode/data/plugin_license/text/scan-diag.expected.json
+++ b/tests/licensedcode/data/plugin_license/text/scan-diag.expected.json
@@ -1,14 +1,14 @@
 {
   "license_detections": [
     {
-      "identifier": "gpl_2_0_with_linux_syscall_exception_gpl_or_linux_openib-c196bf1c-1c1f-18b4-554f-690be18bbad0",
-      "license_expression": "gpl-2.0 WITH linux-syscall-exception-gpl OR linux-openib",
+      "identifier": "fsf_ap-49ad9aab-c91b-eeb7-e90f-dc3f959b1c36",
+      "license_expression": "fsf-ap",
       "detection_count": 1,
       "detection_log": []
     },
     {
-      "identifier": "fsf_ap-49ad9aab-c91b-eeb7-e90f-dc3f959b1c36",
-      "license_expression": "fsf-ap",
+      "identifier": "gpl_2_0_with_linux_syscall_exception_gpl_or_linux_openib-c196bf1c-1c1f-18b4-554f-690be18bbad0",
+      "license_expression": "gpl-2.0 WITH linux-syscall-exception-gpl OR linux-openib",
       "detection_count": 1,
       "detection_log": []
     }

--- a/tests/licensedcode/data/plugin_license/text/scan.expected.json
+++ b/tests/licensedcode/data/plugin_license/text/scan.expected.json
@@ -1,14 +1,14 @@
 {
   "license_detections": [
     {
-      "identifier": "gpl_2_0_with_linux_syscall_exception_gpl_or_linux_openib-c196bf1c-1c1f-18b4-554f-690be18bbad0",
-      "license_expression": "gpl-2.0 WITH linux-syscall-exception-gpl OR linux-openib",
+      "identifier": "fsf_ap-49ad9aab-c91b-eeb7-e90f-dc3f959b1c36",
+      "license_expression": "fsf-ap",
       "detection_count": 1,
       "detection_log": []
     },
     {
-      "identifier": "fsf_ap-49ad9aab-c91b-eeb7-e90f-dc3f959b1c36",
-      "license_expression": "fsf-ap",
+      "identifier": "gpl_2_0_with_linux_syscall_exception_gpl_or_linux_openib-c196bf1c-1c1f-18b4-554f-690be18bbad0",
+      "license_expression": "gpl-2.0 WITH linux-syscall-exception-gpl OR linux-openib",
       "detection_count": 1,
       "detection_log": []
     }

--- a/tests/licensedcode/data/plugin_license/unknown_intro/scan-unknown-intro-eclipse-foundation-tycho.expected.json
+++ b/tests/licensedcode/data/plugin_license/unknown_intro/scan-unknown-intro-eclipse-foundation-tycho.expected.json
@@ -1,9 +1,9 @@
 {
   "license_detections": [
     {
-      "identifier": "epl_1_0-4850ab41-51b3-282e-61da-d1dd32d1eef2",
-      "license_expression": "epl-1.0",
-      "detection_count": 2,
+      "identifier": "apache_2_0-ec71f0b5-0d51-269d-4401-8cfe56a05bfe",
+      "license_expression": "apache-2.0",
+      "detection_count": 3,
       "detection_log": []
     },
     {
@@ -16,30 +16,6 @@
       "identifier": "apache_2_0-c6b06d3c-dbcf-4722-6e26-e6d782bf756a",
       "license_expression": "apache-2.0",
       "detection_count": 2,
-      "detection_log": []
-    },
-    {
-      "identifier": "apache_2_0-ec71f0b5-0d51-269d-4401-8cfe56a05bfe",
-      "license_expression": "apache-2.0",
-      "detection_count": 3,
-      "detection_log": []
-    },
-    {
-      "identifier": "epl_2_0-2d958c5c-8c7d-0aab-f347-248562781281",
-      "license_expression": "epl-2.0",
-      "detection_count": 1,
-      "detection_log": []
-    },
-    {
-      "identifier": "epl_1_0-24481246-c972-682f-28a6-1e4bb59b73c5",
-      "license_expression": "epl-1.0",
-      "detection_count": 2,
-      "detection_log": []
-    },
-    {
-      "identifier": "cpl_1_0-3d9a9925-4663-aa7d-fe9c-d421afd87296",
-      "license_expression": "cpl-1.0",
-      "detection_count": 1,
       "detection_log": []
     },
     {
@@ -57,6 +33,30 @@
     {
       "identifier": "cpl_1_0-08dc5398-457d-49be-a798-b57fe4d8de3e",
       "license_expression": "cpl-1.0",
+      "detection_count": 1,
+      "detection_log": []
+    },
+    {
+      "identifier": "cpl_1_0-3d9a9925-4663-aa7d-fe9c-d421afd87296",
+      "license_expression": "cpl-1.0",
+      "detection_count": 1,
+      "detection_log": []
+    },
+    {
+      "identifier": "epl_1_0-24481246-c972-682f-28a6-1e4bb59b73c5",
+      "license_expression": "epl-1.0",
+      "detection_count": 2,
+      "detection_log": []
+    },
+    {
+      "identifier": "epl_1_0-4850ab41-51b3-282e-61da-d1dd32d1eef2",
+      "license_expression": "epl-1.0",
+      "detection_count": 2,
+      "detection_log": []
+    },
+    {
+      "identifier": "epl_2_0-2d958c5c-8c7d-0aab-f347-248562781281",
+      "license_expression": "epl-2.0",
       "detection_count": 1,
       "detection_log": []
     }

--- a/tests/licensedcode/data/plugin_license/unknown_intro/scan-unknown-intro-long-gaps-between.expected.json
+++ b/tests/licensedcode/data/plugin_license/unknown_intro/scan-unknown-intro-long-gaps-between.expected.json
@@ -1,16 +1,16 @@
 {
   "license_detections": [
     {
-      "identifier": "x11_lucent-3c40145a-efd5-16ba-0a7a-9c28d9993bc2",
-      "license_expression": "x11-lucent",
+      "identifier": "bzip2_libbzip_2010-2234b9aa-1198-8ed2-f0d2-3310ced04b8a",
+      "license_expression": "bzip2-libbzip-2010",
       "detection_count": 1,
       "detection_log": [
         "unknown-intro-followed-by-match"
       ]
     },
     {
-      "identifier": "bzip2_libbzip_2010-2234b9aa-1198-8ed2-f0d2-3310ced04b8a",
-      "license_expression": "bzip2-libbzip-2010",
+      "identifier": "x11_lucent-3c40145a-efd5-16ba-0a7a-9c28d9993bc2",
+      "license_expression": "x11-lucent",
       "detection_count": 1,
       "detection_log": [
         "unknown-intro-followed-by-match"

--- a/tests/licensedcode/data/plugin_license_text/scan.expected.json
+++ b/tests/licensedcode/data/plugin_license_text/scan.expected.json
@@ -7,12 +7,6 @@
       "detection_log": []
     },
     {
-      "identifier": "ja_sig-025b96bc-0a83-9578-3e3f-0e0375a87457",
-      "license_expression": "ja-sig",
-      "detection_count": 2,
-      "detection_log": []
-    },
-    {
       "identifier": "apache_2_0-4bde3f57-78aa-4201-96bf-531cba09e7de",
       "license_expression": "apache-2.0",
       "detection_count": 2,
@@ -22,6 +16,12 @@
       "identifier": "gpl_2_0_with_linux_syscall_exception_gpl_or_linux_openib-c196bf1c-1c1f-18b4-554f-690be18bbad0",
       "license_expression": "gpl-2.0 WITH linux-syscall-exception-gpl OR linux-openib",
       "detection_count": 1,
+      "detection_log": []
+    },
+    {
+      "identifier": "ja_sig-025b96bc-0a83-9578-3e3f-0e0375a87457",
+      "license_expression": "ja-sig",
+      "detection_count": 2,
       "detection_log": []
     }
   ],

--- a/tests/packagedcode/data/cocoapods/assemble/many-podspecs-with-license-expected.json
+++ b/tests/packagedcode/data/cocoapods/assemble/many-podspecs-with-license-expected.json
@@ -561,9 +561,9 @@
   ],
   "license_detections": [
     {
-      "identifier": "apache_2_0-08479bef-4de5-8be8-0987-1bec0c232b20",
+      "identifier": "apache_2_0-428c1364-ecb5-f806-7a2e-77d10737a7ce",
       "license_expression": "apache-2.0",
-      "detection_count": 3
+      "detection_count": 6
     },
     {
       "identifier": "apache_2_0-d310abb3-4d20-b3be-830d-ee37b30a997f",
@@ -571,9 +571,9 @@
       "detection_count": 6
     },
     {
-      "identifier": "apache_2_0-428c1364-ecb5-f806-7a2e-77d10737a7ce",
+      "identifier": "apache_2_0-08479bef-4de5-8be8-0987-1bec0c232b20",
       "license_expression": "apache-2.0",
-      "detection_count": 6
+      "detection_count": 3
     }
   ],
   "files": [

--- a/tests/packagedcode/data/instance/python-package-instance-expected-with-test-manifests-with-license.json
+++ b/tests/packagedcode/data/instance/python-package-instance-expected-with-test-manifests-with-license.json
@@ -90,14 +90,14 @@
   "dependencies": [],
   "license_detections": [
     {
-      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
-      "license_expression": "mit",
-      "detection_count": 3
-    },
-    {
       "identifier": "mit-24a5293c-14d7-5403-efac-1a8b7532c0e8",
       "license_expression": "mit",
       "detection_count": 4
+    },
+    {
+      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
+      "license_expression": "mit",
+      "detection_count": 3
     },
     {
       "identifier": "mit-56f9dd7c-a466-cdf0-4fe0-6e57d31bc32a",

--- a/tests/packagedcode/data/instance/python-package-instance-with-license-expected.json
+++ b/tests/packagedcode/data/instance/python-package-instance-with-license-expected.json
@@ -150,13 +150,13 @@
   ],
   "license_detections": [
     {
-      "identifier": "bsd_new_and__bsd_new_and_bsd_simplified-6feee5ac-439e-c60c-2478-86ff52373283",
-      "license_expression": "bsd-new AND (bsd-new AND bsd-simplified)",
+      "identifier": "bsd_new-f4e99f86-00ab-18d9-a65d-a3a12767dcf5",
+      "license_expression": "bsd-new",
       "detection_count": 2
     },
     {
-      "identifier": "bsd_new-f4e99f86-00ab-18d9-a65d-a3a12767dcf5",
-      "license_expression": "bsd-new",
+      "identifier": "bsd_new_and__bsd_new_and_bsd_simplified-6feee5ac-439e-c60c-2478-86ff52373283",
+      "license_expression": "bsd-new AND (bsd-new AND bsd-simplified)",
       "detection_count": 2
     }
   ],

--- a/tests/packagedcode/data/license_detection/reference-at-manifest/fizzler.expected.json
+++ b/tests/packagedcode/data/license_detection/reference-at-manifest/fizzler.expected.json
@@ -142,12 +142,6 @@
   ],
   "license_detections": [
     {
-      "identifier": "lgpl_2_0_plus_and_gpl_1_0_plus-2a11c930-7038-736e-5e48-b35f872691cc",
-      "license_expression": "lgpl-2.0-plus AND gpl-1.0-plus",
-      "detection_count": 1,
-      "detection_log": []
-    },
-    {
       "identifier": "lgpl-2.0-plus AND gpl-1.0-plus-17115808-8fc8-9c98-b64d-c5013bcbde1b",
       "license_expression": "lgpl-2.0-plus AND gpl-1.0-plus",
       "detection_count": 1,
@@ -162,6 +156,12 @@
       "detection_log": [
         "package-unknown-reference-to-local-file"
       ]
+    },
+    {
+      "identifier": "lgpl_2_0_plus_and_gpl_1_0_plus-2a11c930-7038-736e-5e48-b35f872691cc",
+      "license_expression": "lgpl-2.0-plus AND gpl-1.0-plus",
+      "detection_count": 1,
+      "detection_log": []
     }
   ],
   "files": [

--- a/tests/packagedcode/data/license_detection/reference-at-manifest/nanopb.expected.json
+++ b/tests/packagedcode/data/license_detection/reference-at-manifest/nanopb.expected.json
@@ -94,18 +94,18 @@
   "dependencies": [],
   "license_detections": [
     {
-      "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
-      "license_expression": "zlib",
-      "detection_count": 1,
-      "detection_log": []
-    },
-    {
       "identifier": "zlib-9531c668-be8d-7a25-49eb-c18c9dcd616b",
       "license_expression": "zlib",
       "detection_count": 2,
       "detection_log": [
         "unknown-reference-to-local-file"
       ]
+    },
+    {
+      "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
+      "license_expression": "zlib",
+      "detection_count": 1,
+      "detection_log": []
     }
   ],
   "files": [

--- a/tests/packagedcode/data/license_detection/reference-to-package/base.expected.json
+++ b/tests/packagedcode/data/license_detection/reference-to-package/base.expected.json
@@ -92,18 +92,18 @@
   "dependencies": [],
   "license_detections": [
     {
+      "identifier": "bsd_new-f4e99f86-00ab-18d9-a65d-a3a12767dcf5",
+      "license_expression": "bsd-new",
+      "detection_count": 2,
+      "detection_log": []
+    },
+    {
       "identifier": "bsd-new-af493d9f-0c66-d9f8-4538-579134812514",
       "license_expression": "bsd-new",
       "detection_count": 1,
       "detection_log": [
         "unknown-reference-in-file-to-package"
       ]
-    },
-    {
-      "identifier": "bsd_new-f4e99f86-00ab-18d9-a65d-a3a12767dcf5",
-      "license_expression": "bsd-new",
-      "detection_count": 2,
-      "detection_log": []
     }
   ],
   "files": [

--- a/tests/packagedcode/data/license_detection/reference-to-package/fusiondirectory.expected.json
+++ b/tests/packagedcode/data/license_detection/reference-to-package/fusiondirectory.expected.json
@@ -4756,43 +4756,46 @@
   "dependencies": [],
   "license_detections": [
     {
-      "identifier": "gpl_2_0_plus-53a26be2-1f88-01ec-d294-921768a513c9",
-      "license_expression": "gpl-2.0-plus",
-      "detection_count": 42,
-      "detection_log": []
-    },
-    {
-      "identifier": "gpl_2_0_plus_and_free_unknown-7df72521-0609-4896-2583-44c45dd3f8e6",
-      "license_expression": "gpl-2.0-plus AND free-unknown",
-      "detection_count": 2,
-      "detection_log": []
-    },
-    {
       "identifier": "bsd_new-008266ae-6939-ad31-3617-228b0809863c",
       "license_expression": "bsd-new",
       "detection_count": 2,
       "detection_log": []
     },
     {
-      "identifier": "gpl_2_0_plus_and_free_unknown-f9cd0597-d35d-ec72-0e6b-77970ad90317",
-      "license_expression": "gpl-2.0-plus AND free-unknown",
+      "identifier": "bsd_original-9198bafe-47c0-f9dc-5ef1-bd276a69786e",
+      "license_expression": "bsd-original",
       "detection_count": 2,
       "detection_log": []
     },
     {
-      "identifier": "lgpl_3_0_plus-4c8d95b2-1acf-7a81-473c-d8e70962288c",
-      "license_expression": "lgpl-3.0-plus",
+      "identifier": "bsd_simplified-2383ae10-5494-e069-46c2-e2d6cb56951f",
+      "license_expression": "bsd-simplified",
       "detection_count": 2,
       "detection_log": []
     },
     {
-      "identifier": "public_domain-1a6a4f2c-bd92-9942-920f-be3d0c2bbda6",
-      "license_expression": "public-domain",
-      "detection_count": 2,
-      "detection_log": [
-        "possible-false-positive",
-        "not-license-clues-as-more-detections-present"
-      ]
+      "identifier": "free_unknown-34d6195a-6206-be2e-4bd2-ce3b9493a1ad",
+      "license_expression": "free-unknown",
+      "detection_count": 1,
+      "detection_log": []
+    },
+    {
+      "identifier": "free_unknown-fddf748a-9953-bc6c-cb9d-91001840e335",
+      "license_expression": "free-unknown",
+      "detection_count": 1,
+      "detection_log": []
+    },
+    {
+      "identifier": "gpl_2_0_plus-227f50b1-f05e-5b3b-b107-ae1e2f56448b",
+      "license_expression": "gpl-2.0-plus",
+      "detection_count": 44,
+      "detection_log": []
+    },
+    {
+      "identifier": "gpl_2_0_plus-53a26be2-1f88-01ec-d294-921768a513c9",
+      "license_expression": "gpl-2.0-plus",
+      "detection_count": 42,
+      "detection_log": []
     },
     {
       "identifier": "gpl_2_0_plus-fed2dc38-09ac-103e-1b86-4a4f5c00614a",
@@ -4804,17 +4807,14 @@
       ]
     },
     {
-      "identifier": "mit-1f9f2ae8-7020-0a13-7934-461c752929a4",
-      "license_expression": "mit",
-      "detection_count": 6,
-      "detection_log": [
-        "possible-false-positive",
-        "not-license-clues-as-more-detections-present"
-      ]
+      "identifier": "gpl_2_0_plus_and_free_unknown-7df72521-0609-4896-2583-44c45dd3f8e6",
+      "license_expression": "gpl-2.0-plus AND free-unknown",
+      "detection_count": 2,
+      "detection_log": []
     },
     {
-      "identifier": "bsd_original-9198bafe-47c0-f9dc-5ef1-bd276a69786e",
-      "license_expression": "bsd-original",
+      "identifier": "gpl_2_0_plus_and_free_unknown-f9cd0597-d35d-ec72-0e6b-77970ad90317",
+      "license_expression": "gpl-2.0-plus AND free-unknown",
       "detection_count": 2,
       "detection_log": []
     },
@@ -4825,21 +4825,24 @@
       "detection_log": []
     },
     {
-      "identifier": "gpl_2_0_plus-227f50b1-f05e-5b3b-b107-ae1e2f56448b",
-      "license_expression": "gpl-2.0-plus",
-      "detection_count": 44,
-      "detection_log": []
-    },
-    {
-      "identifier": "bsd_simplified-2383ae10-5494-e069-46c2-e2d6cb56951f",
-      "license_expression": "bsd-simplified",
-      "detection_count": 2,
-      "detection_log": []
-    },
-    {
       "identifier": "lgpl_3_0-6b4a45da-85cc-8eb0-5613-be81d4efd6a5",
       "license_expression": "lgpl-3.0",
       "detection_count": 2,
+      "detection_log": [
+        "possible-false-positive",
+        "not-license-clues-as-more-detections-present"
+      ]
+    },
+    {
+      "identifier": "lgpl_3_0_plus-4c8d95b2-1acf-7a81-473c-d8e70962288c",
+      "license_expression": "lgpl-3.0-plus",
+      "detection_count": 2,
+      "detection_log": []
+    },
+    {
+      "identifier": "mit-1f9f2ae8-7020-0a13-7934-461c752929a4",
+      "license_expression": "mit",
+      "detection_count": 6,
       "detection_log": [
         "possible-false-positive",
         "not-license-clues-as-more-detections-present"
@@ -4855,8 +4858,8 @@
       ]
     },
     {
-      "identifier": "public_domain_and_bsd_original_and_gpl_1_0_plus-ccb73883-974d-42eb-d572-39fa7bf22f4c",
-      "license_expression": "public-domain AND bsd-original AND gpl-1.0-plus",
+      "identifier": "public_domain-1a6a4f2c-bd92-9942-920f-be3d0c2bbda6",
+      "license_expression": "public-domain",
       "detection_count": 2,
       "detection_log": [
         "possible-false-positive",
@@ -4864,16 +4867,13 @@
       ]
     },
     {
-      "identifier": "free_unknown-fddf748a-9953-bc6c-cb9d-91001840e335",
-      "license_expression": "free-unknown",
-      "detection_count": 1,
-      "detection_log": []
-    },
-    {
-      "identifier": "free_unknown-34d6195a-6206-be2e-4bd2-ce3b9493a1ad",
-      "license_expression": "free-unknown",
-      "detection_count": 1,
-      "detection_log": []
+      "identifier": "public_domain_and_bsd_original_and_gpl_1_0_plus-ccb73883-974d-42eb-d572-39fa7bf22f4c",
+      "license_expression": "public-domain AND bsd-original AND gpl-1.0-plus",
+      "detection_count": 2,
+      "detection_log": [
+        "possible-false-positive",
+        "not-license-clues-as-more-detections-present"
+      ]
     }
   ],
   "files": [

--- a/tests/packagedcode/data/license_detection/reference-to-package/paddlenlp.expected.json
+++ b/tests/packagedcode/data/license_detection/reference-to-package/paddlenlp.expected.json
@@ -384,6 +384,28 @@
   ],
   "license_detections": [
     {
+      "identifier": "apache-2.0-35de6d3f-8962-0454-2270-33aac504c123",
+      "license_expression": "apache-2.0",
+      "detection_count": 2,
+      "detection_log": [
+        "unknown-reference-in-file-to-package"
+      ]
+    },
+    {
+      "identifier": "apache-2.0-abb5bcc3-dac9-a935-3392-31a86beb482a",
+      "license_expression": "apache-2.0",
+      "detection_count": 2,
+      "detection_log": [
+        "unknown-reference-to-local-file"
+      ]
+    },
+    {
+      "identifier": "apache_2_0-999670be-3d5e-ebf8-ae18-b555c26c5e80",
+      "license_expression": "apache-2.0",
+      "detection_count": 2,
+      "detection_log": []
+    },
+    {
       "identifier": "apache_2_0-c4e30bcd-ccfd-bbc3-d2f1-196ab911e47d",
       "license_expression": "apache-2.0",
       "detection_count": 2,
@@ -396,27 +418,13 @@
       "detection_log": []
     },
     {
-      "identifier": "apache_2_0-999670be-3d5e-ebf8-ae18-b555c26c5e80",
-      "license_expression": "apache-2.0",
-      "detection_count": 2,
-      "detection_log": []
-    },
-    {
-      "identifier": "apache-2.0-abb5bcc3-dac9-a935-3392-31a86beb482a",
-      "license_expression": "apache-2.0",
-      "detection_count": 2,
-      "detection_log": [
-        "unknown-reference-to-local-file"
-      ]
-    },
-    {
-      "identifier": "apache_2_0-da72644e-69e0-e2c0-89c5-5d42277b3f3b",
+      "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
       "license_expression": "apache-2.0",
       "detection_count": 1,
       "detection_log": []
     },
     {
-      "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
+      "identifier": "apache_2_0-da72644e-69e0-e2c0-89c5-5d42277b3f3b",
       "license_expression": "apache-2.0",
       "detection_count": 1,
       "detection_log": []
@@ -426,14 +434,6 @@
       "license_expression": "apache-2.0",
       "detection_count": 1,
       "detection_log": []
-    },
-    {
-      "identifier": "apache-2.0-35de6d3f-8962-0454-2270-33aac504c123",
-      "license_expression": "apache-2.0",
-      "detection_count": 2,
-      "detection_log": [
-        "unknown-reference-in-file-to-package"
-      ]
     }
   ],
   "files": [

--- a/tests/packagedcode/data/license_detection/reference-to-package/physics.expected.json
+++ b/tests/packagedcode/data/license_detection/reference-to-package/physics.expected.json
@@ -9,16 +9,12 @@
       "detection_log": []
     },
     {
-      "identifier": "gpl_3_0_plus-494d0068-7138-a14f-4cbb-fd2137263a4f",
-      "license_expression": "gpl-3.0-plus",
+      "identifier": "gpl-3.0-76e8f741-ece2-d587-493c-92b0b1e4bdfe",
+      "license_expression": "gpl-3.0",
       "detection_count": 1,
-      "detection_log": []
-    },
-    {
-      "identifier": "gpl_3_0_and_unknown_license_reference_and_gpl_3_0_plus-ebd5f076-5cba-e641-e071-0028c4ee0ddb",
-      "license_expression": "gpl-3.0 AND unknown-license-reference AND gpl-3.0-plus",
-      "detection_count": 1,
-      "detection_log": []
+      "detection_log": [
+        "unknown-reference-in-file-to-nonexistent-package"
+      ]
     },
     {
       "identifier": "gpl-3.0-e907b820-6f8c-81c4-38c5-75006ae093a4",
@@ -29,12 +25,16 @@
       ]
     },
     {
-      "identifier": "gpl-3.0-76e8f741-ece2-d587-493c-92b0b1e4bdfe",
-      "license_expression": "gpl-3.0",
+      "identifier": "gpl_3_0_and_unknown_license_reference_and_gpl_3_0_plus-ebd5f076-5cba-e641-e071-0028c4ee0ddb",
+      "license_expression": "gpl-3.0 AND unknown-license-reference AND gpl-3.0-plus",
       "detection_count": 1,
-      "detection_log": [
-        "unknown-reference-in-file-to-nonexistent-package"
-      ]
+      "detection_log": []
+    },
+    {
+      "identifier": "gpl_3_0_plus-494d0068-7138-a14f-4cbb-fd2137263a4f",
+      "license_expression": "gpl-3.0-plus",
+      "detection_count": 1,
+      "detection_log": []
     }
   ],
   "files": [

--- a/tests/packagedcode/data/license_detection/reference-to-package/samba.expected.json
+++ b/tests/packagedcode/data/license_detection/reference-to-package/samba.expected.json
@@ -326,6 +326,40 @@
   "dependencies": [],
   "license_detections": [
     {
+      "identifier": "cc_by_sa_3_0_and_cc_by_sa_4_0_and_dco_1_1-4fb8e409-441a-1243-5a0d-d6af2acc0c62",
+      "license_expression": "cc-by-sa-3.0 AND cc-by-sa-4.0 AND dco-1.1",
+      "detection_count": 3,
+      "detection_log": []
+    },
+    {
+      "identifier": "gpl_1_0_plus_and_lgpl_3_0_plus_and_gpl_3_0_and_lgpl_3_0-3bd18dcd-0a4c-d46f-f42e-3d2919be9be0",
+      "license_expression": "gpl-1.0-plus AND lgpl-3.0-plus AND gpl-3.0 AND lgpl-3.0",
+      "detection_count": 3,
+      "detection_log": []
+    },
+    {
+      "identifier": "gpl_2_0-29c387aa-50e0-0530-7b0b-aa32e3c372d6",
+      "license_expression": "gpl-2.0",
+      "detection_count": 3,
+      "detection_log": []
+    },
+    {
+      "identifier": "gpl_2_0_plus_and_free_unknown_and_gpl_1_0_plus-4f5c7c7f-d0ee-f1dc-ad8b-236131aab65b",
+      "license_expression": "gpl-2.0-plus AND free-unknown AND gpl-1.0-plus",
+      "detection_count": 3,
+      "detection_log": [
+        "unknown-match"
+      ]
+    },
+    {
+      "identifier": "gpl-3.0-db305a6e-7013-4ffa-0ad4-09f113582e67",
+      "license_expression": "gpl-3.0",
+      "detection_count": 3,
+      "detection_log": [
+        "unknown-reference-to-local-file"
+      ]
+    },
+    {
       "identifier": "gpl_3_0-ab79e5a8-e510-cbf4-5302-ef968484bcdf",
       "license_expression": "gpl-3.0",
       "detection_count": 3,
@@ -338,40 +372,6 @@
       "detection_log": [
         "possible-false-positive",
         "not-license-clues-as-more-detections-present"
-      ]
-    },
-    {
-      "identifier": "gpl_2_0_plus_and_free_unknown_and_gpl_1_0_plus-4f5c7c7f-d0ee-f1dc-ad8b-236131aab65b",
-      "license_expression": "gpl-2.0-plus AND free-unknown AND gpl-1.0-plus",
-      "detection_count": 3,
-      "detection_log": [
-        "unknown-match"
-      ]
-    },
-    {
-      "identifier": "gpl_1_0_plus_and_lgpl_3_0_plus_and_gpl_3_0_and_lgpl_3_0-3bd18dcd-0a4c-d46f-f42e-3d2919be9be0",
-      "license_expression": "gpl-1.0-plus AND lgpl-3.0-plus AND gpl-3.0 AND lgpl-3.0",
-      "detection_count": 3,
-      "detection_log": []
-    },
-    {
-      "identifier": "cc_by_sa_3_0_and_cc_by_sa_4_0_and_dco_1_1-4fb8e409-441a-1243-5a0d-d6af2acc0c62",
-      "license_expression": "cc-by-sa-3.0 AND cc-by-sa-4.0 AND dco-1.1",
-      "detection_count": 3,
-      "detection_log": []
-    },
-    {
-      "identifier": "gpl_2_0-29c387aa-50e0-0530-7b0b-aa32e3c372d6",
-      "license_expression": "gpl-2.0",
-      "detection_count": 3,
-      "detection_log": []
-    },
-    {
-      "identifier": "gpl-3.0-db305a6e-7013-4ffa-0ad4-09f113582e67",
-      "license_expression": "gpl-3.0",
-      "detection_count": 3,
-      "detection_log": [
-        "unknown-reference-to-local-file"
       ]
     },
     {

--- a/tests/packagedcode/data/maven_misc/uberjars/htrace-core-4.0.0-incubating-expected.json
+++ b/tests/packagedcode/data/maven_misc/uberjars/htrace-core-4.0.0-incubating-expected.json
@@ -479,7 +479,12 @@
   ],
   "license_detections": [
     {
-      "identifier": "apache_2_0-e7633baf-a264-a1ab-40f6-a28ec157067a",
+      "identifier": "apache_2_0-4bde3f57-78aa-4201-96bf-531cba09e7de",
+      "license_expression": "apache-2.0",
+      "detection_count": 4
+    },
+    {
+      "identifier": "apache_2_0-482220ca-c07b-bf59-66ed-6e7eaf9f3b1e",
       "license_expression": "apache-2.0",
       "detection_count": 1
     },
@@ -489,14 +494,9 @@
       "detection_count": 1
     },
     {
-      "identifier": "apache_2_0-482220ca-c07b-bf59-66ed-6e7eaf9f3b1e",
+      "identifier": "apache_2_0-e7633baf-a264-a1ab-40f6-a28ec157067a",
       "license_expression": "apache-2.0",
       "detection_count": 1
-    },
-    {
-      "identifier": "apache_2_0-4bde3f57-78aa-4201-96bf-531cba09e7de",
-      "license_expression": "apache-2.0",
-      "detection_count": 4
     }
   ],
   "files": [

--- a/tests/packagedcode/data/pypi/source-package/pip-22.0.4-pypi-package-with-license-expected.json
+++ b/tests/packagedcode/data/pypi/source-package/pip-22.0.4-pypi-package-with-license-expected.json
@@ -113,24 +113,9 @@
   "dependencies": [],
   "license_detections": [
     {
-      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
-      "license_expression": "mit",
-      "detection_count": 2
-    },
-    {
-      "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
-      "license_expression": "mit",
-      "detection_count": 2
-    },
-    {
       "identifier": "mit-24a5293c-14d7-5403-efac-1a8b7532c0e8",
       "license_expression": "mit",
       "detection_count": 5
-    },
-    {
-      "identifier": "mit-59433771-4926-870e-d21a-8162cfa060a3",
-      "license_expression": "mit",
-      "detection_count": 2
     },
     {
       "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
@@ -138,7 +123,22 @@
       "detection_count": 3
     },
     {
+      "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
+      "license_expression": "mit",
+      "detection_count": 2
+    },
+    {
+      "identifier": "mit-59433771-4926-870e-d21a-8162cfa060a3",
+      "license_expression": "mit",
+      "detection_count": 2
+    },
+    {
       "identifier": "mit-707ccf7a-5c60-0e4c-5844-349c989a00f5",
+      "license_expression": "mit",
+      "detection_count": 2
+    },
+    {
+      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
       "license_expression": "mit",
       "detection_count": 2
     },

--- a/tests/scancode/data/info/all.expected.json
+++ b/tests/scancode/data/info/all.expected.json
@@ -1,13 +1,13 @@
 {
   "license_detections": [
     {
-      "identifier": "gpl_2_0_or_bsd_new-1aafbf52-fc7a-3ded-e4ce-3a96e276a0f9",
-      "license_expression": "gpl-2.0 OR bsd-new",
+      "identifier": "bsd_original_uc-f28cb4d4-6336-ee60-f186-4c1929d3a4b0",
+      "license_expression": "bsd-original-uc",
       "detection_count": 1
     },
     {
-      "identifier": "bsd_original_uc-f28cb4d4-6336-ee60-f186-4c1929d3a4b0",
-      "license_expression": "bsd-original-uc",
+      "identifier": "gpl_2_0_or_bsd_new-1aafbf52-fc7a-3ded-e4ce-3a96e276a0f9",
+      "license_expression": "gpl-2.0 OR bsd-new",
       "detection_count": 1
     }
   ],

--- a/tests/scancode/data/info/all.rooted.expected.json
+++ b/tests/scancode/data/info/all.rooted.expected.json
@@ -1,13 +1,13 @@
 {
   "license_detections": [
     {
-      "identifier": "gpl_2_0_or_bsd_new-1aafbf52-fc7a-3ded-e4ce-3a96e276a0f9",
-      "license_expression": "gpl-2.0 OR bsd-new",
+      "identifier": "bsd_original_uc-f28cb4d4-6336-ee60-f186-4c1929d3a4b0",
+      "license_expression": "bsd-original-uc",
       "detection_count": 1
     },
     {
-      "identifier": "bsd_original_uc-f28cb4d4-6336-ee60-f186-4c1929d3a4b0",
-      "license_expression": "bsd-original-uc",
+      "identifier": "gpl_2_0_or_bsd_new-1aafbf52-fc7a-3ded-e4ce-3a96e276a0f9",
+      "license_expression": "gpl-2.0 OR bsd-new",
       "detection_count": 1
     }
   ],

--- a/tests/scancode/data/plugin_only_findings/basic.expected.json
+++ b/tests/scancode/data/plugin_only_findings/basic.expected.json
@@ -3,13 +3,13 @@
   "dependencies": [],
   "license_detections": [
     {
-      "identifier": "gpl_2_0_or_bsd_new-1aafbf52-fc7a-3ded-e4ce-3a96e276a0f9",
-      "license_expression": "gpl-2.0 OR bsd-new",
+      "identifier": "bsd_original_uc-f28cb4d4-6336-ee60-f186-4c1929d3a4b0",
+      "license_expression": "bsd-original-uc",
       "detection_count": 1
     },
     {
-      "identifier": "bsd_original_uc-f28cb4d4-6336-ee60-f186-4c1929d3a4b0",
-      "license_expression": "bsd-original-uc",
+      "identifier": "gpl_2_0_or_bsd_new-1aafbf52-fc7a-3ded-e4ce-3a96e276a0f9",
+      "license_expression": "gpl-2.0 OR bsd-new",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/plugin_consolidate/component-package-build-expected.json
+++ b/tests/summarycode/data/plugin_consolidate/component-package-build-expected.json
@@ -121,11 +121,6 @@
       "detection_count": 5
     },
     {
-      "identifier": "lgpl_2_0-3903e697-0f73-0feb-d95d-198a91825d0f",
-      "license_expression": "lgpl-2.0",
-      "detection_count": 1
-    },
-    {
       "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
       "license_expression": "apache-2.0",
       "detection_count": 1
@@ -133,6 +128,11 @@
     {
       "identifier": "gpl_2_0-864c0c2e-be17-d035-c591-df0235f46a09",
       "license_expression": "gpl-2.0",
+      "detection_count": 1
+    },
+    {
+      "identifier": "lgpl_2_0-3903e697-0f73-0feb-d95d-198a91825d0f",
+      "license_expression": "lgpl-2.0",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/plugin_consolidate/component-package-expected.json
+++ b/tests/summarycode/data/plugin_consolidate/component-package-expected.json
@@ -75,11 +75,6 @@
       "detection_count": 5
     },
     {
-      "identifier": "lgpl_2_0-3903e697-0f73-0feb-d95d-198a91825d0f",
-      "license_expression": "lgpl-2.0",
-      "detection_count": 1
-    },
-    {
       "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
       "license_expression": "apache-2.0",
       "detection_count": 1
@@ -87,6 +82,11 @@
     {
       "identifier": "gpl_2_0-864c0c2e-be17-d035-c591-df0235f46a09",
       "license_expression": "gpl-2.0",
+      "detection_count": 1
+    },
+    {
+      "identifier": "lgpl_2_0-3903e697-0f73-0feb-d95d-198a91825d0f",
+      "license_expression": "lgpl-2.0",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/plugin_consolidate/license-holder-rollup-expected.json
+++ b/tests/summarycode/data/plugin_consolidate/license-holder-rollup-expected.json
@@ -3,14 +3,14 @@
   "dependencies": [],
   "license_detections": [
     {
-      "identifier": "gpl_1_0_plus_and_gpl_2_0-1e023d4a-9b9a-a032-f999-6d506ad4bcde",
-      "license_expression": "gpl-1.0-plus AND gpl-2.0",
-      "detection_count": 2
-    },
-    {
       "identifier": "apache_2_0-b955b3e8-dd31-4357-9227-7a93de3b06a1",
       "license_expression": "apache-2.0",
       "detection_count": 1
+    },
+    {
+      "identifier": "gpl_1_0_plus_and_gpl_2_0-1e023d4a-9b9a-a032-f999-6d506ad4bcde",
+      "license_expression": "gpl-1.0-plus AND gpl-2.0",
+      "detection_count": 2
     }
   ],
   "consolidated_components": [

--- a/tests/summarycode/data/plugin_consolidate/package-fileset-expected.json
+++ b/tests/summarycode/data/plugin_consolidate/package-fileset-expected.json
@@ -70,14 +70,14 @@
   "dependencies": [],
   "license_detections": [
     {
-      "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
-      "license_expression": "apache-2.0",
-      "detection_count": 1
-    },
-    {
       "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
       "license_expression": "apache-2.0",
       "detection_count": 4
+    },
+    {
+      "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
+      "license_expression": "apache-2.0",
+      "detection_count": 1
     }
   ],
   "consolidated_components": [

--- a/tests/summarycode/data/plugin_consolidate/package-manifest-expected.json
+++ b/tests/summarycode/data/plugin_consolidate/package-manifest-expected.json
@@ -70,12 +70,12 @@
   "dependencies": [],
   "license_detections": [
     {
-      "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
+      "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
       "license_expression": "apache-2.0",
       "detection_count": 1
     },
     {
-      "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
+      "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
       "license_expression": "apache-2.0",
       "detection_count": 1
     }

--- a/tests/summarycode/data/score/inconsistent_licenses_copyleft-expected.json
+++ b/tests/summarycode/data/score/inconsistent_licenses_copyleft-expected.json
@@ -273,6 +273,11 @@
   ],
   "license_detections": [
     {
+      "identifier": "gpl_2_0_plus-1db96703-cb36-48f4-1493-265d3d85eb9e",
+      "license_expression": "gpl-2.0-plus",
+      "detection_count": 1
+    },
+    {
       "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
       "license_expression": "mit",
       "detection_count": 2
@@ -285,11 +290,6 @@
     {
       "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
       "license_expression": "mit",
-      "detection_count": 1
-    },
-    {
-      "identifier": "gpl_2_0_plus-1db96703-cb36-48f4-1493-265d3d85eb9e",
-      "license_expression": "gpl-2.0-plus",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/score/jar-expected.json
+++ b/tests/summarycode/data/score/jar-expected.json
@@ -230,12 +230,12 @@
   ],
   "license_detections": [
     {
-      "identifier": "apache_2_0-ab23f79b-ec38-9a8a-9b23-85059407f34d",
+      "identifier": "apache_2_0-c4e30bcd-ccfd-bbc3-d2f1-196ab911e47d",
       "license_expression": "apache-2.0",
-      "detection_count": 1
+      "detection_count": 2
     },
     {
-      "identifier": "apache_2_0-4800df2e-4a56-bac0-cac1-9fd31da23344",
+      "identifier": "apache_2_0-2e855fd2-d4e6-f202-a2a4-6953b9354518",
       "license_expression": "apache-2.0",
       "detection_count": 1
     },
@@ -245,14 +245,14 @@
       "detection_count": 1
     },
     {
-      "identifier": "apache_2_0-2e855fd2-d4e6-f202-a2a4-6953b9354518",
+      "identifier": "apache_2_0-4800df2e-4a56-bac0-cac1-9fd31da23344",
       "license_expression": "apache-2.0",
       "detection_count": 1
     },
     {
-      "identifier": "apache_2_0-c4e30bcd-ccfd-bbc3-d2f1-196ab911e47d",
+      "identifier": "apache_2_0-ab23f79b-ec38-9a8a-9b23-85059407f34d",
       "license_expression": "apache-2.0",
-      "detection_count": 2
+      "detection_count": 1
     }
   ],
   "files": [

--- a/tests/summarycode/data/score/no_license_ambiguity-expected.json
+++ b/tests/summarycode/data/score/no_license_ambiguity-expected.json
@@ -97,13 +97,8 @@
   "dependencies": [],
   "license_detections": [
     {
-      "identifier": "mit_or_apache_2_0-719f8427-422e-8023-c20e-9f8dd0af13b9",
-      "license_expression": "mit OR apache-2.0",
-      "detection_count": 1
-    },
-    {
-      "identifier": "mit_or_apache_2_0-480eec53-1a80-0150-7c7e-39cf79c9f3a8",
-      "license_expression": "mit OR apache-2.0",
+      "identifier": "apache_2_0-e3938c59-cc73-037c-3372-e20c26c25f48",
+      "license_expression": "apache-2.0",
       "detection_count": 1
     },
     {
@@ -112,8 +107,8 @@
       "detection_count": 1
     },
     {
-      "identifier": "apache_2_0-e3938c59-cc73-037c-3372-e20c26c25f48",
-      "license_expression": "apache-2.0",
+      "identifier": "mit-a9138d4e-bc0e-0a20-76fd-237047e6d41c",
+      "license_expression": "mit",
       "detection_count": 1
     },
     {
@@ -122,8 +117,13 @@
       "detection_count": 1
     },
     {
-      "identifier": "mit-a9138d4e-bc0e-0a20-76fd-237047e6d41c",
-      "license_expression": "mit",
+      "identifier": "mit_or_apache_2_0-480eec53-1a80-0150-7c7e-39cf79c9f3a8",
+      "license_expression": "mit OR apache-2.0",
+      "detection_count": 1
+    },
+    {
+      "identifier": "mit_or_apache_2_0-719f8427-422e-8023-c20e-9f8dd0af13b9",
+      "license_expression": "mit OR apache-2.0",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/summary/conflicting_license_categories/conflicting_license_categories.expected.json
+++ b/tests/summarycode/data/summary/conflicting_license_categories/conflicting_license_categories.expected.json
@@ -55,11 +55,6 @@
       "detection_count": 1
     },
     {
-      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
-      "license_expression": "mit",
-      "detection_count": 1
-    },
-    {
       "identifier": "apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39",
       "license_expression": "apache-2.0 AND (apache-2.0 OR mit)",
       "detection_count": 1
@@ -67,6 +62,11 @@
     {
       "identifier": "gpl_1_0_plus_and_gpl_2_0_and_gpl_2_0_plus-d3814696-f4d1-6a85-1134-6baea31b797a",
       "license_expression": "gpl-1.0-plus AND gpl-2.0 AND gpl-2.0-plus",
+      "detection_count": 1
+    },
+    {
+      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
+      "license_expression": "mit",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/summary/end-2-end/bug-1141.expected.json
+++ b/tests/summarycode/data/summary/end-2-end/bug-1141.expected.json
@@ -38,13 +38,13 @@
   "dependencies": [],
   "license_detections": [
     {
-      "identifier": "gpl_3_0_plus-494d0068-7138-a14f-4cbb-fd2137263a4f",
-      "license_expression": "gpl-3.0-plus",
+      "identifier": "gpl_2_0_plus-9b44ef18-69db-1b2d-f6ce-dd439fc51603",
+      "license_expression": "gpl-2.0-plus",
       "detection_count": 1
     },
     {
-      "identifier": "gpl_2_0_plus-9b44ef18-69db-1b2d-f6ce-dd439fc51603",
-      "license_expression": "gpl-2.0-plus",
+      "identifier": "gpl_3_0_plus-494d0068-7138-a14f-4cbb-fd2137263a4f",
+      "license_expression": "gpl-3.0-plus",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/summary/end-2-end/bug-1141.expected.json
+++ b/tests/summarycode/data/summary/end-2-end/bug-1141.expected.json
@@ -15,7 +15,7 @@
     "other_license_expressions": [
       {
         "value": null,
-        "count": 1
+        "count": 2
       },
       {
         "value": "gpl-2.0-plus",

--- a/tests/summarycode/data/summary/holders/clear_holder.expected.json
+++ b/tests/summarycode/data/summary/holders/clear_holder.expected.json
@@ -14,10 +14,6 @@
     "primary_language": "Python",
     "other_license_expressions": [
       {
-        "value": null,
-        "count": 1
-      },
-      {
         "value": "apache-2.0",
         "count": 1
       },

--- a/tests/summarycode/data/summary/holders/clear_holder.expected.json
+++ b/tests/summarycode/data/summary/holders/clear_holder.expected.json
@@ -47,14 +47,14 @@
       "detection_count": 1
     },
     {
-      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
-      "license_expression": "mit",
-      "detection_count": 1
-    },
-    {
       "identifier": "apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39",
       "license_expression": "apache-2.0 AND (apache-2.0 OR mit)",
       "detection_count": 3
+    },
+    {
+      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
+      "license_expression": "mit",
+      "detection_count": 1
     }
   ],
   "files": [

--- a/tests/summarycode/data/summary/holders/combined_holders.expected.json
+++ b/tests/summarycode/data/summary/holders/combined_holders.expected.json
@@ -14,10 +14,6 @@
     "primary_language": "Python",
     "other_license_expressions": [
       {
-        "value": null,
-        "count": 1
-      },
-      {
         "value": "apache-2.0",
         "count": 1
       },

--- a/tests/summarycode/data/summary/holders/combined_holders.expected.json
+++ b/tests/summarycode/data/summary/holders/combined_holders.expected.json
@@ -43,14 +43,14 @@
       "detection_count": 1
     },
     {
-      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
-      "license_expression": "mit",
-      "detection_count": 1
-    },
-    {
       "identifier": "apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39",
       "license_expression": "apache-2.0 AND (apache-2.0 OR mit)",
       "detection_count": 3
+    },
+    {
+      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
+      "license_expression": "mit",
+      "detection_count": 1
     }
   ],
   "files": [

--- a/tests/summarycode/data/summary/license_ambiguity/unambiguous.expected.json
+++ b/tests/summarycode/data/summary/license_ambiguity/unambiguous.expected.json
@@ -43,13 +43,13 @@
       "detection_count": 1
     },
     {
-      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
-      "license_expression": "mit",
+      "identifier": "apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39",
+      "license_expression": "apache-2.0 AND (apache-2.0 OR mit)",
       "detection_count": 1
     },
     {
-      "identifier": "apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39",
-      "license_expression": "apache-2.0 AND (apache-2.0 OR mit)",
+      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
+      "license_expression": "mit",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/summary/license_ambiguity/unambiguous.expected.json
+++ b/tests/summarycode/data/summary/license_ambiguity/unambiguous.expected.json
@@ -14,10 +14,6 @@
     "primary_language": null,
     "other_license_expressions": [
       {
-        "value": null,
-        "count": 1
-      },
-      {
         "value": "apache-2.0",
         "count": 1
       },

--- a/tests/summarycode/data/summary/multiple_package_data/multiple_package_data.expected.json
+++ b/tests/summarycode/data/summary/multiple_package_data/multiple_package_data.expected.json
@@ -22,10 +22,6 @@
         "count": 2
       },
       {
-        "value": null,
-        "count": 1
-      },
-      {
         "value": "apache-2.0 AND (apache-2.0 OR mit)",
         "count": 1
       }

--- a/tests/summarycode/data/summary/multiple_package_data/multiple_package_data.expected.json
+++ b/tests/summarycode/data/summary/multiple_package_data/multiple_package_data.expected.json
@@ -196,6 +196,21 @@
       "detection_count": 1
     },
     {
+      "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
+      "license_expression": "apache-2.0",
+      "detection_count": 1
+    },
+    {
+      "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
+      "license_expression": "apache-2.0",
+      "detection_count": 1
+    },
+    {
+      "identifier": "apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39",
+      "license_expression": "apache-2.0 AND (apache-2.0 OR mit)",
+      "detection_count": 1
+    },
+    {
       "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
       "license_expression": "mit",
       "detection_count": 1
@@ -208,21 +223,6 @@
     {
       "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
       "license_expression": "mit",
-      "detection_count": 1
-    },
-    {
-      "identifier": "apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39",
-      "license_expression": "apache-2.0 AND (apache-2.0 OR mit)",
-      "detection_count": 1
-    },
-    {
-      "identifier": "apache_2_0-ec759ae0-ea5a-f138-793e-388520e080c0",
-      "license_expression": "apache-2.0",
-      "detection_count": 1
-    },
-    {
-      "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
-      "license_expression": "apache-2.0",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/summary/single_file/single_file.expected.json
+++ b/tests/summarycode/data/summary/single_file/single_file.expected.json
@@ -12,12 +12,7 @@
     },
     "declared_holder": "Mort Bay Consulting Pty. Ltd. (Australia) and others, Sun Microsystems",
     "primary_language": null,
-    "other_license_expressions": [
-      {
-        "value": null,
-        "count": 1
-      }
-    ],
+    "other_license_expressions": [],
     "other_holders": [],
     "other_languages": []
   },

--- a/tests/summarycode/data/summary/summary_without_holder/summary-without-holder-pypi.expected.json
+++ b/tests/summarycode/data/summary/summary_without_holder/summary-without-holder-pypi.expected.json
@@ -127,6 +127,21 @@
   "dependencies": [],
   "license_detections": [
     {
+      "identifier": "mit-24a5293c-14d7-5403-efac-1a8b7532c0e8",
+      "license_expression": "mit",
+      "detection_count": 3
+    },
+    {
+      "identifier": "mit-707ccf7a-5c60-0e4c-5844-349c989a00f5",
+      "license_expression": "mit",
+      "detection_count": 2
+    },
+    {
+      "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
+      "license_expression": "mit",
+      "detection_count": 2
+    },
+    {
       "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
       "license_expression": "mit",
       "detection_count": 2
@@ -137,24 +152,9 @@
       "detection_count": 1
     },
     {
-      "identifier": "mit-24a5293c-14d7-5403-efac-1a8b7532c0e8",
-      "license_expression": "mit",
-      "detection_count": 3
-    },
-    {
       "identifier": "mit-59433771-4926-870e-d21a-8162cfa060a3",
       "license_expression": "mit",
       "detection_count": 1
-    },
-    {
-      "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf",
-      "license_expression": "mit",
-      "detection_count": 2
-    },
-    {
-      "identifier": "mit-707ccf7a-5c60-0e4c-5844-349c989a00f5",
-      "license_expression": "mit",
-      "detection_count": 2
     },
     {
       "identifier": "mit-6e6256c5-00ca-dcb6-8033-2fc4b6ff86be",

--- a/tests/summarycode/data/summary/summary_without_holder/summary-without-holder-pypi.expected.json
+++ b/tests/summarycode/data/summary/summary_without_holder/summary-without-holder-pypi.expected.json
@@ -15,7 +15,7 @@
     "other_license_expressions": [
       {
         "value": null,
-        "count": 1
+        "count": 9
       }
     ],
     "other_holders": [],

--- a/tests/summarycode/data/summary/with_package_data/with_package_data.expected.json
+++ b/tests/summarycode/data/summary/with_package_data/with_package_data.expected.json
@@ -118,13 +118,8 @@
       "detection_count": 1
     },
     {
-      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
-      "license_expression": "mit",
-      "detection_count": 1
-    },
-    {
-      "identifier": "apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39",
-      "license_expression": "apache-2.0 AND (apache-2.0 OR mit)",
+      "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
+      "license_expression": "apache-2.0",
       "detection_count": 1
     },
     {
@@ -133,8 +128,13 @@
       "detection_count": 1
     },
     {
-      "identifier": "apache_2_0-d66ab77d-a5cc-7104-e702-dc7df61fe9e8",
-      "license_expression": "apache-2.0",
+      "identifier": "apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39",
+      "license_expression": "apache-2.0 AND (apache-2.0 OR mit)",
+      "detection_count": 1
+    },
+    {
+      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
+      "license_expression": "mit",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/summary/with_package_data/with_package_data.expected.json
+++ b/tests/summarycode/data/summary/with_package_data/with_package_data.expected.json
@@ -14,10 +14,6 @@
     "primary_language": "Python",
     "other_license_expressions": [
       {
-        "value": null,
-        "count": 1
-      },
-      {
         "value": "apache-2.0 AND (apache-2.0 OR mit)",
         "count": 1
       },

--- a/tests/summarycode/data/summary/without_package_data/without_package_data.expected.json
+++ b/tests/summarycode/data/summary/without_package_data/without_package_data.expected.json
@@ -43,13 +43,13 @@
       "detection_count": 1
     },
     {
-      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
-      "license_expression": "mit",
+      "identifier": "apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39",
+      "license_expression": "apache-2.0 AND (apache-2.0 OR mit)",
       "detection_count": 1
     },
     {
-      "identifier": "apache_2_0_and__apache_2_0_or_mit-9b638e72-e872-a67f-3447-eec297ef7b39",
-      "license_expression": "apache-2.0 AND (apache-2.0 OR mit)",
+      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
+      "license_expression": "mit",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/summary/without_package_data/without_package_data.expected.json
+++ b/tests/summarycode/data/summary/without_package_data/without_package_data.expected.json
@@ -14,10 +14,6 @@
     "primary_language": null,
     "other_license_expressions": [
       {
-        "value": null,
-        "count": 1
-      },
-      {
         "value": "apache-2.0",
         "count": 1
       },

--- a/tests/summarycode/data/tallies/end-2-end/bug-1141.expected.json
+++ b/tests/summarycode/data/tallies/end-2-end/bug-1141.expected.json
@@ -17,7 +17,7 @@
     "detected_license_expression": [
       {
         "value": null,
-        "count": 1
+        "count": 2
       },
       {
         "value": "gpl-2.0-plus",

--- a/tests/summarycode/data/tallies/end-2-end/bug-1141.expected.json
+++ b/tests/summarycode/data/tallies/end-2-end/bug-1141.expected.json
@@ -3,13 +3,13 @@
   "dependencies": [],
   "license_detections": [
     {
-      "identifier": "gpl_3_0_plus-494d0068-7138-a14f-4cbb-fd2137263a4f",
-      "license_expression": "gpl-3.0-plus",
+      "identifier": "gpl_2_0_plus-9b44ef18-69db-1b2d-f6ce-dd439fc51603",
+      "license_expression": "gpl-2.0-plus",
       "detection_count": 1
     },
     {
-      "identifier": "gpl_2_0_plus-9b44ef18-69db-1b2d-f6ce-dd439fc51603",
-      "license_expression": "gpl-2.0-plus",
+      "identifier": "gpl_3_0_plus-494d0068-7138-a14f-4cbb-fd2137263a4f",
+      "license_expression": "gpl-3.0-plus",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/tallies/full_tallies/tallies.expected.json
+++ b/tests/summarycode/data/tallies/full_tallies/tallies.expected.json
@@ -3332,8 +3332,8 @@
   ],
   "license_detections": [
     {
-      "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963",
-      "license_expression": "cc0-1.0",
+      "identifier": "artistic_2_0-2ca48deb-7b37-fc93-edd9-b349ad073774",
+      "license_expression": "artistic-2.0",
       "detection_count": 1
     },
     {
@@ -3342,28 +3342,18 @@
       "detection_count": 1
     },
     {
-      "identifier": "artistic_2_0-2ca48deb-7b37-fc93-edd9-b349ad073774",
-      "license_expression": "artistic-2.0",
+      "identifier": "boost_1_0-7d91c102-4b73-b55e-398c-cca7ae1e7bf5",
+      "license_expression": "boost-1.0",
       "detection_count": 1
-    },
-    {
-      "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
-      "license_expression": "zlib",
-      "detection_count": 7
-    },
-    {
-      "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c",
-      "license_expression": "zlib",
-      "detection_count": 2
-    },
-    {
-      "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1",
-      "license_expression": "lgpl-2.1-plus",
-      "detection_count": 3
     },
     {
       "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae",
       "license_expression": "cc-by-2.5",
+      "detection_count": 1
+    },
+    {
+      "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963",
+      "license_expression": "cc0-1.0",
       "detection_count": 1
     },
     {
@@ -3372,14 +3362,19 @@
       "detection_count": 1
     },
     {
-      "identifier": "boost_1_0-7d91c102-4b73-b55e-398c-cca7ae1e7bf5",
-      "license_expression": "boost-1.0",
+      "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1",
+      "license_expression": "lgpl-2.1-plus",
+      "detection_count": 3
+    },
+    {
+      "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0",
+      "license_expression": "mit-old-style",
       "detection_count": 1
     },
     {
-      "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
+      "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
       "license_expression": "zlib",
-      "detection_count": 1
+      "detection_count": 7
     },
     {
       "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296",
@@ -3387,8 +3382,13 @@
       "detection_count": 2
     },
     {
-      "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0",
-      "license_expression": "mit-old-style",
+      "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c",
+      "license_expression": "zlib",
+      "detection_count": 2
+    },
+    {
+      "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
+      "license_expression": "zlib",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/tallies/full_tallies/tallies.expected.json
+++ b/tests/summarycode/data/tallies/full_tallies/tallies.expected.json
@@ -3399,12 +3399,12 @@
         "count": 12
       },
       {
-        "value": "lgpl-2.1-plus",
-        "count": 3
+        "value": null,
+        "count": 5
       },
       {
-        "value": null,
-        "count": 1
+        "value": "lgpl-2.1-plus",
+        "count": 3
       },
       {
         "value": "artistic-2.0",

--- a/tests/summarycode/data/tallies/full_tallies/tallies_by_facet.expected.json
+++ b/tests/summarycode/data/tallies/full_tallies/tallies_by_facet.expected.json
@@ -3332,8 +3332,8 @@
   ],
   "license_detections": [
     {
-      "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963",
-      "license_expression": "cc0-1.0",
+      "identifier": "artistic_2_0-2ca48deb-7b37-fc93-edd9-b349ad073774",
+      "license_expression": "artistic-2.0",
       "detection_count": 1
     },
     {
@@ -3342,28 +3342,18 @@
       "detection_count": 1
     },
     {
-      "identifier": "artistic_2_0-2ca48deb-7b37-fc93-edd9-b349ad073774",
-      "license_expression": "artistic-2.0",
+      "identifier": "boost_1_0-7d91c102-4b73-b55e-398c-cca7ae1e7bf5",
+      "license_expression": "boost-1.0",
       "detection_count": 1
-    },
-    {
-      "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
-      "license_expression": "zlib",
-      "detection_count": 7
-    },
-    {
-      "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c",
-      "license_expression": "zlib",
-      "detection_count": 2
-    },
-    {
-      "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1",
-      "license_expression": "lgpl-2.1-plus",
-      "detection_count": 3
     },
     {
       "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae",
       "license_expression": "cc-by-2.5",
+      "detection_count": 1
+    },
+    {
+      "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963",
+      "license_expression": "cc0-1.0",
       "detection_count": 1
     },
     {
@@ -3372,14 +3362,19 @@
       "detection_count": 1
     },
     {
-      "identifier": "boost_1_0-7d91c102-4b73-b55e-398c-cca7ae1e7bf5",
-      "license_expression": "boost-1.0",
+      "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1",
+      "license_expression": "lgpl-2.1-plus",
+      "detection_count": 3
+    },
+    {
+      "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0",
+      "license_expression": "mit-old-style",
       "detection_count": 1
     },
     {
-      "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
+      "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
       "license_expression": "zlib",
-      "detection_count": 1
+      "detection_count": 7
     },
     {
       "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296",
@@ -3387,8 +3382,13 @@
       "detection_count": 2
     },
     {
-      "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0",
-      "license_expression": "mit-old-style",
+      "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c",
+      "license_expression": "zlib",
+      "detection_count": 2
+    },
+    {
+      "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
+      "license_expression": "zlib",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/tallies/full_tallies/tallies_by_facet.expected.json
+++ b/tests/summarycode/data/tallies/full_tallies/tallies_by_facet.expected.json
@@ -3399,12 +3399,12 @@
         "count": 12
       },
       {
-        "value": "lgpl-2.1-plus",
-        "count": 3
+        "value": null,
+        "count": 5
       },
       {
-        "value": null,
-        "count": 1
+        "value": "lgpl-2.1-plus",
+        "count": 3
       },
       {
         "value": "artistic-2.0",

--- a/tests/summarycode/data/tallies/full_tallies/tallies_details.expected.json
+++ b/tests/summarycode/data/tallies/full_tallies/tallies_details.expected.json
@@ -3399,12 +3399,12 @@
         "count": 12
       },
       {
-        "value": "lgpl-2.1-plus",
-        "count": 3
+        "value": null,
+        "count": 5
       },
       {
-        "value": null,
-        "count": 1
+        "value": "lgpl-2.1-plus",
+        "count": 3
       },
       {
         "value": "artistic-2.0",
@@ -3609,12 +3609,12 @@
             "count": 12
           },
           {
-            "value": "lgpl-2.1-plus",
-            "count": 3
+            "value": null,
+            "count": 5
           },
           {
-            "value": null,
-            "count": 1
+            "value": "lgpl-2.1-plus",
+            "count": 3
           },
           {
             "value": "artistic-2.0",
@@ -3821,12 +3821,12 @@
       "tallies": {
         "detected_license_expression": [
           {
-            "value": "lgpl-2.1-plus",
+            "value": null,
             "count": 3
           },
           {
-            "value": null,
-            "count": 1
+            "value": "lgpl-2.1-plus",
+            "count": 3
           },
           {
             "value": "cc-by-2.5",
@@ -3933,12 +3933,12 @@
       "tallies": {
         "detected_license_expression": [
           {
-            "value": "lgpl-2.1-plus",
+            "value": null,
             "count": 3
           },
           {
-            "value": null,
-            "count": 1
+            "value": "lgpl-2.1-plus",
+            "count": 3
           },
           {
             "value": "cc-by-2.5",
@@ -4739,10 +4739,6 @@
           {
             "value": "zlib",
             "count": 3
-          },
-          {
-            "value": null,
-            "count": 1
           }
         ],
         "copyrights": [
@@ -8497,10 +8493,6 @@
       "tallies": {
         "detected_license_expression": [
           {
-            "value": null,
-            "count": 1
-          },
-          {
             "value": "gpl-2.0-plus WITH ada-linking-exception",
             "count": 1
           }
@@ -9260,10 +9252,6 @@
       "tallies": {
         "detected_license_expression": [
           {
-            "value": null,
-            "count": 1
-          },
-          {
             "value": "zlib",
             "count": 1
           }
@@ -9439,10 +9427,6 @@
           {
             "value": "zlib",
             "count": 2
-          },
-          {
-            "value": null,
-            "count": 1
           }
         ],
         "copyrights": [
@@ -9706,10 +9690,6 @@
       "authors": [],
       "tallies": {
         "detected_license_expression": [
-          {
-            "value": null,
-            "count": 1
-          },
           {
             "value": "mit-old-style",
             "count": 1

--- a/tests/summarycode/data/tallies/full_tallies/tallies_details.expected.json
+++ b/tests/summarycode/data/tallies/full_tallies/tallies_details.expected.json
@@ -3332,8 +3332,8 @@
   ],
   "license_detections": [
     {
-      "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963",
-      "license_expression": "cc0-1.0",
+      "identifier": "artistic_2_0-2ca48deb-7b37-fc93-edd9-b349ad073774",
+      "license_expression": "artistic-2.0",
       "detection_count": 1
     },
     {
@@ -3342,28 +3342,18 @@
       "detection_count": 1
     },
     {
-      "identifier": "artistic_2_0-2ca48deb-7b37-fc93-edd9-b349ad073774",
-      "license_expression": "artistic-2.0",
+      "identifier": "boost_1_0-7d91c102-4b73-b55e-398c-cca7ae1e7bf5",
+      "license_expression": "boost-1.0",
       "detection_count": 1
-    },
-    {
-      "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
-      "license_expression": "zlib",
-      "detection_count": 7
-    },
-    {
-      "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c",
-      "license_expression": "zlib",
-      "detection_count": 2
-    },
-    {
-      "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1",
-      "license_expression": "lgpl-2.1-plus",
-      "detection_count": 3
     },
     {
       "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae",
       "license_expression": "cc-by-2.5",
+      "detection_count": 1
+    },
+    {
+      "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963",
+      "license_expression": "cc0-1.0",
       "detection_count": 1
     },
     {
@@ -3372,14 +3362,19 @@
       "detection_count": 1
     },
     {
-      "identifier": "boost_1_0-7d91c102-4b73-b55e-398c-cca7ae1e7bf5",
-      "license_expression": "boost-1.0",
+      "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1",
+      "license_expression": "lgpl-2.1-plus",
+      "detection_count": 3
+    },
+    {
+      "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0",
+      "license_expression": "mit-old-style",
       "detection_count": 1
     },
     {
-      "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
+      "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
       "license_expression": "zlib",
-      "detection_count": 1
+      "detection_count": 7
     },
     {
       "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296",
@@ -3387,8 +3382,13 @@
       "detection_count": 2
     },
     {
-      "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0",
-      "license_expression": "mit-old-style",
+      "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c",
+      "license_expression": "zlib",
+      "detection_count": 2
+    },
+    {
+      "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
+      "license_expression": "zlib",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/tallies/full_tallies/tallies_key_files-details.expected.json-lines
+++ b/tests/summarycode/data/tallies/full_tallies/tallies_key_files-details.expected.json-lines
@@ -99,12 +99,12 @@
           "count": 12
         },
         {
-          "value": "lgpl-2.1-plus",
-          "count": 3
+          "value": null,
+          "count": 5
         },
         {
-          "value": null,
-          "count": 1
+          "value": "lgpl-2.1-plus",
+          "count": 3
         },
         {
           "value": "artistic-2.0",

--- a/tests/summarycode/data/tallies/full_tallies/tallies_key_files-details.expected.json-lines
+++ b/tests/summarycode/data/tallies/full_tallies/tallies_key_files-details.expected.json-lines
@@ -35,38 +35,8 @@
   {
     "license_detections": [
       {
-        "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963",
-        "license_expression": "cc0-1.0",
-        "detection_count": 1
-      },
-      {
         "identifier": "artistic_2_0-c1ede1c6-eb3d-61cc-53ad-abba5e17c732",
         "license_expression": "artistic-2.0",
-        "detection_count": 1
-      },
-      {
-        "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
-        "license_expression": "zlib",
-        "detection_count": 7
-      },
-      {
-        "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c",
-        "license_expression": "zlib",
-        "detection_count": 2
-      },
-      {
-        "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1",
-        "license_expression": "lgpl-2.1-plus",
-        "detection_count": 3
-      },
-      {
-        "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae",
-        "license_expression": "cc-by-2.5",
-        "detection_count": 1
-      },
-      {
-        "identifier": "gpl_2_0_plus_with_ada_linking_exception-ca27fab9-344b-58b2-3c05-f3ca150dad7e",
-        "license_expression": "gpl-2.0-plus WITH ada-linking-exception",
         "detection_count": 1
       },
       {
@@ -75,9 +45,34 @@
         "detection_count": 1
       },
       {
-        "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
-        "license_expression": "zlib",
+        "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae",
+        "license_expression": "cc-by-2.5",
         "detection_count": 1
+      },
+      {
+        "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963",
+        "license_expression": "cc0-1.0",
+        "detection_count": 1
+      },
+      {
+        "identifier": "gpl_2_0_plus_with_ada_linking_exception-ca27fab9-344b-58b2-3c05-f3ca150dad7e",
+        "license_expression": "gpl-2.0-plus WITH ada-linking-exception",
+        "detection_count": 1
+      },
+      {
+        "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1",
+        "license_expression": "lgpl-2.1-plus",
+        "detection_count": 3
+      },
+      {
+        "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0",
+        "license_expression": "mit-old-style",
+        "detection_count": 1
+      },
+      {
+        "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
+        "license_expression": "zlib",
+        "detection_count": 7
       },
       {
         "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296",
@@ -85,8 +80,13 @@
         "detection_count": 2
       },
       {
-        "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0",
-        "license_expression": "mit-old-style",
+        "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c",
+        "license_expression": "zlib",
+        "detection_count": 2
+      },
+      {
+        "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
+        "license_expression": "zlib",
         "detection_count": 1
       }
     ]

--- a/tests/summarycode/data/tallies/full_tallies/tallies_key_files.expected.json
+++ b/tests/summarycode/data/tallies/full_tallies/tallies_key_files.expected.json
@@ -1,38 +1,8 @@
 {
   "license_detections": [
     {
-      "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963",
-      "license_expression": "cc0-1.0",
-      "detection_count": 1
-    },
-    {
       "identifier": "artistic_2_0-c1ede1c6-eb3d-61cc-53ad-abba5e17c732",
       "license_expression": "artistic-2.0",
-      "detection_count": 1
-    },
-    {
-      "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
-      "license_expression": "zlib",
-      "detection_count": 7
-    },
-    {
-      "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c",
-      "license_expression": "zlib",
-      "detection_count": 2
-    },
-    {
-      "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1",
-      "license_expression": "lgpl-2.1-plus",
-      "detection_count": 3
-    },
-    {
-      "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae",
-      "license_expression": "cc-by-2.5",
-      "detection_count": 1
-    },
-    {
-      "identifier": "gpl_2_0_plus_with_ada_linking_exception-ca27fab9-344b-58b2-3c05-f3ca150dad7e",
-      "license_expression": "gpl-2.0-plus WITH ada-linking-exception",
       "detection_count": 1
     },
     {
@@ -41,9 +11,34 @@
       "detection_count": 1
     },
     {
-      "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
-      "license_expression": "zlib",
+      "identifier": "cc_by_2_5-2664cdba-0ee6-a527-2588-8a3a1be3ecae",
+      "license_expression": "cc-by-2.5",
       "detection_count": 1
+    },
+    {
+      "identifier": "cc0_1_0-4be2dd81-b884-28ac-690a-75aff1b0e963",
+      "license_expression": "cc0-1.0",
+      "detection_count": 1
+    },
+    {
+      "identifier": "gpl_2_0_plus_with_ada_linking_exception-ca27fab9-344b-58b2-3c05-f3ca150dad7e",
+      "license_expression": "gpl-2.0-plus WITH ada-linking-exception",
+      "detection_count": 1
+    },
+    {
+      "identifier": "lgpl_2_1_plus-3fe3e5e6-cb18-c0a1-f831-f08fab3612c1",
+      "license_expression": "lgpl-2.1-plus",
+      "detection_count": 3
+    },
+    {
+      "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0",
+      "license_expression": "mit-old-style",
+      "detection_count": 1
+    },
+    {
+      "identifier": "zlib-663c0d51-510f-fca6-b163-671ecb188ff9",
+      "license_expression": "zlib",
+      "detection_count": 7
     },
     {
       "identifier": "zlib-27de81f4-f6ce-2bf5-ab37-9a4c71f4b296",
@@ -51,8 +46,13 @@
       "detection_count": 2
     },
     {
-      "identifier": "mit_old_style-578ee504-a9b5-6c26-1bb4-fd7b80a664f0",
-      "license_expression": "mit-old-style",
+      "identifier": "zlib-b04102d0-a663-78b5-de18-9677ee48ce9c",
+      "license_expression": "zlib",
+      "detection_count": 2
+    },
+    {
+      "identifier": "zlib-f32ae987-c66a-44ce-bd13-c90e0c59aab8",
+      "license_expression": "zlib",
       "detection_count": 1
     }
   ],

--- a/tests/summarycode/data/tallies/full_tallies/tallies_key_files.expected.json
+++ b/tests/summarycode/data/tallies/full_tallies/tallies_key_files.expected.json
@@ -63,12 +63,12 @@
         "count": 12
       },
       {
-        "value": "lgpl-2.1-plus",
-        "count": 3
+        "value": null,
+        "count": 5
       },
       {
-        "value": null,
-        "count": 1
+        "value": "lgpl-2.1-plus",
+        "count": 3
       },
       {
         "value": "artistic-2.0",

--- a/tests/summarycode/data/todo/no_todo/base64-arraybuffer.expected.json
+++ b/tests/summarycode/data/todo/no_todo/base64-arraybuffer.expected.json
@@ -168,12 +168,12 @@
   ],
   "license_detections": [
     {
-      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
+      "identifier": "mit-e634e936-0701-7555-bfaa-1fce0c174838",
       "license_expression": "mit",
-      "detection_count": 1
+      "detection_count": 2
     },
     {
-      "identifier": "mit-f9ae5fa5-0848-4d18-62fc-d668971434b3",
+      "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
       "license_expression": "mit",
       "detection_count": 1
     },
@@ -183,14 +183,14 @@
       "detection_count": 1
     },
     {
-      "identifier": "mit-3fce6ea2-8abd-6c6b-3ede-a37af7c6efee",
+      "identifier": "mit-cacd5c0c-204a-85c2-affc-e4c125b2492a",
       "license_expression": "mit",
       "detection_count": 1
     },
     {
-      "identifier": "mit-e634e936-0701-7555-bfaa-1fce0c174838",
+      "identifier": "mit-f9ae5fa5-0848-4d18-62fc-d668971434b3",
       "license_expression": "mit",
-      "detection_count": 2
+      "detection_count": 1
     }
   ],
   "todo": [],


### PR DESCRIPTION
Changes:

1. The top level license detection is now sorted.
2. License tallies are now computed from license detections.
3. Fix a bug effecting the count of files with no license detected.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Looked for possible updates in documentation and added updates if applicable
* [x] Updated CHANGELOG.rst

