### PR TITLE
Support for Python Private Packages Using Private : : Classifier #3968

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.12
     Topic :: Software Development
     Topic :: Utilities
+    Private :: Do Not Upload 
 
 keywords =
     open source


### PR DESCRIPTION
Fixes #3968
Changes Implemented:
Added support for the `Private :: Do Not Upload` classifier in the setup configuration.
Updated the `setup.cfg`  file to enable users to designate their packages as private using this classifier.