### PR TITLE
Update pygmars

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,7 @@ ply==3.11
 publicsuffix2==2.20191221
 pyahocorasick==2.2.0
 pycparser==2.22
+pygmars==1.0.0
 Pygments==2.13.0
 pymaven-patch==0.3.2
 pyparsing==3.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,6 @@ ply==3.11
 publicsuffix2==2.20191221
 pyahocorasick==2.2.0
 pycparser==2.22
-pygmars==0.9.0
 Pygments==2.13.0
 pymaven-patch==0.3.2
 pyparsing==3.2.3

--- a/setup-mini.cfg
+++ b/setup-mini.cfg
@@ -102,7 +102,7 @@ install_requires =
     plugincode >= 32.0.0
     publicsuffix2
     pyahocorasick >= 2.0.0
-    pygmars @ git+https://github.com/aboutcode-org/pygmars@9ba5319959e56edcec46efaa6caffaf1ba97a293
+    pygmars >= 1.0.0
     pygments
     pymaven_patch >= 0.2.8
     requests >= 2.7.0

--- a/setup-mini.cfg
+++ b/setup-mini.cfg
@@ -102,7 +102,7 @@ install_requires =
     plugincode >= 32.0.0
     publicsuffix2
     pyahocorasick >= 2.0.0
-    pygmars >= 0.9.0
+    pygmars @ git+https://github.com/aboutcode-org/pygmars@9ba5319959e56edcec46efaa6caffaf1ba97a293
     pygments
     pymaven_patch >= 0.2.8
     requests >= 2.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,7 +103,7 @@ install_requires =
     plugincode >= 32.0.0
     publicsuffix2
     pyahocorasick >= 2.0.0
-    pygmars >= 0.9.0
+    pygmars @ git+https://github.com/aboutcode-org/pygmars@9ba5319959e56edcec46efaa6caffaf1ba97a293
     pygments
     pymaven_patch >= 0.2.8
     requests >= 2.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,7 +103,7 @@ install_requires =
     plugincode >= 32.0.0
     publicsuffix2
     pyahocorasick >= 2.0.0
-    pygmars @ git+https://github.com/aboutcode-org/pygmars@9ba5319959e56edcec46efaa6caffaf1ba97a293
+    pygmars >= 1.0.0
     pygments
     pymaven_patch >= 0.2.8
     requests >= 2.7.0

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -2888,7 +2888,7 @@ GRAMMAR = """
     # Nicolas Pitre, (c) 2002 Monta Vista Software Inc
     # Cliff Brake, (c) 2001
     #COPYRIGHT: {<NAME>  <COPY>  <NAME-YEAR> <NAME>  <COPY>  <YR-RANGE>}    #1566.1
-    
+
     # copyright: Copyright (c) Joe Joyce and contributors, 2016-2019.
     COPYRIGHT: {<COPY>+ <NAME>  <CC>  <NN>  <YR-RANGE>} #1579992
 


### PR DESCRIPTION
This PR updates pygmars to v1.0.0. The big change is that we no longer perform regex substitution when generating the string representation of a `ParseString` object. This saves us quite a bit of time during copyright detection.