### PR TITLE
Fix bug in cargo parent path detection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ Next release
   https://github.com/aboutcode-org/scancode-toolkit/pull/4474
   https://github.com/aboutcode-org/scancode-toolkit/issues/4101
 
+- Fix: Prevent crash when parent resource is missing in Cargo package assembler. Thanks [@Iron-56](https://github.com/Iron-56)!  
+  https://github.com/nexB/scancode-toolkit/issues/1436
+  
 
 v32.4.1 - 2025-07-23
 --------------------

--- a/src/packagedcode/cargo.py
+++ b/src/packagedcode/cargo.py
@@ -59,7 +59,8 @@ class CargoBaseHandler(models.DatafileHandler):
                 package_data.extra_data[attribute] = 'workspace'
                 workspace_package_data[attribute] = getattr(package_data, attribute)
 
-        workspace_root_path = resource.parent(codebase).path
+        parent = resource.parent(codebase)
+        workspace_root_path = parent.path if parent else None
         if workspace_package_data and workspace_members:
 
             # TODO: support glob patterns found in cargo workspaces
@@ -97,7 +98,7 @@ class CargoBaseHandler(models.DatafileHandler):
         else:
             yield from cls.assemble_from_many_datafiles(
                 datafile_name_patterns=('Cargo.toml', 'cargo.toml', 'Cargo.lock', 'cargo.lock'),
-                directory=resource.parent(codebase),
+                directory=resource.parent(codebase) or resource,
                 codebase=codebase,
                 package_adder=package_adder,
             )


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #1436 

### Summary

Fix crash when `resource.parent(codebase)` returns `None` in Rust plugin during Cargo workspace detection.


<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (not applicable)
* [x] Updated CHANGELOG.rst (applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
