### PR TITLE
change default value of --process to (number of CPUs)-1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,10 @@ v33.0.0 (next next, roadmap)
   license detection and reduce false positives.
   See https://github.com/nexB/scancode-toolkit/issues/3300
 
+- default value for `--processes` was previously 1. It was changed
+  to (number of CPUs)-1.
+  See https://github.com/aboutcode-org/scancode-toolkit/issues/2980
+
 - File categorization support added, a post scan plugin tagging
   files with priority levels for review, and also take advantage
   of these in other summary plugins.

--- a/docs/source/cli-reference/help-text-options.rst
+++ b/docs/source/cli-reference/help-text-options.rst
@@ -165,7 +165,7 @@ The Following Help Text is displayed, i.e. This is the help text for Scancode Ve
                               seconds. [default: 120 seconds]
       -n, --processes INT     Set the number of parallel processes to use. Disable
                               parallel processing if 0. Also disable threading if
-                              -1. [default: 1]
+                              -1. [default: (number of CPUs)-1]
       -q, --quiet             Do not print summary or progress.
       -v, --verbose           Print progress as file-by-file path instead of a
                               progress bar. Print verbose scan counters.

--- a/docs/source/rst_snippets/core_options.rst
+++ b/docs/source/rst_snippets/core_options.rst
@@ -2,7 +2,7 @@ All "Core" Scan Options
 -----------------------
 
 -n, --processes INTEGER  Scan ``<input>`` using n parallel processes.
-                         [Default: 1]
+                         [Default: (number of CPUs)-1]
 
 -v, --verbose            Print verbose file-by-file progress messages.
 

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -201,6 +201,13 @@ def validate_input_path(ctx, param, value):
 
     return value
 
+def default_processes():
+    """ return number that is used as a default value for --processes """
+    cpu_count = os.cpu_count()
+    if cpu_count > 1:
+        return cpu_count-1
+    else:
+        return 1
 
 @click.command(name='scancode',
     epilog=epilog_text,
@@ -230,10 +237,10 @@ def validate_input_path(ctx, param, value):
 
 @click.option('-n', '--processes',
     type=int,
-    default=1,
+    default=default_processes(),
     metavar='INT',
     help='Set the number of parallel processes to use. '
-         'Disable parallel processing if 0. Also disable threading if -1. [default: 1]',
+         'Disable parallel processing if 0. Also disable threading if -1. [default: (number of CPUs)-1]',
     help_group=cliutils.CORE_GROUP, sort_order=10, cls=PluggableCommandLineOption)
 
 @click.option('--timeout',

--- a/tests/scancode/data/help/help.txt
+++ b/tests/scancode/data/help/help.txt
@@ -138,7 +138,7 @@ Options:
                              seconds. [default: 120 seconds]
     -n, --processes INT      Set the number of parallel processes to use. Disable
                              parallel processing if 0. Also disable threading if
-                             -1. [default: 1]
+                             -1. [default: (number of CPUs)-1]
     -q, --quiet              Do not print summary or progress.
     -v, --verbose            Print progress as file-by-file path instead of a
                              progress bar. Print verbose scan counters.

--- a/tests/scancode/data/help/help_linux.txt
+++ b/tests/scancode/data/help/help_linux.txt
@@ -140,7 +140,7 @@ Options:
                              seconds. [default: 120 seconds]
     -n, --processes INT      Set the number of parallel processes to use. Disable
                              parallel processing if 0. Also disable threading if
-                             -1. [default: 1]
+                             -1. [default: (number of CPUs)-1]
     -q, --quiet              Do not print summary or progress.
     -v, --verbose            Print progress as file-by-file path instead of a
                              progress bar. Print verbose scan counters.


### PR DESCRIPTION
Related: #2980


### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [-] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
  Test suite fails to run for me, but the script run correctly.
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable)


