### PR TITLE
Fix failing --no-check-version cli option

### DIFF
--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -480,6 +480,8 @@ def scancode(
         if check_version:
             from scancode.outdated import check_scancode_version
             outdated = check_scancode_version()
+        else:
+            outdated = None
 
         # run proper
         success, _results = run_scan(

--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -121,6 +121,12 @@ def test_run_scan_includes_outdated_in_extra():
     assert results['headers'][0]['extra_data']['OUTDATED'] == 'out of date'
 
 
+def test_no_version_check_run_is_successful():
+    test_file = test_env.get_test_loc('single/iproute.c')
+    result_file = test_env.get_temp_file('json')
+    run_scan_click(['--no-check-version', test_file, '--json', result_file], expected_rc=0)
+
+
 def test_usage_and_help_return_a_correct_script_name_on_all_platforms():
     result = run_scan_click(['--help'])
     assert 'Usage: scancode [OPTIONS]' in result.output


### PR DESCRIPTION
Currently, if the --no-check-version option is used, the scan fails because an unbound variable is passed to the `run_scan` function.

Fix by assigning `None` in that case. Add a test that passes with this change and fails without it.

Fixes  #4004

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
