### PR TITLE
Fix author extraction for single-line declarations(#4229)

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -1810,6 +1810,9 @@ PATTERNS = [
        r'[A-Z][a-z]+[\.,]?'
      r')$', 'NNP'),
 
+    # Matches a capitalized word with a dot (Like Frankie.Chu). 
+    (r'^[A-Z][a-zA-Z]*\.[a-zA-Z]+$', 'NNP'),
+
     # cmmunications
     (r'communications', 'NNP'),
 
@@ -3494,6 +3497,9 @@ GRAMMAR = """
 
     # developed by Atkinson, et al.
     AUTHOR: {<AUTH> <NNP>+ <CC> <AUTHDOT> } #Atkinson, et al.
+
+    # Author:Frankie.Chu
+    AUTHOR: {<AUTH> <NNP>}
 
 
 #######################################

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -437,6 +437,23 @@ def get_tokens(numbered_lines, splitter=re.compile(r'[\t =;]+').split):
                 .strip()
             )
 
+            # remove leading plus sign
+            if tok.startswith('+'):
+                tok = tok.lstrip('+')
+                # convert 'AUTHOR' to ('author' or 'Author')
+                if tok == 'AUTHOR':
+                    tok = 'author' 
+
+            # Split tokens like 'Author:Frankie.Chu' into 'Author' and 'Frankie.Chu'
+            if tok.startswith("Author:"):
+                parts = tok.split(":", 1)
+                for part in parts:
+                    part = part.strip()
+                    if part and part not in ':.':
+                        yield Token(value=part, start_line=start_line, pos=pos)
+                        pos += 1
+                continue  
+
             # the tokenizer allows a single colon or dot to be a token and we discard these
             if tok and tok not in ':.':
                 yield Token(value=tok, start_line=start_line, pos=pos)

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -438,7 +438,7 @@ def get_tokens(numbered_lines, splitter=re.compile(r'[\t =;]+').split):
             )
 
             # remove leading plus sign
-            if tok.startswith('+'):
+            if tok.startswith('+') and len(tok) > 1:
                 tok = tok.lstrip('+')
                 # convert 'AUTHOR' to ('author' or 'Author')
                 if tok == 'AUTHOR':

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -1810,9 +1810,6 @@ PATTERNS = [
        r'[A-Z][a-z]+[\.,]?'
      r')$', 'NNP'),
 
-    # Matches a capitalized word with a dot (Like Frankie.Chu). 
-    (r'^[A-Z][a-zA-Z]*\.[a-zA-Z]+$', 'NNP'),
-
     # cmmunications
     (r'communications', 'NNP'),
 
@@ -3497,10 +3494,6 @@ GRAMMAR = """
 
     # developed by Atkinson, et al.
     AUTHOR: {<AUTH> <NNP>+ <CC> <AUTHDOT> } #Atkinson, et al.
-
-    # Author:Frankie.Chu
-    AUTHOR: {<AUTH> <NNP>}
-
 
 #######################################
 # Mixed AUTHOR and COPYRIGHT


### PR DESCRIPTION
Fixes #4229 

## Currently, I did these things:
### 1. Split tokens on colons (`:`)
Previously, entries like `Author:Frankie.Chu` were treated as a single token. I updated the tokenizer to split on `:` so that `Author` and `Frankie.Chu` are recognized as separate tokens.

### 2. Remove leading plus sign from author token
There is no support for leading `+` in author token like `#+AUTHOR: Lee Hinman`,  I removed the leading plus sign from the author token `+AUTHOR`. There are 45k+ file used these this,  these  `.org` file see https://github.com/search?q=%22%2Bauthor%3A%22&type=code&p=5

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks
* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
Signed-off-by: Alok Kumar [alokkumarjipura9973@gmail.com](mailto:alokkumarjipura9973@gmail.com)
