### PR TITLE
Added a validation check to raise an error if a directory is passed to the --from-json option

### DIFF
--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -181,26 +181,26 @@ def validate_input_path(ctx, param, value):
     Validate a ``value`` list of inputs path strings
     """
     options = ctx.params
-    from_json = options.get("--from-json", False)
+    from_json = options.get("from_json", False)
     for inp in value:
         if not (is_file(location=inp, follow_symlinks=True) or is_dir(location=inp, follow_symlinks=True)):
             raise click.BadParameter(f"input: {inp!r} is not a regular file or a directory")
-            
-        if is_dir(location=inp, follow_symlinks=True):
-            raise click.BadParameter(f"input: {inp!r} is a directory, expected a file")
 
         if not is_readable(location=inp):
             raise click.BadParameter(f"input: {inp!r} is not readable")
 
-        if from_json and not is_file(location=inp, follow_symlinks=True):
-            # extra JSON validation
-            raise click.BadParameter(f"JSON input: {inp!r} is not a file")
+        if from_json:
+            if is_dir(location=inp, follow_symlinks=True):
+                raise click.BadParameter("Error: Invalid value: Input JSON scan file(s) is not valid JSON")
+
             if not inp.lower().endswith(".json"):
-                raise click.BadParameter(f"JSON input: {inp!r} is not a JSON file with a .json extension")
-            with open(inp) as js:
-                start = js.read(100).strip()
-            if not start.startswith("{"):
-                raise click.BadParameter(f"JSON input: {inp!r} is not a well formed JSON file")
+                raise click.BadParameter("Error: Invalid value: Input JSON scan file(s) is not valid JSON")
+
+            try:
+                with open(inp, 'r', encoding='utf-8') as f:
+                    json.load(f)  # Try to parse the file as JSON
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                    raise click.BadParameter("Error: Invalid value: Input JSON scan file(s) is not valid JSON")
 
     return value
 

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -185,6 +185,9 @@ def validate_input_path(ctx, param, value):
     for inp in value:
         if not (is_file(location=inp, follow_symlinks=True) or is_dir(location=inp, follow_symlinks=True)):
             raise click.BadParameter(f"input: {inp!r} is not a regular file or a directory")
+            
+        if is_dir(location=inp, follow_symlinks=True):
+            raise click.BadParameter(f"input: {inp!r} is a directory, expected a file")
 
         if not is_readable(location=inp):
             raise click.BadParameter(f"input: {inp!r} is not readable")


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #3592 

When the --from-json option is used, it currently allows directories as input, resulting in a crash. This issue was initially addressed in [PR #3609](https://github.com/aboutcode-org/scancode-toolkit/pull/3609), but the fix did not fully resolve the problem. As a result, the tool continues to crash when directories are passed to --from-json.

This PR aims to resolve the issue by adding validation checks for directories.

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
