### PR TITLE
initial fuzzing support

### DIFF
--- a/fuzz/fuzz_target.py
+++ b/fuzz/fuzz_target.py
@@ -1,0 +1,25 @@
+import atheris
+import sys
+import os
+from packagedcode.debian import DebianDebPackageHandler
+from licensedcode.detection import is_correct_detection, calculate_query_coverage_coefficient
+
+def TestOneInput(data):
+    fdp = atheris.FuzzedDataProvider(data)
+    
+    # Fuzz Debian package handler
+    try:
+        DebianDebPackageHandler.parse(fdp.ConsumeBytes(len(data)))
+    except Exception:
+        pass
+    
+    # Fuzz license detection functions
+    try:
+        license_matches = fdp.ConsumeUnicodeNoSurrogates(1000)
+        is_correct_detection(license_matches)
+        calculate_query_coverage_coefficient(license_matches)
+    except Exception:
+        pass
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()


### PR DESCRIPTION
Introducing initial fuzzing support for scancode-toolkit to identify and address potential bugs. As it have so many users

Upon merging this, I will create a pull request in the [OSS-Fuzz repository](https://github.com/google/oss-fuzz) to initiate fuzzing for this library using Google's infrastructure. Any detected issues will be communicated to the maintainers of scancode-toolkit.

Could you also Please review the [OSS-Fuzz documentation](https://google.github.io/oss-fuzz/) and [Bug Disclosure Guidelines](https://google.github.io/oss-fuzz/getting-started/bug-disclosure-guidelines/) before merging.

Thanks

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
