### PR TITLE
Fix and enhance support for different bazel metadata versions

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,6 +3,7 @@ The following organizations or individuals have contributed to ScanCode:
 - Abhigyan Kumar Singh @Abhigyankrsingh
 - Abhishek Kumar @Abhishek-Dev09
 - Aditya Viki @adityaviki
+- Adrian Braemer @abraemer
 - Agni Bhattacharyya @PyAgni
 - Akanksha Garg @akugarg
 - Alex Blekhman @a-tinsmith

--- a/src/packagedcode/build.py
+++ b/src/packagedcode/build.py
@@ -13,6 +13,7 @@ import ast
 from collections import defaultdict
 
 from commoncode import fileutils
+from packageurl import PackageURL
 
 from licensedcode.cache import build_spdx_license_expression
 from licensedcode.cache import get_cache
@@ -374,52 +375,27 @@ class BuckMetadataBzlHandler(BaseStarlarkManifestHandler):
                 )
             )
 
-        if (
-            'upstream_type' in metadata_fields
-            and 'name' in metadata_fields
-            and 'version' in metadata_fields
-            and 'licenses' in metadata_fields
-            and 'upstream_address' in metadata_fields
-        ):
-            # TODO: Create function that determines package type from download URL,
-            # then create a package of that package type from the metadata info
-            package_data = dict(
-                datasource_id=cls.datasource_id,
-                type=metadata_fields.get('upstream_type', cls.default_package_type),
-                name=metadata_fields.get('name'),
-                version=metadata_fields.get('version'),
-                extracted_license_statement=metadata_fields.get('licenses', []),
-                parties=parties,
-                homepage_url=metadata_fields.get('upstream_address', ''),
-                # TODO: Store 'upstream_hash` somewhere
-            )
-            yield models.PackageData.from_data(package_data, package_only=True)
+        # TODO: Create function that determines package type from download URL,
+        # then create a package of that package type from the metadata info
+        package_data = dict(
+            datasource_id=cls.datasource_id,
+            type=metadata_fields.get('upstream_type', metadata_fields.get('package_type', cls.default_package_type)),
+            name=metadata_fields.get('name'),
+            version=metadata_fields.get('version'),
+            extracted_license_statement=metadata_fields.get('licenses', metadata_fields.get('license_expression')),
+            parties=parties,
+            homepage_url=metadata_fields.get('upstream_address', metadata_fields.get('homepage_url')),
+            download_url=metadata_fields.get('download_url'),
+            vcs_url=metadata_fields.get('vcs_url'),
+            sha1=metadata_fields.get('download_archive_sha1'),
+            # TODO: Store 'upstream_hash` somewhere
+        )
+        if 'vcs_commit_hash' in metadata_fields:
+            package_data["extra_data"] = dict(vcs_commit_hash=metadata_fields['vcs_commit_hash'])
+        if 'package_url' in metadata_fields:
+            package_data.update(PackageURL.from_string(metadata_fields['package_url']).to_dict())
+        yield models.PackageData.from_data(package_data, package_only=True)
 
-        if (
-            'package_type' in metadata_fields
-            and 'name' in metadata_fields
-            and 'version' in metadata_fields
-            and 'license_expression' in metadata_fields
-            and 'homepage_url' in metadata_fields
-            and 'download_url' in metadata_fields
-            and 'vcs_url' in metadata_fields
-            and 'download_archive_sha1' in metadata_fields
-            and 'vcs_commit_hash' in metadata_fields
-        ):
-            package_data = dict(
-                datasource_id=cls.datasource_id,
-                type=metadata_fields.get('package_type', cls.default_package_type),
-                name=metadata_fields.get('name'),
-                version=metadata_fields.get('version'),
-                extracted_license_statement=metadata_fields.get('license_expression', ''),
-                parties=parties,
-                homepage_url=metadata_fields.get('homepage_url', ''),
-                download_url=metadata_fields.get('download_url', ''),
-                vcs_url=metadata_fields.get('vcs_url', ''),
-                sha1=metadata_fields.get('download_archive_sha1', ''),
-                extra_data=dict(vcs_commit_hash=metadata_fields.get('vcs_commit_hash', ''))
-            )
-            yield models.PackageData.from_data(package_data, package_only=True)
 
     @classmethod
     def assign_package_to_resources(cls, package, resource, codebase, package_adder):

--- a/src/packagedcode/build.py
+++ b/src/packagedcode/build.py
@@ -377,23 +377,47 @@ class BuckMetadataBzlHandler(BaseStarlarkManifestHandler):
 
         # TODO: Create function that determines package type from download URL,
         # then create a package of that package type from the metadata info
+        
+        if 'upstream_type' in metadata_fields:
+            package_type = metadata_fields['upstream_type']
+        elif 'package_type' in metadata_fields:
+            package_type = metadata_fields['package_type']
+        else:
+            package_type = cls.default_package_type
+
+        if 'licenses' in metadata_fields:
+            extracted_license_statement = metadata_fields['licenses']
+        else:
+            extracted_license_statement = metadata_fields.get('license_expression')
+
+        if 'upstream_address' in metadata_fields:
+            homepage_url = metadata_fields['upstream_address']
+        else:
+            homepage_url = metadata_fields.get('homepage_url')
+        
+
+        extra_data = {}
+        if 'vcs_commit_hash' in metadata_fields:
+            extra_data['vcs_commit_hash'] = metadata_fields['vcs_commit_hash']
+        if 'upstream_hash' in metadata_fields:
+            extra_data['upstream_hash'] = metadata_fields['upstream_hash']
+
         package_data = dict(
             datasource_id=cls.datasource_id,
-            type=metadata_fields.get('upstream_type', metadata_fields.get('package_type', cls.default_package_type)),
+            type=package_type,
             name=metadata_fields.get('name'),
             version=metadata_fields.get('version'),
-            extracted_license_statement=metadata_fields.get('licenses', metadata_fields.get('license_expression')),
+            extracted_license_statement=extracted_license_statement,
             parties=parties,
-            homepage_url=metadata_fields.get('upstream_address', metadata_fields.get('homepage_url')),
+            homepage_url=homepage_url,
             download_url=metadata_fields.get('download_url'),
             vcs_url=metadata_fields.get('vcs_url'),
             sha1=metadata_fields.get('download_archive_sha1'),
-            # TODO: Store 'upstream_hash` somewhere
+            extra_data=extra_data
         )
-        if 'vcs_commit_hash' in metadata_fields:
-            package_data["extra_data"] = dict(vcs_commit_hash=metadata_fields['vcs_commit_hash'])
         if 'package_url' in metadata_fields:
             package_data.update(PackageURL.from_string(metadata_fields['package_url']).to_dict())
+        
         yield models.PackageData.from_data(package_data, package_only=True)
 
 

--- a/src/packagedcode/build.py
+++ b/src/packagedcode/build.py
@@ -375,12 +375,11 @@ class BuckMetadataBzlHandler(BaseStarlarkManifestHandler):
             )
 
         if (
-            'upstream_type'
-            and 'name'
-            and 'version'
-            and 'licenses'
-            and 'upstream_address'
-            in metadata_fields
+            'upstream_type' in metadata_fields
+            and 'name' in metadata_fields
+            and 'version' in metadata_fields
+            and 'licenses' in metadata_fields
+            and 'upstream_address' in metadata_fields
         ):
             # TODO: Create function that determines package type from download URL,
             # then create a package of that package type from the metadata info
@@ -397,16 +396,15 @@ class BuckMetadataBzlHandler(BaseStarlarkManifestHandler):
             yield models.PackageData.from_data(package_data, package_only=True)
 
         if (
-            'package_type'
-            and 'name'
-            and 'version'
-            and 'license_expression'
-            and 'homepage_url'
-            and 'download_url'
-            and 'vcs_url'
-            and 'download_archive_sha1'
-            and 'vcs_commit_hash'
-            in metadata_fields
+            'package_type' in metadata_fields
+            and 'name' in metadata_fields
+            and 'version' in metadata_fields
+            and 'license_expression' in metadata_fields
+            and 'homepage_url' in metadata_fields
+            and 'download_url' in metadata_fields
+            and 'vcs_url' in metadata_fields
+            and 'download_archive_sha1' in metadata_fields
+            and 'vcs_commit_hash' in metadata_fields
         ):
             package_data = dict(
                 datasource_id=cls.datasource_id,

--- a/tests/packagedcode/data/build/metadatabzl/with-package-url/METADATA.bzl
+++ b/tests/packagedcode/data/build/metadatabzl/with-package-url/METADATA.bzl
@@ -1,0 +1,12 @@
+METADATA = {
+    "licenses": [
+        "BSD-3-Clause",
+    ],
+    "maintainers": [
+        "oss_foundation",
+    ],
+    "name": "androidx.compose.animation:animation",
+    "upstream_address": "https://developer.android.com/jetpack/androidx/releases/compose-animation#0.0.1",
+    "version": "0.0.1",
+    "package_url" : "pkg:maven/androidx.compose.animation/animation@0.0.1"
+}

--- a/tests/packagedcode/test_build.py
+++ b/tests/packagedcode/test_build.py
@@ -99,6 +99,7 @@ class TestBuild(PackageTester):
                     role='maintainer'
                 )
             ],
+            extra_data=dict(upstream_hash='deadbeef'),
             homepage_url='https://github.com/example/example',
         )
         expected_packages = [models.PackageData.from_data(package_data=package_data, package_only=True)]

--- a/tests/packagedcode/test_build.py
+++ b/tests/packagedcode/test_build.py
@@ -103,6 +103,28 @@ class TestBuild(PackageTester):
         )
         expected_packages = [models.PackageData.from_data(package_data=package_data, package_only=True)]
         compare_package_results(expected_packages, result_packages)
+    
+    def test_MetadataBzl_parse_with_package_url(self):
+        test_file = self.get_test_loc('metadatabzl/with-package-url/METADATA.bzl')
+        result_packages = build.BuckMetadataBzlHandler.parse(test_file, package_only=True)
+        package_data = dict(
+            datasource_id=build.BuckMetadataBzlHandler.datasource_id,
+            name='animation',
+            namespace='androidx.compose.animation',
+            type='maven',
+            version='0.0.1',
+            extracted_license_statement=['BSD-3-Clause'],
+            parties=[
+                models.Party(
+                    type=models.party_org,
+                    name='oss_foundation',
+                    role='maintainer'
+                )
+            ],
+            homepage_url='https://developer.android.com/jetpack/androidx/releases/compose-animation#0.0.1',
+        )
+        expected_packages = [models.PackageData.from_data(package_data=package_data, package_only=True)]
+        compare_package_results(expected_packages, result_packages)
 
     def test_MetadataBzl_recognize_new_format(self):
         test_file = self.get_test_loc('metadatabzl/new-format/METADATA.bzl')


### PR DESCRIPTION
I noticed that the conditions deciding between the two version for `.bzl` files are somewhat wrong. In Python `'a' and 'b' in some_string` is equal to `('a' and 'b') in some_string` and thus simplifies to `'b' in some_string`. In this instance, I think it shouldn't make a huge difference because fortunately the strings `upstream_address` and `vcs_commit_hash` still somewhat distinguish between versions.

I think just fixing the conditions makes them too restrictive (AFAIK there is no real standard for these METADATA.bzl files), so I combined both paths into one. This ensures that we always extract as much information as possible. 

I also added the option to use information from a `package_url` field which is important to me as we often have some `METADATA.bzl` files which are generated from Maven dependencies and thus the `name` is invalid by PURL specification. I wrote a somewhat realistic test case for this.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁

Closes #4196
