### PR TITLE
3955 update dockerfile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,9 @@ v33.0.0 (next next, roadmap)
   of these in other summary plugins.
   See https://github.com/nexB/scancode-toolkit/issues/1745
 
+- Update Dockerfile and test container build.
+  See https://github.com/aboutcode-org/scancode-toolkit/issues/3955
+
 v32.3.0 - 2024-10-21
 --------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # See https://aboutcode.org for more information about nexB OSS projects.
 #
 
-FROM --platform=linux/amd64 python:3.12.7-slim-bookworm
+FROM --platform=linux/amd64 python:3.12-slim-bookworm
 
 # Python settings: Force unbuffered stdout and stderr (i.e. they are flushed to terminal immediately)
 ENV PYTHONUNBUFFERED 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # See https://aboutcode.org for more information about nexB OSS projects.
 #
 
-FROM --platform=linux/amd64 python:3.8-slim-buster
+FROM --platform=linux/amd64 python:3.12.7-slim-bookworm
 
 # Python settings: Force unbuffered stdout and stderr (i.e. they are flushed to terminal immediately)
 ENV PYTHONUNBUFFERED 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,11 +203,11 @@ jobs:
           python_architecture: x64
           test_suites:
               click_versions: |
-                for clk_ver in 8.1.3 8.1.2 8.1.1 8.1.0 8.0.4 8.0.3 8.0.2 8.0.1 7.1.2 7.1.1 7.1 6.7; 
+                for clk_ver in 8.1.3 8.1.2 8.1.1 8.1.0 8.0.4 8.0.3 8.0.2 8.0.1 7.1.2 7.1.1 7.1 6.7;
                  do
                   venv/bin/pip install click==$clk_ver;
-                  venv/bin/scancode -i samples/ -n3 --json foo.json; 
-                  venv/bin/scancode -i --verbose samples/ -n3 --json foo.json; 
+                  venv/bin/scancode -i samples/ -n3 --json foo.json;
+                  venv/bin/scancode -i --verbose samples/ -n3 --json foo.json;
                  done
 
 
@@ -230,7 +230,7 @@ jobs:
           python_versions: ['3.9', '3.10', '3.11', '3.12']
           test_suites:
               all: venv/bin/pip install --upgrade-strategy eager --force-reinstall --upgrade -e .[testing] && venv/bin/pytest -n 2 -vvs tests/scancode/test_cli.py
-  
+
     - template: etc/ci/azure-posix.yml
       parameters:
           job_name: macos12_cpython_latest_from_pip
@@ -263,3 +263,12 @@ jobs:
           test_suites:
               all: venv\Scripts\pip install --upgrade-strategy eager --force-reinstall --upgrade -e .[testing] &&  venv\Scripts\pytest -n 2 -vvs  tests\scancode\test_cli.py
 
+
+################################################################################
+# Test container build
+################################################################################
+
+    - template: etc/ci/azure-posix-docker.yml
+      parameters:
+          job_name: ubuntu22_build_container
+          image_name: ubuntu-22.04

--- a/etc/ci/azure-posix-docker.yml
+++ b/etc/ci/azure-posix-docker.yml
@@ -1,0 +1,33 @@
+parameters:
+    job_name: ''
+    image_name: ''
+    python_versions: []
+    test_suites: {}
+    python_architecture: x64
+
+jobs:
+    - job: ${{ parameters.job_name }}
+
+      pool:
+          vmImage: ${{ parameters.image_name }}
+
+      strategy:
+          matrix:
+              ${{ each tsuite in parameters.test_suites }}:
+                 ${{ tsuite.key }}:
+                     test_suite_label: ${{ tsuite.key }}
+                     test_suite: ${{ tsuite.value }}
+
+      steps:
+          - checkout: self
+            fetchDepth: 10
+
+          - task: Docker@2
+            inputs:
+                command: 'build'
+                Dockerfile: '**/Dockerfile'
+                arguments: '-t scancode'
+            displayName: 'Build scancode-toolkit container'
+
+          - script: |
+              docker run scancode --help

--- a/etc/ci/azure-posix-docker.yml
+++ b/etc/ci/azure-posix-docker.yml
@@ -1,22 +1,12 @@
 parameters:
     job_name: ''
     image_name: ''
-    python_versions: []
-    test_suites: {}
-    python_architecture: x64
 
 jobs:
     - job: ${{ parameters.job_name }}
 
       pool:
           vmImage: ${{ parameters.image_name }}
-
-      strategy:
-          matrix:
-              ${{ each tsuite in parameters.test_suites }}:
-                 ${{ tsuite.key }}:
-                     test_suite_label: ${{ tsuite.key }}
-                     test_suite: ${{ tsuite.value }}
 
       steps:
           - checkout: self
@@ -26,8 +16,9 @@ jobs:
             inputs:
                 command: 'build'
                 Dockerfile: '**/Dockerfile'
-                arguments: '-t scancode'
+                arguments: '--tag scancode'
             displayName: 'Build scancode-toolkit container'
 
           - script: |
-              docker run scancode --help
+                docker run scancode --help
+            displayName: 'Run scancode --help'


### PR DESCRIPTION
This PR updates the Dockerfile to use the 3.12-slim-bookworm image. Feel free to update it if scancode-toolkit now builds for Python 3.13.0. I've also created a test to run on Azure Pipelines to build the scancode-toolkit container from source and run `scancode --help`.