### PR TITLE
Fix reference to install section

### DIFF
--- a/docs/source/getting-started/install.rst
+++ b/docs/source/getting-started/install.rst
@@ -1,3 +1,5 @@
+.. _install:
+
 Comprehensive Installation
 ==========================
 

--- a/docs/source/tutorials/how_to_run_a_scan.rst
+++ b/docs/source/tutorials/how_to_run_a_scan.rst
@@ -8,7 +8,7 @@ by default with Scancode.
 Prerequisites
 -------------
 
-Refer to the :ref:'install' installation guide.
+Refer to the :ref:`install` installation guide.
 
 
 Looking into Files


### PR DESCRIPTION
For references to work, the use of backticks, not apostrophes is required.

Also, the reference has to actually exist.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 <del>and links the original issue above 🔗</del>
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Looked for possible updates in documentation and added updates if applicable
* [x] Updated CHANGELOG.rst