### PR TITLE
Update cyseq to v0.0.2

### DIFF
--- a/requirements-native.txt
+++ b/requirements-native.txt
@@ -1,4 +1,5 @@
 cffi==1.17.1
+cyseq==0.0.2
 intbitset==4.0.0
 lxml==5.4.0
 MarkupSafe==3.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,7 @@ install_requires =
     typecode >= 30.0.1
     typecode[full] >= 30.0.1
     extractcode[full] >= 31.0.0
-    cyseq; platform_system == 'Linux'
+    cyseq >= 0.0.2
 
 
 [options.packages.find]


### PR DESCRIPTION
This PR updates cyseq to v0.0.2. This allows windows and mac sctk installations to use the faster seq implementation.