### PR TITLE
feat(OutputHTML): Always print license references table

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,6 +35,7 @@ The following organizations or individuals have contributed to ScanCode:
 - Horie Issei @is2ei
 - James Ward @jamesward
 - Jelmer Vernooĳ @jelmer
+- Jens Keim @pepper-jk
 - Kunal Chhabra @kunalchhabra37
 - Jillian Daguil @jdaguil
 - Jiri Popelka @jpopelka

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next release
 --------------
 
+- Enable License References table for HTML Output without requiring
+  `--license-references` by implementing a fallback license reference
+  collection based on the behavior of v32.0.0.
+  https://github.com/aboutcode-org/scancode-toolkit/pull/4474
+  https://github.com/aboutcode-org/scancode-toolkit/issues/4101
 
 
 v32.4.1 - 2025-07-23

--- a/docs/source/cli-reference/output-format.rst
+++ b/docs/source/cli-reference/output-format.rst
@@ -408,6 +408,8 @@ Comparing Different ``json`` Output Formats
         - Package Information
         - License References (SPDX ID, Links to spdx/scancode/licensedb/License Homepage)
 
+    .. include::  /rst_snippets/note_snippets/output_html_license_references.rst
+
     .. figure:: data/output_html1.png
 
     .. figure:: data/output_html2.png

--- a/docs/source/cli-reference/output-format.rst
+++ b/docs/source/cli-reference/output-format.rst
@@ -406,7 +406,7 @@ Comparing Different ``json`` Output Formats
         - Copyright and Licenses Information
         - File Information
         - Package Information
-        - Licenses (Links to Dejacode/License Homepage)
+        - License References (SPDX ID, Links to spdx/scancode/licensedb/License Homepage)
 
     .. figure:: data/output_html1.png
 

--- a/docs/source/rst_snippets/note_snippets/output_html_license_references.rst
+++ b/docs/source/rst_snippets/note_snippets/output_html_license_references.rst
@@ -1,0 +1,4 @@
+.. note::
+
+    For the license references table it is recommended to pass the ``--license-references`` argument.
+    However, there is a fall back implemented in case the ``license_references`` data is missing.

--- a/src/formattedcode/output_html.py
+++ b/src/formattedcode/output_html.py
@@ -188,9 +188,13 @@ def generate_output(results, license_references, version, template):
     """
     # FIXME: This code is highly coupled with actual scans and may not
     # support adding new scans at all
+
+    from licensedcode.cache import get_licenses_db
+
     converted = {}
     converted_infos = {}
     converted_packages = {}
+    licenses = {}
 
     LICENSES = 'license_detections'
     COPYRIGHTS = 'copyrights'
@@ -223,6 +227,11 @@ def generate_output(results, license_references, version, template):
                     'value': license_expression,
                 })
 
+                if not license_references and license_expression not in licenses:
+                    license_object = get_licenses_db().get(license_expression)
+                    if license_object != None:
+                        licenses[license_expression] = license_object
+
         if results:
             converted[path] = sorted(results, key=itemgetter('start'))
 
@@ -238,6 +247,10 @@ def generate_output(results, license_references, version, template):
 
         if PACKAGES in scanned_file:
             converted_packages[path] = scanned_file[PACKAGES]
+
+    if not license_references:
+        licenses = dict(sorted(licenses.items()))
+        license_references = list(licenses.values())
 
     files = {
         'license_copyright': converted,


### PR DESCRIPTION
![Image](https://github.com/user-attachments/assets/ea166867-08da-468c-aeff-1cff6f78b906)

### Description

The **license references** table in the HTML output does not get created with the current version of scancode (32.3.2).
The table was previously (31.2.6) called **licenses** and was located at the very bottom the static HTML output, see image above.
It summarized all licenses found in the scanned project in one table together with their metadata, such as URL to license text and category.

Evidence suggests that this is broken ever since 32.0.0, specifically PR #3275, where the source of the license references table was changed. This PR basically reverts the changes from 49e7d89, which case the described bug, and adjusts the older code to fit the current HTML template:

The new template expects a sorted list of license objects, therefore the `licenses` dictionary gets converted. `None` entries get discarded. Finally the empty `license_references` get overridden with the finished list of collected licenses.

Fixes #4101. Please refer to the issue for more information on the bug.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors.
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable)

Signed-off-by: Jens Keim <jens.keim@forvia.com>