### PR TITLE
Fix debian source purl parsing in status

### DIFF
--- a/src/packagedcode/debian.py
+++ b/src/packagedcode/debian.py
@@ -673,9 +673,19 @@ def build_package_data(debian_data, datasource_id, package_type='deb', distro=No
     source_packages = []
     source = debian_data.get('source')
     if source:
+        # source package strings often have version in them like:
+        # Source: util-linux (2.36.1-8+deb11u1)
+        if " (" in source and ")" in source:
+            source_name, source_version = source.split(" (")
+            source_version, _ = source_version.split(")")
+        else:
+            source_name = source
+            source_version = None
+
         source_pkg_purl = PackageURL(
             type=package_type,
-            name=source,
+            name=source_name,
+            version=source_version,
             namespace=distro,
         ).to_string()
 

--- a/tests/packagedcode/data/debian/status-with-source/status
+++ b/tests/packagedcode/data/debian/status-with-source/status
@@ -1,0 +1,18 @@
+Package: bsdutils
+Essential: yes
+Status: install ok installed
+Priority: required
+Section: utils
+Installed-Size: 394
+Maintainer: util-linux packagers <util-linux@packages.debian.org>
+Architecture: amd64
+Multi-Arch: foreign
+Source: util-linux (2.36.1-8+deb11u1)
+Version: 1:2.36.1-8+deb11u1
+Pre-Depends: libc6 (>= 2.17), libsystemd0
+Recommends: bsdextrautils
+Description: basic utilities from 4.4BSD-Lite
+ This package contains the bare minimum of BSD utilities needed for a Debian
+ system: logger, renice, script, scriptlive, scriptreplay and wall. The
+ remaining standard BSD utilities are provided by bsdextrautils.
+Homepage: http://www.kernel.org/pub/linux/utils/util-linux/

--- a/tests/packagedcode/data/debian/status-with-source/status.expected
+++ b/tests/packagedcode/data/debian/status-with-source/status.expected
@@ -1,0 +1,60 @@
+[
+  {
+    "type": "deb",
+    "namespace": "debian",
+    "name": "bsdutils",
+    "version": "1:2.36.1-8+deb11u1",
+    "qualifiers": {
+      "arch": "amd64"
+    },
+    "subpath": null,
+    "primary_language": null,
+    "description": "basic utilities from 4.4BSD-Lite\n This package contains the bare minimum of BSD utilities needed for a Debian\n system: logger, renice, script, scriptlive, scriptreplay and wall. The\n remaining standard BSD utilities are provided by bsdextrautils.",
+    "release_date": null,
+    "parties": [
+      {
+        "type": null,
+        "role": "maintainer",
+        "name": "util-linux packagers <util-linux@packages.debian.org>",
+        "email": null,
+        "url": null
+      }
+    ],
+    "keywords": [
+      "utils"
+    ],
+    "homepage_url": "http://www.kernel.org/pub/linux/utils/util-linux/",
+    "download_url": null,
+    "size": null,
+    "sha1": null,
+    "md5": null,
+    "sha256": null,
+    "sha512": null,
+    "bug_tracking_url": null,
+    "code_view_url": null,
+    "vcs_url": null,
+    "copyright": null,
+    "holder": null,
+    "declared_license_expression": null,
+    "declared_license_expression_spdx": null,
+    "license_detections": [],
+    "other_license_expression": null,
+    "other_license_expression_spdx": null,
+    "other_license_detections": [],
+    "extracted_license_statement": null,
+    "notice_text": null,
+    "source_packages": [
+      "pkg:deb/debian/util-linux@2.36.1-8%2Bdeb11u1"
+    ],
+    "file_references": [],
+    "extra_data": {
+      "multi_arch": "foreign"
+    },
+    "dependencies": [],
+    "repository_homepage_url": null,
+    "repository_download_url": null,
+    "api_data_url": null,
+    "datasource_id": "debian_installed_status_db",
+    "purl": "pkg:deb/debian/bsdutils@1:2.36.1-8%2Bdeb11u1?arch=amd64"
+  }
+]

--- a/tests/packagedcode/test_debian.py
+++ b/tests/packagedcode/test_debian.py
@@ -84,6 +84,12 @@ class TestDebian(PackageTester):
         packages = list(debian.DebianInstalledStatusDatabaseHandler.parse(test_file))
         self.check_packages_data(packages, expected_loc, regen=REGEN_TEST_FIXTURES)
 
+    def test_parse_status_file_with_source_packages(self):
+        test_file = self.get_test_loc('debian/status-with-source/status')
+        expected_loc = self.get_test_loc('debian/status-with-source/status.expected')
+        packages = list(debian.DebianInstalledStatusDatabaseHandler.parse(test_file))
+        self.check_packages_data(packages, expected_loc, regen=REGEN_TEST_FIXTURES)
+
     def test_parse_status_file_perl_error(self):
         test_file = self.get_test_loc('debian/mini-status/status')
         expected_loc = self.get_test_loc('debian/mini-status/status.expected')


### PR DESCRIPTION
Debian status files have source package information, and these are mostly always just source package name, but sometimes there are versions also. Handle the case where we have both source package name and version for a package.


### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable)