### PR TITLE
Rename bsd-no-disclaimer-unmodified to *-axis-*

### DIFF
--- a/src/licensedcode/data/licenses/bsd-axis-no-disclaimer-unmodified.LICENSE
+++ b/src/licensedcode/data/licenses/bsd-axis-no-disclaimer-unmodified.LICENSE
@@ -1,12 +1,12 @@
 ---
-key: bsd-no-disclaimer-unmodified
-short_name: BSD-2-Clause no disclaimer Unmod
-name: BSD-2-Clause without Warranty Disclaimer with Unmodified requirement
+key: bsd-axis-no-disclaimer-unmodified
+short_name: BSD-Axis no disclaimer Unmod
+name: BSD-Axis without Warranty Disclaimer with Unmodified requirement
 category: Permissive
 owner: Unspecified
 notes: A rare variant that comes with a slightly different wording and no warranty disclaimer
     and the words "without modifications" applying to the license conditions
-spdx_license_key: LicenseRef-scancode-bsd-no-disclaimer-unmodified
+spdx_license_key: LicenseRef-scancode-bsd-axis-no-disclaimer-unmodified
 ---
 
  * Redistribution and use in source and binary forms, with or without

--- a/src/licensedcode/data/rules/bsd-axis-no-disclaimer-unmodified_or_gpl-2.0-plus.RULE
+++ b/src/licensedcode/data/rules/bsd-axis-no-disclaimer-unmodified_or_gpl-2.0-plus.RULE
@@ -1,5 +1,5 @@
 ---
-license_expression: bsd-no-disclaimer-unmodified OR gpl-2.0-plus
+license_expression: bsd-axis-no-disclaimer-unmodified OR gpl-2.0-plus
 is_license_notice: yes
 minimum_coverage: 90
 ---

--- a/tests/licensedcode/data/datadriven/lic2/arm_math.c.yml
+++ b/tests/licensedcode/data/datadriven/lic2/arm_math.c.yml
@@ -1,2 +1,2 @@
 license_expressions:
-  - bsd-no-disclaimer-unmodified OR gpl-2.0-plus
+  - bsd-axis-no-disclaimer-unmodified OR gpl-2.0-plus


### PR DESCRIPTION
This license seems to be a variant of the BSD-Axis license, not a variant of the BSD-2-Clause license. This patch fixes it by renaming the license identifier to reflect reality.

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [X] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [X] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [X] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
