### PR TITLE
Bump commoncode to v32.2.0 and pin bs4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 attrs==23.2.0
 banal==1.0.6
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
 binaryornot==0.4.4
 beartype==0.17.2
 boolean.py==4.0
@@ -10,7 +10,7 @@ chardet==5.0.0
 charset-normalizer==2.1.0
 click==8.1.7
 colorama==0.4.5
-commoncode==32.0.0
+commoncode==32.2.0
 construct==2.10.68
 container-inspector==31.1.0
 cryptography==42.0.5

--- a/setup-mini.cfg
+++ b/setup-mini.cfg
@@ -64,12 +64,12 @@ python_requires = >=3.9
 install_requires =
     attrs >= 18.1,!=20.1.0;python_version<'3.11'
     attrs >= 22.1.0;python_version>='3.11'
-    Beautifulsoup4 >= 4.0.0
+    Beautifulsoup4[chardet] >= 4.13.0
     boolean.py >= 4.0
     chardet >= 3.0.0
     click >= 6.7, !=7.0, !=8.1.8
     colorama >= 0.3.9
-    commoncode >= 32.0.0
+    commoncode >= 32.2.0
     container-inspector >= 31.0.0
     debian-inspector >= 31.1.0
     dparse2 >= 0.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,12 +64,12 @@ python_requires = >=3.9
 install_requires =
     attrs >= 18.1,!=20.1.0;python_version<'3.11'
     attrs >= 22.1.0;python_version>='3.11'
-    Beautifulsoup4 >= 4.0.0
+    Beautifulsoup4[chardet] >= 4.13.0
     boolean.py >= 4.0
     chardet >= 3.0.0
     click >= 6.7, !=7.0, !=8.1.8
     colorama >= 0.3.9
-    commoncode >= 32.0.0
+    commoncode >= 32.2.0
     container-inspector >= 31.0.0
     debian-inspector >= 31.1.0
     dparse2 >= 0.7.0

--- a/tests/scancode/test_api.py
+++ b/tests/scancode/test_api.py
@@ -53,9 +53,9 @@ class TestAPI(FileBasedTesting):
         info = api.get_file_info(test_dir)
         expected = [
             ('size', 0),
-            ('sha1', None),
-            ('md5', None),
-            ('sha256', None),
+            ('sha1', 0),
+            ('md5', 0),
+            ('sha256', 0),
             ('mime_type', 'inode/x-empty'),
             ('file_type', 'empty'),
             ('programming_language', None),


### PR DESCRIPTION
There was an issue in copyright scan and other places which was caused by a breaking change in bs4, which is fixed in commoncode with https://github.com/aboutcode-org/commoncode/releases/tag/v32.2.0

Reference: https://github.com/aboutcode-org/scancode-toolkit/issues/4129
Reference: https://github.com/aboutcode-org/commoncode/issues/79

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable)
