### PR TITLE
Synchronize Licenses and update SPDX License List to 3.25.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,14 @@ v33.0.0 (next next, roadmap)
 - Update link references of ownership from nexB to aboutcode-org
   See https://github.com/aboutcode-org/scancode-toolkit/issues/3885
 
+- New and updated licenses, including support for newly released
+  SPDX license list versions:
+  - SPDX License List 3.25.0:
+    This release of the SPDX license list had 9 new licenses
+    and exceptions, and out of them 5 were present as licenses
+    and 2 were present as rules already. There were 2 new
+    license/exception texts added, and also 1 license was deprecated.
+    For more details see https://github.com/aboutcode-org/scancode-toolkit/pull/3897
 
 v32.2.1 - 2024-07-02
 ---------------------

--- a/src/licensedcode/data/licenses/docbook-schema.LICENSE
+++ b/src/licensedcode/data/licenses/docbook-schema.LICENSE
@@ -1,0 +1,27 @@
+---
+key: docbook-schema
+short_name: DocBook Schema License
+name: DocBook Schema License
+spdx_license_key: DocBook-Schema
+category: Permissive
+owner: OASIS
+other_urls:
+    - https://github.com/docbook/xslt10-stylesheets/blob/efd62655c11cc8773708df7a843613fa1e932bf8/xsl/assembly/schema/docbook51b7.rnc
+---
+ 
+Permission to use, copy, modify and distribute the DocBook schema
+and its accompanying documentation for any purpose and without fee
+is hereby granted in perpetuity, provided that the above copyright
+notice and this paragraph appear in all copies. The copyright
+holders make no representation about the suitability of the schema
+for any purpose. It is provided "as is" without expressed or implied
+warranty.
+ 
+If you modify the DocBook schema in any way, label your schema as a
+variant of DocBook. See the reference documentation
+(http://docbook.org/tdg5/en/html/ch05.html#s-notdocbook)
+for more information.
+ 
+Please direct all questions, bug reports, or suggestions for changes
+to the docbook@lists.oasis-open.org mailing list. For more
+information, see http://www.oasis-open.org/docbook/.

--- a/src/licensedcode/data/licenses/docbook-schema.LICENSE
+++ b/src/licensedcode/data/licenses/docbook-schema.LICENSE
@@ -2,13 +2,18 @@
 key: docbook-schema
 short_name: DocBook Schema License
 name: DocBook Schema License
-spdx_license_key: DocBook-Schema
 category: Permissive
 owner: OASIS
+spdx_license_key: DocBook-Schema
 other_urls:
     - https://github.com/docbook/xslt10-stylesheets/blob/efd62655c11cc8773708df7a843613fa1e932bf8/xsl/assembly/schema/docbook51b7.rnc
+ignorable_urls:
+    - http://docbook.org/tdg5/en/html/ch05.html#s-notdocbook
+    - http://www.oasis-open.org/docbook
+ignorable_emails:
+    - docbook@lists.oasis-open.org
 ---
- 
+
 Permission to use, copy, modify and distribute the DocBook schema
 and its accompanying documentation for any purpose and without fee
 is hereby granted in perpetuity, provided that the above copyright

--- a/src/licensedcode/data/licenses/docbook.LICENSE
+++ b/src/licensedcode/data/licenses/docbook.LICENSE
@@ -6,8 +6,12 @@ category: Permissive
 owner: DocBook Project
 homepage_url: https://github.com/docbook/xslt10-stylesheets/blob/282955cda01b7ace132a734dca0a241cfd736d91/xsl/COPYING
 notes: this is an MIT/X11 style license with an extra advertizing clause
-spdx_license_key: LicenseRef-scancode-docbook
+spdx_license_key: DocBook-XML
+other_spdx_license_keys:
+    - LicenseRef-scancode-docbook
 faq_url: https://web-beta.archive.org/web/20160118144348/http://wiki.docbook.org/DocBookLicense
+other_urls:
+    - https://github.com/docbook/xslt10-stylesheets/blob/efd62655c11cc8773708df7a843613fa1e932bf8/xsl/COPYING#L27
 minimum_coverage: 80
 ---
 

--- a/src/licensedcode/data/licenses/erlang-otp-linking-exception.LICENSE
+++ b/src/licensedcode/data/licenses/erlang-otp-linking-exception.LICENSE
@@ -1,0 +1,25 @@
+---
+key: erlang-otp-linking-exception
+short_name: Erlang/OTP Linking Exception
+name: Erlang/OTP Linking Exception
+category: Copyleft Limited
+owner: Erlang
+is_exception: yes
+spdx_license_key: erlang-otp-linking-exception
+other_urls:
+    - https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs
+    - https://erlang.org/pipermail/erlang-questions/2012-May/066355.html
+    - https://gitea.osmocom.org/erlang/osmo_ss7/src/commit/2286c1b8738d715950026650bf53f19a69d6ed0e/src/ss7_links.erl#L20
+---
+
+If you modify this Program, or any covered work, by linking or
+combining it with runtime libraries of Erlang/OTP as released by
+Ericsson on https://www.erlang.org (or a modified version of these
+libraries), containing parts covered by the terms of the Erlang Public
+License (https://www.erlang.org/EPLICENSE), the licensors of this
+Program grant you additional permission to convey the resulting work
+without the need to license the runtime libraries of Erlang/OTP under
+the GNU Affero General Public License. Corresponding Source for a
+non-source form of such a combination shall include the source code
+for the parts of the runtime libraries of Erlang/OTP used as well as
+that of the covered work.

--- a/src/licensedcode/data/licenses/erlang-otp-linking-exception.LICENSE
+++ b/src/licensedcode/data/licenses/erlang-otp-linking-exception.LICENSE
@@ -10,6 +10,9 @@ other_urls:
     - https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs
     - https://erlang.org/pipermail/erlang-questions/2012-May/066355.html
     - https://gitea.osmocom.org/erlang/osmo_ss7/src/commit/2286c1b8738d715950026650bf53f19a69d6ed0e/src/ss7_links.erl#L20
+ignorable_urls:
+    - https://www.erlang.org/
+    - https://www.erlang.org/EPLICENSE
 ---
 
 If you modify this Program, or any covered work, by linking or

--- a/src/licensedcode/data/licenses/fcl-1.0-apache-2.0.LICENSE
+++ b/src/licensedcode/data/licenses/fcl-1.0-apache-2.0.LICENSE
@@ -1,0 +1,134 @@
+---
+key: fcl-1.0-apache-2.0
+short_name: FCL-1.0-Apache-2.0
+name: Fair Core License, Version 1.0, Apache 2.0 Future License
+category: Source-available
+owner: keygen
+homepage_url: https://github.com/keygen-sh/fcl.dev/blob/master/FCL-1.0-Apache-2.0.md
+spdx_license_key: LicenseRef-scancode-fcl-1.0-apache-2.0
+other_urls:
+    - https://fcl.dev/
+ignorable_urls:
+    - http://www.apache.org/licenses/LICENSE-2.0
+---
+
+# Fair Core License, Version 1.0, Apache 2.0 Future License
+
+## Abbreviation
+
+FCL-1.0-Apache-2.0
+
+## Notice
+
+Copyright ${year} ${licensor name}
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Limitations,
+Patents, Redistribution and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Limitations
+
+You must not move, change, disable, or circumvent the license key functionality
+in the Software; or modify any portion of the Software protected by the license
+key to:
+
+1. enable access to the protected functionality without a valid license key; or
+
+2. remove the protected functionality.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright or other proprietary notices provided in or with the
+Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+In the event the provision of this Disclaimer section is unenforceable under
+applicable law, the licenses granted herein are void.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software,
+under the Apache License, Version 2.0, that is effective on the second
+anniversary of the date we make the Software available. On or after that date,
+you may use the Software under the Apache License, Version 2.0, in which case
+the following will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/src/licensedcode/data/licenses/fcl-1.0-mit.LICENSE
+++ b/src/licensedcode/data/licenses/fcl-1.0-mit.LICENSE
@@ -1,0 +1,137 @@
+---
+key: fcl-1.0-mit
+short_name: FCL-1.0-MIT
+name: Fair Core License, Version 1.0, MIT Future License
+category: Source-available
+owner: keygen
+homepage_url: https://github.com/keygen-sh/fcl.dev/blob/master/FCL-1.0-MIT.md
+spdx_license_key: LicenseRef-scancode-fcl-1.0-mit
+other_urls:
+    - https://fcl.dev/
+---
+
+# Fair Core License, Version 1.0, MIT Future License
+
+## Abbreviation
+
+FCL-1.0-MIT
+
+## Notice
+
+Copyright ${year} ${licensor name}
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Limitations,
+Patents, Redistribution and Trademark clauses below, we hereby grant you the
+right to use, copy, modify, create derivative works, publicly perform, publicly
+display and redistribute the Software for any Permitted Purpose identified
+below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Limitations
+
+You must not move, change, disable, or circumvent the license key functionality
+in the Software; or modify any portion of the Software protected by the license
+key to:
+
+1. enable access to the protected functionality without a valid license key; or
+
+2. remove the protected functionality.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright or other proprietary notices provided in or with the
+Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+In the event the provision of this Disclaimer section is unenforceable under
+applicable law, the licenses granted herein are void.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software,
+under the MIT license, that is effective on the second anniversary of the date
+we make the Software available. On or after that date, you may use the Software
+under the MIT license, in which case the following will apply:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/licensedcode/data/licenses/fsl-1.1-apache-2.0.LICENSE
+++ b/src/licensedcode/data/licenses/fsl-1.1-apache-2.0.LICENSE
@@ -1,0 +1,119 @@
+---
+key: fsl-1.1-apache-2.0
+short_name: FSL-1.1-Apache-2.0
+name: Functional Source License, Version 1.1, Apache 2.0 Future License
+category: Source-available
+owner: Sentry
+homepage_url: https://raw.githubusercontent.com/getsentry/fsl.software/main/FSL-1.1-Apache-2.0.template.md
+spdx_license_key: LicenseRef-scancode-fsl-1.1-apache-2.0
+other_urls:
+    - https://fsl.software/
+ignorable_urls:
+    - http://www.apache.org/licenses/LICENSE-2.0
+---
+
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright ${year} ${licensor name}
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/src/licensedcode/data/licenses/fsl-1.1-mit.LICENSE
+++ b/src/licensedcode/data/licenses/fsl-1.1-mit.LICENSE
@@ -1,0 +1,122 @@
+---
+key: fsl-1.1-mit
+short_name: FSL-1.1-MIT
+name: Functional Source License, Version 1.1, MIT Future License
+category: Source-available
+owner: Sentry
+homepage_url: https://github.com/getsentry/fsl.software/blob/main/FSL-1.1-MIT.template.md
+spdx_license_key: LicenseRef-scancode-fsl-1.1-mit
+other_urls:
+    - https://fsl.software/
+---
+
+# Functional Source License, Version 1.1, MIT Future License
+
+## Abbreviation
+
+FSL-1.1-MIT
+
+## Notice
+
+Copyright ${year} ${licensor name}
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the MIT license that is effective on the second anniversary of the date we make
+the Software available. On or after that date, you may use the Software under
+the MIT license, in which case the following will apply:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/licensedcode/data/licenses/generic-amiwm.LICENSE
+++ b/src/licensedcode/data/licenses/generic-amiwm.LICENSE
@@ -1,0 +1,47 @@
+---
+key: generic-amiwm
+short_name: Generic-amiwm
+name: Generic-amiwm
+category: Proprietary Free
+owner: Marcus Comstedt
+homepage_url: https://metadata.ftp-master.debian.org/changelogs//non-free/a/amiwm/amiwm_0.22pl2-3_copyright
+spdx_license_key: LicenseRef-scancode-generic-amiwm
+---
+
+License: Generic-amiwm
+ Generic amiwm License
+ =====================
+ .
+ This license applies to whomever receives this file.  It is a generic
+ license to use and distribute amiwm.  If you want to acquire the software
+ under a different license, please contact the author.  This license is
+ in part based on the XV license by John Bradley.
+ .
+ Permission to copy and distribute amiwm in its entirety, for
+ non-commercial purposes, is hereby granted without fee, provided
+ that this license information and copyright notice appear in all copies.
+ .
+ If you redistribute amiwm, the *entire* contents of this distribution
+ must be distributed, including the README, INSTALL and LICENSE files,
+ the sources, and the various scripts and Makefiles.
+ .
+ You may distribute binaries built from the unmodified amiwm sources, for
+ non-commercial purposes, provided that the entire amiwm source distribution
+ is also included, as per the preceding paragraph.
+ .
+ You may distribute amiwm as a component of an aggregate software
+ distribution, provided that no other condition of this license is violated.
+ In particular, the entire amiwm distribution must be included in the
+ aggregate software distribution.
+ .
+ Unrestricted use of the software is also hereby granted without fee.
+ Distribution and modification of source or binaries are not considered use
+ and explicitly covered by other paragraphs of this license.
+ .
+ The software may be modified for your own purposes, but modified versions
+ may not be distributed without prior consent of the author.  You may
+ freely distribute patches against the unmodified source code.
+ .
+ This software is provided 'as-is', without any express or implied
+ warranty.  In no event will the author be held liable for any damages
+ arising from the use of this software.

--- a/src/licensedcode/data/licenses/hidapi.LICENSE
+++ b/src/licensedcode/data/licenses/hidapi.LICENSE
@@ -5,7 +5,11 @@ name: HIDAPI License
 category: Permissive
 owner: Signal 11 Software
 homepage_url: https://github.com/signal11/hidapi/blob/master/LICENSE-orig.txt
-spdx_license_key: LicenseRef-scancode-hidapi
+spdx_license_key: HIDAPI
+other_spdx_license_keys:
+    - LicenseRef-scancode-hidapi
+other_urls:
+    - https://github.com/signal11/hidapi/blob/master/LICENSE-orig.txt
 ---
 
 This software may be used by anyone for any reason so long as the copyright

--- a/src/licensedcode/data/licenses/hpnd-netrek.LICENSE
+++ b/src/licensedcode/data/licenses/hpnd-netrek.LICENSE
@@ -1,0 +1,17 @@
+---
+key: hpnd-netrek
+short_name: HPND Netrek variant
+name: Historical Permission Notice and Disclaimer Netrek variant
+category: Permissive
+owner: S. M. Patel
+spdx_license_key: HPND-Netrek
+---
+
+Permission to use, copy, modify, and distribute this
+software and its documentation for any purpose and without
+fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright
+notice and this permission notice appear in supporting
+documentation.  No representations are made about the
+suitability of this software for any purpose.  It is
+provided "as is" without express or implied warranty.

--- a/src/licensedcode/data/licenses/linking-exception-agpl-3.0.LICENSE
+++ b/src/licensedcode/data/licenses/linking-exception-agpl-3.0.LICENSE
@@ -6,7 +6,16 @@ category: Copyleft Limited
 owner: Unspecified
 homepage_url: http://mo.morsi.org/blog/2009/08/13/lesser_affero_gplv3/
 is_exception: yes
-spdx_license_key: LicenseRef-scancode-linking-exception-agpl-3.0
+spdx_license_key: romic-exception
+other_spdx_license_keys:
+    - LicenseRef-scancode-linking-exception-agpl-3.0
+other_urls:
+    - https://github.com/zenbones/SmallMind/blob/3c62b5995fe7f27c453f140ff9b60560a0893f2a/COPYRIGHT#L25-L30
+    - https://github.com/savearray2/py.js/blob/b781273c08c8afa89f4954de4ecf42ec01429bae/README.md#license
+    - https://github.com/CubeArtisan/cubeartisan/blob/2c6ab53455237b88a3ea07be02a838a135c4ab79/LICENSE.LESSER#L10-L15
+    - https://web.archive.org/web/20210124015834/http://mo.morsi.org/blog/2009/08/13/lesser_affero_gplv3/
+    - https://sourceforge.net/p/romic/code/ci/3ab2856180cf0d8b007609af53154cf092efc58f/tree/COPYING
+    - https://github.com/moll/node-mitm/blob/bbf24b8bd7596dc6e091e625363161ce91984fc7/LICENSE#L8-L11
 ---
 
 Additional permission under the GNU Affero GPL version 3 section 7:

--- a/src/licensedcode/data/licenses/llama-3.1-license-2024.LICENSE
+++ b/src/licensedcode/data/licenses/llama-3.1-license-2024.LICENSE
@@ -1,0 +1,70 @@
+---
+key: llama-3.1-license-2024
+short_name: Llama 3.1 Community License Agreement 2024
+name: Llama 3.1 Community License Agreement 2024
+category: Proprietary Free
+owner: Facebook
+homepage_url: https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE
+spdx_license_key: LicenseRef-scancode-llama-3.1-license-2024
+text_urls:
+    - https://raw.githubusercontent.com/meta-llama/llama-models/main/models/llama3_1/LICENSE
+other_urls:
+    - https://github.com/meta-llama/llama-models
+ignorable_copyrights:
+    - Copyright (c) Meta Platforms, Inc.
+ignorable_holders:
+    - Meta Platforms, Inc.
+ignorable_urls:
+    - https://about.meta.com/brand/resources/meta/company-brand
+    - https://llama.meta.com/doc/overview
+    - https://llama.meta.com/llama-downloads
+    - https://llama.meta.com/llama3_1/use-policy
+---
+
+LLAMA 3.1 COMMUNITY LICENSE AGREEMENT
+ Llama 3.1 Version Release Date: July 23, 2024
+
+“Agreement” means the terms and conditions for use, reproduction, distribution and modification of the Llama Materials set forth herein.
+
+“Documentation” means the specifications, manuals and documentation accompanying Llama 3.1 distributed by Meta at https://llama.meta.com/doc/overview.
+
+“Licensee” or “you” means you, or your employer or any other person or entity (if you are entering into this Agreement on such person or entity’s behalf), of the age required under applicable laws, rules or regulations to provide legal consent and that has legal authority to bind your employer or such other person or entity if you are entering in this Agreement on their behalf.
+
+“Llama 3.1” means the foundational large language models and software and algorithms, including machine-learning model code, trained model weights, inference-enabling code, training-enabling code, fine-tuning enabling code and other elements of the foregoing distributed by Meta at https://llama.meta.com/llama-downloads.
+
+“Llama Materials” means, collectively, Meta’s proprietary Llama 3.1 and Documentation (and any portion thereof) made available under this Agreement.
+
+“Meta” or “we” means Meta Platforms Ireland Limited (if you are located in or, if you are an entity, your principal place of business is in the EEA or Switzerland) and Meta Platforms, Inc. (if you are located outside of the EEA or Switzerland). 
+
+By clicking “I Accept” below or by using or distributing any portion or element of the Llama Materials, you agree to be bound by this Agreement.
+
+1. License Rights and Redistribution.
+    a. Grant of Rights. You are granted a non-exclusive, worldwide, non-transferable and royalty-free limited license under Meta’s intellectual property or other rights owned by Meta embodied in the Llama Materials to use, reproduce, distribute, copy, create derivative works of, and make modifications to the Llama Materials.  
+
+    b. Redistribution and Use.  
+
+          i. If you distribute or make available the Llama Materials (or any derivative works thereof), or a product or service (including another AI model) that contains any of them, you shall (A) provide a copy of this Agreement with any such Llama Materials; and (B) prominently display “Built with Llama” on a related website, user interface, blogpost, about page, or product documentation. If you use the Llama Materials or any outputs or results of the Llama Materials to create, train, fine tune, or otherwise improve an AI model, which is distributed or made available, you shall also include “Llama” at the beginning of any such AI model name.
+
+          ii. If you receive Llama Materials, or any derivative works thereof, from a Licensee as part of an integrated end user product, then Section 2 of this Agreement will not apply to you. 
+
+          iii. You must retain in all copies of the Llama Materials that you distribute the following attribution notice within a “Notice” text file distributed as a part of such copies: “Llama 3.1 is licensed under the Llama 3.1 Community License, Copyright © Meta Platforms, Inc. All Rights Reserved.”
+
+          iv. Your use of the Llama Materials must comply with applicable laws and regulations (including trade compliance laws and regulations) and adhere to the Acceptable Use Policy for the Llama Materials (available at https://llama.meta.com/llama3_1/use-policy), which is hereby incorporated by reference into this Agreement.
+  
+2. Additional Commercial Terms. If, on the Llama 3.1 version release date, the monthly active users of the products or services made available by or for Licensee, or Licensee’s affiliates, is greater than 700 million monthly active users in the preceding calendar month, you must request a license from Meta, which Meta may grant to you in its sole discretion, and you are not authorized to exercise any of the rights under this Agreement unless or until Meta otherwise expressly grants you such rights.
+
+3. Disclaimer of Warranty. UNLESS REQUIRED BY APPLICABLE LAW, THE LLAMA MATERIALS AND ANY OUTPUT AND RESULTS THEREFROM ARE PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OF ANY KIND, AND META DISCLAIMS ALL WARRANTIES OF ANY KIND, BOTH EXPRESS AND IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. YOU ARE SOLELY RESPONSIBLE FOR DETERMINING THE APPROPRIATENESS OF USING OR REDISTRIBUTING THE LLAMA MATERIALS AND ASSUME ANY RISKS ASSOCIATED WITH YOUR USE OF THE LLAMA MATERIALS AND ANY OUTPUT AND RESULTS.
+
+4. Limitation of Liability. IN NO EVENT WILL META OR ITS AFFILIATES BE LIABLE UNDER ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, TORT, NEGLIGENCE, PRODUCTS LIABILITY, OR OTHERWISE, ARISING OUT OF THIS AGREEMENT, FOR ANY LOST PROFITS OR ANY INDIRECT, SPECIAL, CONSEQUENTIAL, INCIDENTAL, EXEMPLARY OR PUNITIVE DAMAGES, EVEN IF META OR ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF ANY OF THE FOREGOING.
+ 
+5. Intellectual Property.
+
+    a. No trademark licenses are granted under this Agreement, and in connection with the Llama Materials, neither Meta nor Licensee may use any name or mark owned by or associated with the other or any of its affiliates, except as required for reasonable and customary use in describing and redistributing the Llama Materials or as set forth in this Section 5(a). Meta hereby grants you a license to use “Llama” (the “Mark”) solely as required to comply with the last sentence of Section 1.b.i. You will comply with Meta’s brand guidelines (currently accessible at https://about.meta.com/brand/resources/meta/company-brand/). All goodwill arising out of your use of the Mark will inure to the benefit of Meta.
+
+    b. Subject to Meta’s ownership of Llama Materials and derivatives made by or for Meta, with respect to any derivative works and modifications of the Llama Materials that are made by you, as between you and Meta, you are and will be the owner of such derivative works and modifications.
+
+    c. If you institute litigation or other proceedings against Meta or any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Llama Materials or Llama 3.1 outputs or results, or any portion of any of the foregoing, constitutes infringement of intellectual property or other rights owned or licensable by you, then any licenses granted to you under this Agreement shall terminate as of the date such litigation or claim is filed or instituted. You will indemnify and hold harmless Meta from and against any claim by any third party arising out of or related to your use or distribution of the Llama Materials.
+
+6. Term and Termination. The term of this Agreement will commence upon your acceptance of this Agreement or access to the Llama Materials and will continue in full force and effect until terminated in accordance with the terms and conditions herein. Meta may terminate this Agreement if you are in breach of any term or condition of this Agreement. Upon termination of this Agreement, you shall delete and cease use of the Llama Materials. Sections 3, 4 and 7 shall survive the termination of this Agreement. 
+
+7. Governing Law and Jurisdiction. This Agreement will be governed and construed under the laws of the State of California without regard to choice of law principles, and the UN Convention on Contracts for the International Sale of Goods does not apply to this Agreement. The courts of California shall have exclusive jurisdiction of any dispute arising out of this Agreement.

--- a/src/licensedcode/data/licenses/net-snmp.LICENSE
+++ b/src/licensedcode/data/licenses/net-snmp.LICENSE
@@ -5,8 +5,10 @@ name: Net SNMP License
 category: Permissive
 owner: Net-SNMP
 homepage_url: http://net-snmp.sourceforge.net/about/license.html
-notes: composite
-spdx_license_key: Net-SNMP
+notes: composite, this was deprecated in SPDX License List 3.25
+spdx_license_key: LicenseRef-scancode-net-snmp
+other_spdx_license_keys:
+    - Net-SNMP
 minimum_coverage: 70
 ignorable_copyrights:
     - Copyright (c) 2001-2003, Networks Associates Technology, Inc

--- a/src/licensedcode/data/licenses/otnla-2016-11-30.LICENSE
+++ b/src/licensedcode/data/licenses/otnla-2016-11-30.LICENSE
@@ -1,0 +1,111 @@
+---
+key: otnla-2016-11-30
+short_name: OTNLA 2016-11-30
+name: Oracle Technology Network License Agreement 2016-11-30
+category: Proprietary Free
+owner: Oracle Corporation
+homepage_url: https://www.oracle.com/downloads/licenses/distribution-license.html
+spdx_license_key: LicenseRef-scancode-otnla-2016-11-30
+other_urls:
+    - https://www.infoworld.com/article/3478122/get-ready-for-more-java-licensing-changes.html
+ignorable_urls:
+    - http://docs.oracle.com/en
+    - http://www.oracle.com/goto/opensourcecode
+    - http://www.oracle.com/legal/privacy/privacy-policy.html
+    - https://oss.oracle.com/sources/
+---
+
+Oracle Technology Network License Agreement
+
+Oracle is willing to authorize Your access to software associated with this License Agreement (“Agreement”) only upon the condition that You accept that this Agreement governs Your use of the software. By selecting the “Accept License Agreement” button or box (or the equivalent) or installing or using the Programs You indicate Your acceptance of this Agreement and Your agreement, as an authorized representative of Your company or organization (if being acquired for use by an entity) or as an individual, to comply with the license terms that apply to the software that You wish to download and access. If You are not willing to be bound by this Agreement, do not select the “Accept License Agreement” button or box (or the equivalent) and do not download or access the software.
+
+Definitions
+
+"Oracle" refers to Oracle America, Inc. "You" and "Your" refers to (a) a company or organization (each an “Entity”) accessing the Programs, if use of the Programs will be on behalf of such Entity; or (b) an individual accessing the Programs, if use of the Programs will not be on behalf of an Entity. “Contractors” refers to Your agents and contractors (including, without limitation, outsourcers). "Program(s)" refers to Oracle software provided by Oracle pursuant to this Agreement and any updates, error corrections, and/or Program Documentation provided by Oracle. “Program Documentation” refers to Program user manuals and Program installation manuals, if any. If available, Program Documentation may be delivered with the Programs and/or may be accessed from http://docs.oracle.com/en/. “Associated Product” refers to the Oracle product(s), if any, and as identified in the Programs documentation or on the Programs download site, with which the Programs are intended to enable or enhance interoperation with Your application(s). “Separate Terms” refers to separate license terms that are specified in the Program Documentation, readmes or notice files and that apply to Separately Licensed Third Party Technology. “Separately Licensed Third Party Technology” refers to third party technology that is licensed under Separate Terms and not under the terms of this Agreement.
+
+License Rights and Restrictions
+
+Oracle grants You a nonexclusive, nontransferable, limited license to, subject to the restrictions stated in this Agreement, (a) internally use the Programs solely for the purposes of developing, testing, prototyping and demonstrating Your applications, and running the Programs for Your own internal business operations; and (b) redistribute unmodified Programs and Programs Documentation pursuant to the Programs Redistribution section below. You may allow Your Contractor(s) to use the Programs, provided they are acting on Your behalf to exercise license rights granted in this Agreement and further provided that You are responsible for their compliance with this Agreement in such use. You will have a written agreement with Your Contractor(s) that strictly limits their right to use the Programs and that otherwise protects Oracle’s intellectual property rights to the same extent as this Agreement. You may make copies of the Programs to the extent reasonably necessary to exercise the license rights granted in this Agreement. You may make one copy of the Programs for backup purposes.
+
+Further, You may not:
+
+    remove or modify any Program markings or any notice of Oracle’s or a licensor’s proprietary rights;
+    use the Programs to provide third party training unless Oracle expressly authorizes such use on the Program’s download page;
+    assign this Agreement or distribute, give, or transfer the Programs or an interest in them to any third party, except as expressly permitted in this Agreement (the foregoing shall not be construed to limit the rights You may otherwise have with respect to Separately Licensed Third Party Technology);
+    cause or permit reverse engineering (unless required by law for interoperability), disassembly or decompilation of the Programs; and
+    disclose results of any Program benchmark tests without Oracle’s prior consent.
+
+The Programs may contain source code that, unless expressly licensed in this Agreement for other purposes (for example, licensed under an open source license), is provided solely for reference purposes pursuant to the terms of this Agreement and may not be modified.
+
+All rights not expressly granted in this Agreement are reserved by Oracle. If You want to use the Programs or Your application for any purpose other than as expressly permitted under this Agreement, You must obtain from Oracle or an Oracle reseller a valid Programs license under a separate agreement permitting such use. However, You acknowledge that the Programs may not be intended for production use and/or Oracle may not make a version of the Programs available for production or other purposes; any development or other work You undertake with the Programs is at Your sole risk.
+
+Programs Redistribution
+
+We grant You a nonexclusive, nontransferable right to copy and distribute unmodified Programs and Programs Documentation as part of and included in Your application that is intended to interoperate with the Associated Product, if any, provided that You do not charge Your end users any additional fees for the use of the Programs. Prior to distributing the Programs and Programs Documentation, You shall require Your end users to execute an agreement binding them to terms, with respect to the Programs and Programs Documentation, materially consistent and no less restrictive than those contained in this section and the sections of this Agreement entitled “License Rights and Restrictions” (except that the redistribution right granted to You shall not be included; Your end users may not distribute Programs and Programs Documentation to any third parties), "Ownership," "Export Controls," "Disclaimer of Warranties; Limitation of Liability," "No Technical Support" (with respect to Oracle support; You may provide Your own support for Programs at Your discretion), "Audit; Termination (except that Oracle’s audit right shall not be included)," "Relationship Between the Parties," and “U.S. Government End Users.” You must also include a provision stating that Your end users shall have no right to distribute the Programs and Programs Documentation, and a provision specifying us as a third party beneficiary of the agreement. You are responsible for obtaining these agreements with Your end users.
+
+You agree to: (a) defend and indemnify us against all claims and damages caused by Your distribution of the Programs and Programs Documentation in breach of this Agreement and/or failure to include the required contractual provisions in Your end user agreement as stated above; (b) keep executed end user agreements and records of end user information including name, address, date of distribution and identity of Programs distributed; (c) allow us to inspect Your end user agreements and records upon request; and, (d) enforce the terms of Your end user agreements so as to effect a timely cure of any end user breach, and to notify us of any breach of the terms.
+
+Ownership
+
+Oracle or its licensors retain all ownership and intellectual property rights to the Programs.
+
+Third-Party Technology
+
+The Programs may contain or require the use of third party technology that is provided with the Programs. Oracle may provide certain notices to You in Program Documentation, readmes or notice files in connection with such third party technology. Third party technology will be licensed to You either under the terms of this Agreement or, if specified in the Program Documentation, readmes or notice files, under Separate Terms. Your rights to use Separately Licensed Third Party Technology under Separate Terms are not restricted in any way by this Agreement. However, for clarity, notwithstanding the existence of a notice, third party technology that is not Separately Licensed Third Party Technology shall be deemed part of the Programs and is licensed to You under the terms of this Agreement.
+
+Source Code for Open Source Software
+
+For software that You receive from Oracle in binary form that is licensed under an open source license that gives You the right to receive the source code for that binary, You can obtain a copy of the applicable source code from https://oss.oracle.com/sources/ or http://www.oracle.com/goto/opensourcecode. If the source code for such software was not provided to You with the binary, You can also receive a copy of the source code on physical media by submitting a written request pursuant to the instructions in the "Written Offer for Source Code" section of the latter website.
+
+Export Controls
+
+Export laws and regulations of the United States and any other relevant local export laws and regulations apply to the Programs . You agree that such export control laws govern Your use of the Programs (including technical data) and any services deliverables provided under this agreement, and You agree to comply with all such export laws and regulations (including "deemed export" and "deemed re-export" regulations). You agree that no data, information, program and/or materials resulting from Programs or services (or direct products thereof) will be exported, directly or indirectly, in violation of these laws, or will be used for any purpose prohibited by these laws including, without limitation, nuclear, chemical, or biological weapons proliferation, or development of missile technology. Accordingly, You confirm:
+
+    You will not download, provide, make available or otherwise export or re-export the Programs, directly or indirectly, to countries prohibited by applicable laws and regulations nor to citizens, nationals or residents of those countries.
+    You are not listed on the United States Department of Treasury lists of Specially Designated Nationals and Blocked Persons, Specially Designated Terrorists, and Specially Designated Narcotic Traffickers, nor are You listed on the United States Department of Commerce Table of Denial Orders.
+    You will not download or otherwise export or re-export the Programs, directly or indirectly, to persons on the above mentioned lists.
+    You will not use the Programs for, and will not allow the Programs to be used for, any purposes prohibited by applicable law, including, without limitation, for the development, design, manufacture or production of nuclear, chemical or biological weapons of mass destruction.
+
+Information Collection
+
+The Programs’ installation and/or auto-update processes, if any, may transmit a limited amount of data to Oracle or its service provider about those processes to help Oracle understand and optimize them. Oracle does not associate the data with personally identifiable information. Refer to Oracle’s Privacy Policy at http://www.oracle.com/legal/privacy/privacy-policy.html.
+
+Disclaimer of Warranties; Limitation of Liability
+
+THE PROGRAMS ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. ORACLE FURTHER DISCLAIMS ALL WARRANTIES, EXPRESS AND IMPLIED, INCLUDING WITHOUT LIMITATION, ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NONINFRINGEMENT .
+
+IN NO EVENT WILL ORACLE BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, OR DAMAGES FOR LOSS OF PROFITS, REVENUE, DATA OR DATA USE, INCURRED BY YOU OR ANY THIRD PARTY, WHETHER IN AN ACTION IN CONTRACT OR TORT, EVEN IF ORACLE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. ORACLE’S ENTIRE LIABILITY FOR DAMAGES UNDER THIS AGREEMENT SHALL IN NO EVENT EXCEED ONE THOUSAND DOLLARS (U.S. $1,000) .
+
+No Technical Support
+
+Unless Oracle support for the Programs, if any, is expressly included in a separate, current support agreement between You and Oracle, Oracle’s technical support organization will not provide technical support, phone support, or updates to You for the Programs provided under this Agreement.
+
+Audit; Termination
+
+Oracle may audit Your use of the Programs. You may terminate this Agreement by destroying all copies of the Programs. This Agreement shall automatically terminate without notice if You fail to comply with any of the terms of this Agreement, in which case You shall promptly destroy all copies of the Programs.
+
+U.S. Government End Users
+
+Programs and/or Programs Documentation delivered to U.S. Government end users are “commercial computer software” pursuant to the applicable Federal Acquisition Regulation and agency-specific supplemental regulations. As such, use, duplication, disclosure, modification, and adaptation of the Programs and/or Programs Documentation shall be subject to the license terms and license restrictions set forth in this Agreement. No other rights are granted to the U.S. Government.
+
+Relationship Between the Parties
+
+Oracle is an independent contractor and we agree that no partnership, joint venture, or agency relationship exists between us. We each will be responsible for paying our own employees, including employment related taxes and insurance.. Nothing in this agreement shall be construed to limit either party's right to independently develop or distribute software that is functionally similar to the other party's products, so long as proprietary information of the other party is not included in such software.
+
+Entire Agreement; Governing Law
+
+You agree that this Agreement is the complete agreement for the Programs and this Agreement supersedes all prior or contemporaneous agreements or representations, including any clickwrap, shrinkwrap or similar licenses, or license agreements for prior versions of the Programs. This Agreement may not be modified and the rights and restrictions may not be altered or waived except in a writing signed by authorized representatives of You and of Oracle. If any term of this Agreement is found to be invalid or unenforceable, the remaining provisions will remain effective.
+
+This Agreement is governed by the substantive and procedural laws of the State of California, USA, and You and Oracle agree to submit to the exclusive jurisdiction of, and venue in, the courts of San Francisco or Santa Clara counties in California in any dispute arising out of or relating to this Agreement.
+
+Notices
+
+Should you have any questions concerning this License Agreement, or if you desire to contact Oracle for any reason, please write:
+
+    Oracle America, Inc.
+    500 Oracle Parkway
+    Redwood City, CA 94065
+
+Oracle Employees: Under no circumstances are Oracle Employees authorized to download software for the purpose of distributing it to customers. Oracle products are available to employees for internal use or demonstration purposes only. In keeping with Oracle's trade compliance obligations under U.S. and applicable multilateral law, failure to comply with this policy could result in disciplinary action up to and including termination.
+
+Last updated: 30 November 2016

--- a/src/licensedcode/data/licenses/rsalv2.LICENSE
+++ b/src/licensedcode/data/licenses/rsalv2.LICENSE
@@ -6,6 +6,7 @@ category: Source-available
 owner: Redis
 homepage_url: https://redis.com/legal/rsalv2-agreement/
 spdx_license_key: LicenseRef-scancode-rsalv2
+faq_url: https://redis.com/blog/redis-adopts-dual-source-available-licensing/
 other_urls:
     - https://redis.com/blog/redis-adopts-dual-source-available-licensing/
 ---

--- a/src/licensedcode/data/licenses/ruby-pty.LICENSE
+++ b/src/licensedcode/data/licenses/ruby-pty.LICENSE
@@ -1,0 +1,21 @@
+---
+key: ruby-pty
+short_name: Ruby pty extension license
+name: Ruby pty extension license
+category: Permissive
+owner: Ruby
+spdx_license_key: Ruby-pty
+other_urls:
+    - https://github.com/ruby/ruby/blob/9f6deaa6888a423720b4b127b5314f0ad26cc2e6/ext/pty/pty.c#L775-L786
+    - https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-ef5fa30838d6d0cecad9e675cc50b24628cfe2cb277c346053fafcc36c91c204
+    - https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-fedf217c1ce44bda01f0a678d3ff8b198bed478754d699c527a698ad933979a0
+---
+
+This software may be redistributed freely for this purpose, in full
+or in part, provided that this entire copyright notice is included
+on any copies of this software and applications and derivations thereof.
+
+This software is provided on an "as is" basis, without warranty of any
+kind, either expressed or implied, as to any matter including, but not
+limited to warranty of fitness of purpose, or merchantability, or
+results obtained from use of this software.

--- a/src/licensedcode/data/licenses/ubuntu-font-1.0.LICENSE
+++ b/src/licensedcode/data/licenses/ubuntu-font-1.0.LICENSE
@@ -5,13 +5,17 @@ name: Ubuntu Font Licence v1.0
 category: Copyleft Limited
 owner: Ubuntu Font Family
 homepage_url: http://font.ubuntu.com/licence/
-spdx_license_key: LicenseRef-scancode-ubuntu-font-1.0
+spdx_license_key: Ubuntu-font-1.0
+other_spdx_license_keys:
+    - LicenseRef-scancode-ubuntu-font-1.0
 text_urls:
     - https://assets.ubuntu.com/v1/81e5605d-ubuntu-font-licence-1.0.txt
 faq_url: https://www.ubuntu.com/legal/font-licence
 other_urls:
-    - https://launchpad.net/ubuntu-font-licence
     - https://design.ubuntu.com/font/
+    - https://launchpad.net/ubuntu-font-licence
+    - https://ubuntu.com/legal/font-licence
+    - https://assets.ubuntu.com/v1/81e5605d-ubuntu-font-licence-1.0.txt
 standard_notice: |
     This Font Software is licensed under the Ubuntu Font Licence, Version
     1.0.  https://launchpad.net/ubuntu-font-licence

--- a/src/licensedcode/data/licenses/x11-swapped.LICENSE
+++ b/src/licensedcode/data/licenses/x11-swapped.LICENSE
@@ -3,7 +3,7 @@ key: x11-swapped
 short_name: X11 swapped final paragraphs
 name: X11 swapped final paragraphs
 category: Permissive
-owner: Unspecified
+owner: Derick Eddington
 notes: |
     Added in SPDX license list 3.25
     This was previously the license rule: x11-xconsortium_37.RULE

--- a/src/licensedcode/data/licenses/x11-swapped.LICENSE
+++ b/src/licensedcode/data/licenses/x11-swapped.LICENSE
@@ -1,0 +1,37 @@
+---
+key: x11-swapped
+short_name: X11 swapped final paragraphs
+name: X11 swapped final paragraphs
+category: Permissive
+owner: Unspecified
+notes: |
+    Added in SPDX license list 3.25
+    This was previously the license rule: x11-xconsortium_37.RULE
+    The no advert paragraph has its position switched with the warranty disclaimer in this variant.
+    The texts are otherwise essentially the same See https://github.com/achillean/shodan-python/blob/90491308971a7ba6e358d6152d7b02307964c6fe/LICENSE
+spdx_license_key: X11-swapped
+other_urls:
+    - https://github.com/fedeinthemix/chez-srfi/blob/master/srfi/LICENSE
+---
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+Except as contained in this notice, the name(s) of the above copyright
+holders shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in this Software without prior written authorization.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/src/licensedcode/data/rules/agpl-3.0-plus_298.RULE
+++ b/src/licensedcode/data/rules/agpl-3.0-plus_298.RULE
@@ -1,10 +1,8 @@
 ---
-license_expression: agpl-3.0-plus OR commercial-license
+license_expression: agpl-3.0-plus
 is_license_notice: yes
-relevance: 100
 ignorable_urls:
     - https://www.gnu.org/licenses/
-is_deprecated: yes
 ---
 
 This program is free software: you can redistribute it and/or modify it under

--- a/src/licensedcode/data/rules/agpl-3.0-plus_299.RULE
+++ b/src/licensedcode/data/rules/agpl-3.0-plus_299.RULE
@@ -1,10 +1,8 @@
 ---
-license_expression: agpl-3.0-plus OR commercial-license
+license_expression: agpl-3.0-plus
 is_license_notice: yes
-relevance: 100
 ignorable_urls:
-    - https://www.gnu.org/licenses/
-is_deprecated: yes
+    - http://www.gnu.org/licenses/
 ---
 
 This program is free software: you can redistribute it and/or modify it under
@@ -17,4 +15,4 @@ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU Affero General Public License along
-with this program. If not, see <https://www.gnu.org/licenses/>.
+with this program. If not, see <http://www.gnu.org/licenses/>.

--- a/src/licensedcode/data/rules/agpl-3.0-plus_or_commercial-license_4.RULE
+++ b/src/licensedcode/data/rules/agpl-3.0-plus_or_commercial-license_4.RULE
@@ -4,6 +4,7 @@ is_license_notice: yes
 relevance: 100
 ignorable_urls:
     - http://www.gnu.org/licenses/
+is_deprecated: yes
 ---
 
 This program is free software: you can redistribute it and/or modify it under

--- a/src/licensedcode/data/rules/agpl-3.0-plus_with_erlang-otp-linking-exception_1.RULE
+++ b/src/licensedcode/data/rules/agpl-3.0-plus_with_erlang-otp-linking-exception_1.RULE
@@ -1,0 +1,36 @@
+---
+license_expression: agpl-3.0-plus WITH erlang-otp-linking-exception
+is_license_text: yes
+minimum_coverage: 90
+ignorable_urls:
+    - http://www.erlang.org/
+    - http://www.erlang.org/EPLICENSE
+    - http://www.gnu.org/licenses/
+---
+
+%% This program is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU Affero General Public License as
+%% published by the Free Software Foundation; either version 3 of the
+%% License, or (at your option) any later version.
+%%
+%% This program is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%% GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU Affero General Public License
+%% along with this program.  If not, see <http://www.gnu.org/licenses/>.
+%%
+%% Additional Permission under GNU AGPL version 3 section 7:
+%%
+%% If you modify this Program, or any covered work, by linking or
+%% combining it with runtime libraries of Erlang/OTP as released by
+%% Ericsson on http://www.erlang.org (or a modified version of these
+%% libraries), containing parts covered by the terms of the Erlang Public
+%% License (http://www.erlang.org/EPLICENSE), the licensors of this
+%% Program grant you additional permission to convey the resulting work
+%% without the need to license the runtime libraries of Erlang/OTP under
+%% the GNU Affero General Public License. Corresponding Source for a
+%% non-source form of such a combination shall include the source code
+%% for the parts of the runtime libraries of Erlang/OTP used as well as
+%% that of the covered work.

--- a/src/licensedcode/data/rules/x11-xconsortium_37.RULE
+++ b/src/licensedcode/data/rules/x11-xconsortium_37.RULE
@@ -1,9 +1,11 @@
 ---
 license_expression: x11-xconsortium
 is_license_text: yes
+is_deprecated: yes
 relevance: 99
-notes: the no advert paragraph has its position switched with the warranty disclaimer in this
-    variant. The texts are otherwise essentially the same See https://github.com/achillean/shodan-python/blob/90491308971a7ba6e358d6152d7b02307964c6fe/LICENSE
+notes: |
+    Added in SPDX license list 3.25
+    Replaced by license: x11-swapped
 ---
 
 Permission is hereby granted, free of charge, to any person

--- a/src/scancode_config.py
+++ b/src/scancode_config.py
@@ -143,8 +143,9 @@ __release_date__ = datetime.datetime(2024, 7, 2)
 # on the data format version
 __output_format_version__ = '3.2.0'
 
-#
-spdx_license_list_version = '3.24'
+# see https://github.com/spdx/tools-python/issues/820
+# this is actually `3.25.0`
+spdx_license_list_version = '3.25'
 
 ################################################################################
 # USAGE MODE-, INSTALLATION- and IMPORT- and RUN-SPECIFIC DIRECTORIES

--- a/tests/formattedcode/data/spdx/license_known/expected.rdf
+++ b/tests/formattedcode/data/spdx/license_known/expected.rdf
@@ -94,7 +94,7 @@
         "@rdf:resource": "http://spdx.org/licenses/CC0-1.0"
       },
       "@rdf:about": "#SPDXRef-DOCUMENT",
-      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.24",
+      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.25",
       "spdx:name": "SPDX Document created by ScanCode Toolkit",
       "spdx:specVersion": "SPDX-2.2"
     },

--- a/tests/formattedcode/data/spdx/license_known/expected.tv
+++ b/tests/formattedcode/data/spdx/license_known/expected.tv
@@ -10,7 +10,7 @@ ScanCode should be considered or used as legal advice. Consult an Attorney
 for any legal advice.
 ScanCode is a free software code scanning tool from nexB Inc. and others.
 Visit https://github.com/nexB/scancode-toolkit/ for support and download.
-SPDX License List: 3.24</text>
+SPDX License List: 3.25</text>
 ## Creation Information
 ## Package Information
 PackageName: scan

--- a/tests/formattedcode/data/spdx/license_known/expected_with_text.rdf
+++ b/tests/formattedcode/data/spdx/license_known/expected_with_text.rdf
@@ -94,7 +94,7 @@
         "@rdf:resource": "http://spdx.org/licenses/CC0-1.0"
       },
       "@rdf:about": "#SPDXRef-DOCUMENT",
-      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.24",
+      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.25",
       "spdx:name": "SPDX Document created by ScanCode Toolkit",
       "spdx:specVersion": "SPDX-2.2"
     },

--- a/tests/formattedcode/data/spdx/license_known/expected_with_text.tv
+++ b/tests/formattedcode/data/spdx/license_known/expected_with_text.tv
@@ -10,7 +10,7 @@ ScanCode should be considered or used as legal advice. Consult an Attorney
 for any legal advice.
 ScanCode is a free software code scanning tool from nexB Inc. and others.
 Visit https://github.com/nexB/scancode-toolkit/ for support and download.
-SPDX License List: 3.24</text>
+SPDX License List: 3.25</text>
 ## Creation Information
 ## Package Information
 PackageName: scan

--- a/tests/formattedcode/data/spdx/license_ref/expected.rdf
+++ b/tests/formattedcode/data/spdx/license_ref/expected.rdf
@@ -116,7 +116,7 @@
           }
         }
       ],
-      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.24",
+      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.25",
       "spdx:name": "SPDX Document created by ScanCode Toolkit",
       "spdx:specVersion": "SPDX-2.2"
     },

--- a/tests/formattedcode/data/spdx/license_ref/expected.tv
+++ b/tests/formattedcode/data/spdx/license_ref/expected.tv
@@ -10,7 +10,7 @@ ScanCode should be considered or used as legal advice. Consult an Attorney
 for any legal advice.
 ScanCode is a free software code scanning tool from nexB Inc. and others.
 Visit https://github.com/nexB/scancode-toolkit/ for support and download.
-SPDX License List: 3.24</text>
+SPDX License List: 3.25</text>
 ## Creation Information
 ## Package Information
 PackageName: scan

--- a/tests/formattedcode/data/spdx/license_ref/expected_with_text.rdf
+++ b/tests/formattedcode/data/spdx/license_ref/expected_with_text.rdf
@@ -116,7 +116,7 @@
           }
         }
       ],
-      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.24",
+      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.25",
       "spdx:name": "SPDX Document created by ScanCode Toolkit",
       "spdx:specVersion": "SPDX-2.2"
     },

--- a/tests/formattedcode/data/spdx/license_ref/expected_with_text.tv
+++ b/tests/formattedcode/data/spdx/license_ref/expected_with_text.tv
@@ -10,7 +10,7 @@ ScanCode should be considered or used as legal advice. Consult an Attorney
 for any legal advice.
 ScanCode is a free software code scanning tool from nexB Inc. and others.
 Visit https://github.com/nexB/scancode-toolkit/ for support and download.
-SPDX License List: 3.24</text>
+SPDX License List: 3.25</text>
 ## Creation Information
 ## Package Information
 PackageName: scan

--- a/tests/formattedcode/data/spdx/or_later/expected.rdf
+++ b/tests/formattedcode/data/spdx/or_later/expected.rdf
@@ -59,7 +59,7 @@
         "@rdf:resource": "http://spdx.org/licenses/CC0-1.0"
       },
       "@rdf:about": "#SPDXRef-DOCUMENT",
-      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.24",
+      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.25",
       "spdx:name": "SPDX Document created by ScanCode Toolkit",
       "spdx:specVersion": "SPDX-2.2"
     },

--- a/tests/formattedcode/data/spdx/simple/expected.rdf
+++ b/tests/formattedcode/data/spdx/simple/expected.rdf
@@ -59,7 +59,7 @@
         "@rdf:resource": "http://spdx.org/licenses/CC0-1.0"
       },
       "@rdf:about": "#SPDXRef-DOCUMENT",
-      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.24",
+      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.25",
       "spdx:name": "SPDX Document created by ScanCode Toolkit",
       "spdx:specVersion": "SPDX-2.2"
     },

--- a/tests/formattedcode/data/spdx/simple/expected.tv
+++ b/tests/formattedcode/data/spdx/simple/expected.tv
@@ -10,7 +10,7 @@ ScanCode should be considered or used as legal advice. Consult an Attorney
 for any legal advice.
 ScanCode is a free software code scanning tool from nexB Inc. and others.
 Visit https://github.com/nexB/scancode-toolkit/ for support and download.
-SPDX License List: 3.24</text>
+SPDX License List: 3.25</text>
 ## Creation Information
 ## Package Information
 PackageName: simple

--- a/tests/formattedcode/data/spdx/tree/expected.rdf
+++ b/tests/formattedcode/data/spdx/tree/expected.rdf
@@ -229,7 +229,7 @@
         "@rdf:resource": "http://spdx.org/licenses/CC0-1.0"
       },
       "@rdf:about": "#SPDXRef-DOCUMENT",
-      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.24",
+      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.25",
       "spdx:name": "SPDX Document created by ScanCode Toolkit",
       "spdx:specVersion": "SPDX-2.2"
     },

--- a/tests/formattedcode/data/spdx/tree/expected.tv
+++ b/tests/formattedcode/data/spdx/tree/expected.tv
@@ -10,7 +10,7 @@ ScanCode should be considered or used as legal advice. Consult an Attorney
 for any legal advice.
 ScanCode is a free software code scanning tool from nexB Inc. and others.
 Visit https://github.com/nexB/scancode-toolkit/ for support and download.
-SPDX License List: 3.24</text>
+SPDX License List: 3.25</text>
 ## Creation Information
 ## Package Information
 PackageName: scan

--- a/tests/formattedcode/data/spdx/unicode/expected.rdf
+++ b/tests/formattedcode/data/spdx/unicode/expected.rdf
@@ -68,7 +68,7 @@
           "rdfs:comment": "See details at https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/agere-bsd.LICENSE"
         }
       },
-      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.24",
+      "rdfs:comment": "Generated with ScanCode and provided on an \"AS IS\" BASIS, WITHOUT WARRANTIES\nOR CONDITIONS OF ANY KIND, either express or implied. No content created from\nScanCode should be considered or used as legal advice. Consult an Attorney\nfor any legal advice.\nScanCode is a free software code scanning tool from nexB Inc. and others.\nVisit https://github.com/nexB/scancode-toolkit/ for support and download.\nSPDX License List: 3.25",
       "spdx:name": "SPDX Document created by ScanCode Toolkit",
       "spdx:specVersion": "SPDX-2.2"
     },

--- a/tests/formattedcode/data/spdx/unicode/expected.tv
+++ b/tests/formattedcode/data/spdx/unicode/expected.tv
@@ -10,7 +10,7 @@ ScanCode should be considered or used as legal advice. Consult an Attorney
 for any legal advice.
 ScanCode is a free software code scanning tool from nexB Inc. and others.
 Visit https://github.com/nexB/scancode-toolkit/ for support and download.
-SPDX License List: 3.24</text>
+SPDX License List: 3.25</text>
 ## Creation Information
 ## Package Information
 PackageName: unicode

--- a/tests/licensedcode/data/datadriven/external/glc/MIT-NoAd.t1.yml
+++ b/tests/licensedcode/data/datadriven/external/glc/MIT-NoAd.t1.yml
@@ -1,5 +1,5 @@
 license_expressions:
-  - x11-xconsortium
+  - x11-swapped
 notes: |
   License test derived from a file of the BSD-licensed repository at:
   https://raw.githubusercontent.com/google/licensecheck/v0.3.1/testdata/MIT-NoAd.t1


### PR DESCRIPTION
Synchronizes with SPDX License List 3.25.0, and also adds other licenses added by @DennisClark 

This release of the SPDX license list had:
* 9 new licenses and exceptions
   * 5 were present as licenses
   * 2 were present as rules
   * 2 new license/exception texts added
* 1 license was deprecated.

Reference: https://github.com/aboutcode-org/scancode-toolkit/issues/3896

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable)
