### PR TITLE
TestRule.test_dump_rule_file: sort the rule file lists.

### DIFF
--- a/tests/licensedcode/test_models.py
+++ b/tests/licensedcode/test_models.py
@@ -263,9 +263,11 @@ class TestRule(FileBasedTesting):
         test_dir = self.get_test_loc('models/rules', copy=True)
         test_dir_dump = self.get_test_loc('models/rule_file_dump')
         rules = list(models.load_rules(test_dir))
+        rules.sort(key=lambda x: x.identifier)
         rule_example = rules.pop()
         rule_example.dump(rules_data_dir=test_dir_dump)
         rule_from_dump = list(models.load_rules(test_dir_dump))
+        rule_from_dump.sort(key=lambda x: x.identifier)
         rule_example_from_dump = rule_from_dump.pop()
         # Note: one license is obsolete and not loaded. Other are various exception/version cases
         before_dump = as_sorted_mapping_seq(licenses=[rule_example], include_text=True)


### PR DESCRIPTION
Fixes #3581.

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Looked for possible updates in documentation and added updates if applicable
* [x] Updated CHANGELOG.rst
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
