### PR TITLE
Update go inspector

### DIFF
--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -1,4 +1,4 @@
 packagedcode-msitools==0.101.210706
 regipy==3.1.0
 rpm-inspector-rpm==4.16.1.3.210404
-go-inspector==0.3.1
+go-inspector==0.5.0

--- a/setup-mini.cfg
+++ b/setup-mini.cfg
@@ -149,7 +149,7 @@ packages =
     rpm_inspector_rpm >= 4.16.1.3; platform_system == 'Linux'
     regipy >= 3.1.0; platform_system == 'Linux'
     packagedcode_msitools >= 0.101.210706; platform_system == 'Linux'
-    go-inspector >= 0.3.1; platform_system == 'Linux'
+    go-inspector >= 0.5.0; platform_system == 'Linux'
 
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -149,7 +149,7 @@ packages =
     rpm_inspector_rpm >= 4.16.1.3; platform_system == 'Linux'
     regipy >= 3.1.0; platform_system == 'Linux'
     packagedcode_msitools >= 0.101.210706; platform_system == 'Linux'
-    go-inspector >= 0.3.1; platform_system == 'Linux'
+    go-inspector >= 0.5.0; platform_system == 'Linux'
 
 
 [options.entry_points]

--- a/src/packagedcode/recognize.py
+++ b/src/packagedcode/recognize.py
@@ -113,3 +113,11 @@ def _parse(
 
             if TRACE:
                 raise
+
+        except Exception as e:
+            # We should continue when an Exception has occured when trying to
+            # recognize a package
+            if TRACE:
+                logger_debug(f'_parse: Exception: {str(e)}')
+
+            continue


### PR DESCRIPTION
This  PR updates go-inspector to v0.5.0 . GoReSym is now built from source and has been updated to v3.0.1.