### PR TITLE
Fix some minor typos in home.rst

### DIFF
--- a/docs/source/getting-started/home.rst
+++ b/docs/source/getting-started/home.rst
@@ -30,13 +30,13 @@ ScanCode tries to address these issues by offering:
 - Extensive documentation and support.
 - We release of the code and reference data under permissive licenses (Apache
   2.0 and CC-BY-4.0)
-- ScanCode.io to assemble scripted and specialied code analysis pipelines with
+- ScanCode.io to assemble scripted and specialized code analysis pipelines with
   a web-based analysis server
 - ScanCode workbench for desktop-based scans visualization
 
 ScanCode is recognized as the industry leading engine for license and copyright
 detection and used as the basis of several open source compliance efforts in
-open source projects and companies. It's detection engine is embedded in the
+open source projects and companies. Its detection engine is embedded in the
 most advanced open source and commercial tools available today for Software
 Composition Analysis.
 
@@ -52,8 +52,8 @@ related information in your code:
   <https://github.com/package-url/purl-spec>`_,
 
 - by detecting license tags, notices and texts in text and binaries using the
-  world most comprehensive database of licenses texts and notices and a unique
-  combination of techniuqes,
+  world's most comprehensive database of license texts and notices and a unique
+  combination of techniques,
 
 - by recognizing copyright statements using an advanced natural language parsing
   grammar and detecting other origin clues (such as emails, urls, and authors)
@@ -65,7 +65,7 @@ Using this data you can:
 
 - Discover direct dependent packages and indirect pinned or locked dependencies,
 
-- Assemble a software component Inventory of your codebase, and report the data
+- Assemble a software component inventory of your codebase, and report the data
   using standard SBOM formats,
 
 - Use this data as the input to:


### PR DESCRIPTION
Spotted some typos while reading through
- specialied --> specialized
-  it's --> its
- "licenses texts" --> "license texts"
- techniuqes --> techniques
- "world most" --> "world's most"
- Inventory --> inventory (capital mid-sentence, though maybe this is a key term for the project?)

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [ ] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
