### PR TITLE
Fix missing spdx license expression in license detection

### DIFF
--- a/src/licensedcode/detection.py
+++ b/src/licensedcode/detection.py
@@ -1907,6 +1907,7 @@ def process_detections(detections, licensing=Licensing()):
                     for key in license_keys
                 ):
                     detection.license_expression = license_expression
+                    detection.license_expression_spdx = detection.spdx_license_expression()
                     detection.detection_log.append(DetectionRule.NOT_LICENSE_CLUES.value)
                     detection.identifier = detection.identifier_with_expression
 


### PR DESCRIPTION
**Context**

Occassionally, the spdx license expression is missing in license detections even though the license expression itself is non-null and a matching spdx expression would be available.

Should fix #4015 

**Summary**

In the post processing step clues are converted to detections under certain conditions. This entails that their license expression may be updated if it was previously `None`. In these cases, we also need to update the spdx license expression.

It seems that this fix covers at least some instances of the bug, that I know of.

**Test Plan**

Run scancode on the example from #4015 

```
scancode -l <path/to>/Amd.h  --json scancode_null_expression.json
```

The result:

```
"files": [
        {
            "path": "Amd.h",
            "type": "file",
            "detected_license_expression": "mpl-2.0",
            "detected_license_expression_spdx": "MPL-2.0",
            "license_detections": [
                {
                    "license_expression": "mpl-2.0",
                    "license_expression_spdx": "MPL-2.0",
                    "matches": [
                        {
                            "license_expression": "mpl-2.0",
                            "license_expression_spdx": "MPL-2.0",
                            "from_file": "Amd.h",
                            "start_line": 6,
                            "end_line": 8,
                            "matcher": "2-aho",
                            "score": 100.0,
                            "matched_length": 39,
                            "match_coverage": 100.0,
                            "rule_relevance": 100,
                            "rule_identifier": "mpl-2.0_3.RULE",
                            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mpl-2.0_3.RULE"
                        }
                    ],
                    "identifier": "mpl_2_0-d0113b18-ff50-a2fd-17f7-9227082156a7"
                },
                {
                    "license_expression": "mpl-2.0",
                    "license_expression_spdx": "MPL-2.0",
                    "matches": [
                        {
                            "license_expression": "mpl-2.0",
                            "license_expression_spdx": "MPL-2.0",
                            "from_file": "Amd.h",
                            "start_line": 17,
                            "end_line": 18,
                            "matcher": "3-seq",
                            "score": 50.0,
                            "matched_length": 8,
                            "match_coverage": 50.0,
                            "rule_relevance": 100,
                            "rule_identifier": "mpl-2.0_97.RULE",
                            "rule_url": "https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/mpl-2.0_97.RULE"
                        }
                    ],
                    "identifier": "mpl_2_0-31c7f2f0-eb53-75b7-e843-a9ef4eb4ddf4"
                }
            ],
            "license_clues": [],
            "percentage_of_license_text": 2.27,
            "scan_errors": []
        }
    ]
```

[scancode_null_expression.json](https://github.com/user-attachments/files/18152467/scancode_null_expression.json)


### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
