### PR TITLE
Bump commoncode to v31.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,9 @@ v33.0.0 (next next, roadmap)
   - Yocto/BitBake .bb recipes.
 
 - Fallback packages for non-native dependencies of SCTK.
-- Dependencies for 
+- Dependencies for
 - Support for copyright detection objects.
+- Bump commoncode to v31.0.3
 
 v32.1.0 (next, roadmap)
 ----------------------------
@@ -148,7 +149,7 @@ There are fixes for two issues in this release:
 - https://github.com/nexB/scancode-toolkit/issues/3407:
   here in typecode we had an improper import of ctypes.utils
   and this is fixed in a new release v30.0.1 of typecode
-- https://github.com/nexB/scancode-toolkit/issues/3408 
+- https://github.com/nexB/scancode-toolkit/issues/3408
   the setup.cfg and setup-mini.cfg was not aligned for plugin
   entrypoints.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ chardet==5.0.0
 charset-normalizer==2.1.0
 click==8.1.3
 colorama==0.4.5
-commoncode==31.0.2
+commoncode==31.0.3
 construct==2.10.68
 container-inspector==31.1.0
 cryptography==37.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ install_requires =
     chardet >= 3.0.0
     click >= 6.7, !=7.0
     colorama >= 0.3.9
-    commoncode >= 31.0.2
+    commoncode >= 31.0.3
     container-inspector >= 31.0.0
     debian-inspector >= 31.0.0
     dparse2 >= 0.7.0


### PR DESCRIPTION
This PR bumps commoncode to v31.0.3

This version of commoncode fixes a VirtualCodebase creation issue when there is a directory under the root with the same name as the root directory itself. https://github.com/nexB/commoncode/issues/57