### PR TITLE
Update test_detect.py

### DIFF
--- a/tests/licensedcode/test_detect.py
+++ b/tests/licensedcode/test_detect.py
@@ -1074,9 +1074,9 @@ class TestMatchAccuracyWithFullIndex(FileBasedTesting):
         # looks acceptable below. Most cases just need to fix the test.
         expected = [
             # detected, match.lines(), match.qspan,
-            ('gpl-2.0-plus', (12, 25), Span(48, 157)),
-            ('fsf-unlimited-no-warranty', (231, 238), Span(965, 1028)),
-            ('warranty-disclaimer', (306, 307), Span(1337, 1359)),
+            ('gpl-2.0-plus', (12, 25), Span(51, 160)),
+            ('fsf-unlimited-no-warranty', (231, 238), Span(978, 1041)),
+            ('warranty-disclaimer', (306, 307), Span(1351, 1373)),
         ]
         self.check_position('positions/automake.pl', expected)
 


### PR DESCRIPTION
Fix lingering test failure
```
    def check_position(self, test_path, expected, with_span=True):
        """
        Check license detection in file or folder against expected result.
        Expected is a list of (license, lines span, qspan span) tuples.
        """
        test_location = self.get_test_loc(test_path)
        results = []
        # FULL INDEX!!
        idx = cache.get_index()
        matches = idx.match(test_location)
        for match in matches:
            for detected in match.rule.license_keys():
                results.append((detected, match.lines(), with_span and match.qspan or None))
>       assert results == expected
E       AssertionError: assert [('gpl-2.0-plus', (12, 25), Span(51, 160)),\n ('fsf-unlimited-no-warranty', (231, 238), Span(978, 1041)),\n ('warranty-disclaimer', (306, 307), Span(1351, 1373))] == [('gpl-2.0-plus', (12, 25), Span(48, 157)),\n ('fsf-unlimited-no-warranty', (231, 238), Span(965, 1028)),\n ('warranty-disclaimer', (306, 307), Span(1337, 1359))]
E         At index 0 diff: ('gpl-2.0-plus', (12, 25), Span(51, 160)) != ('gpl-2.0-plus', (12, 25), Span(48, 157))
E         Full diff:
E           [
E         -  ('gpl-2.0-plus', (12, 25), Span(48, 157)),
E         ?                                  ^^   ^^
E         +  ('gpl-2.0-plus', (12, 25), Span(51, 160)),
E         ?                                  ^^   ^^
E         -  ('fsf-unlimited-no-warranty', (231, 238), Span(965, 1028)),
E         ?                                                  ^^    ^^
E         +  ('fsf-unlimited-no-warranty', (231, 238), Span(978, 1041)),
E         ?                                                  ^^    ^^
E         -  ('warranty-disclaimer', (306, 307), Span(1337, 1359)),
E         ?                                               --- --
E         +  ('warranty-disclaimer', (306, 307), Span(1351, 1373)),
E         ?                                             +++++
E           ]

```


### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
