### PR TITLE
packagedcode: replace unmaintained toml with tomllib/tomli

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Next release
   https://github.com/aboutcode-org/scancode-toolkit/pull/4474
   https://github.com/aboutcode-org/scancode-toolkit/issues/4101
 
+- Replace unmaintained ``toml`` library with ``tomllib`` / ``tomli``.
+  https://github.com/aboutcode-org/scancode-toolkit/issues/4532
 
 v32.4.1 - 2025-07-23
 --------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -110,7 +110,7 @@ install_requires =
     saneyaml >= 0.6.0
     spdx_tools == 0.8.2
     text_unidecode >= 1.0
-    toml >= 0.10.0
+    tomli >= 2; python_version < "3.11"
     urlpy
     xmltodict >= 0.11.0
     zipp >= 3.0.0; python_version < "3.9"

--- a/src/packagedcode/cargo.py
+++ b/src/packagedcode/cargo.py
@@ -12,10 +12,18 @@ import os
 import re
 import sys
 
-import toml
 from packageurl import PackageURL
 
 from packagedcode import models
+
+# tomli was added to the stdlib as tomllib in Python 3.11.
+# It's the same code.
+# Still, prefer tomli if it's installed, as on newer Python versions, it is
+# compiled with mypyc and is more performant.
+try:
+    import tomli as tomllib
+except ImportError:
+    import tomllib
 
 """
 Handle Rust cargo crates
@@ -170,7 +178,8 @@ class CargoTomlHandler(CargoBaseHandler):
 
     @classmethod
     def parse(cls, location, package_only=False):
-        package_data_toml = toml.load(location, _dict=dict)
+        with open(location, "rb") as fp:
+            package_data_toml = tomllib.load(fp)
         workspace = package_data_toml.get('workspace', {})
         core_package_data = package_data_toml.get('package', {})
         extra_data = {}
@@ -283,7 +292,8 @@ class CargoLockHandler(CargoBaseHandler):
 
     @classmethod
     def parse(cls, location, package_only=False):
-        cargo_lock = toml.load(location, _dict=dict)
+        with open(location, "rb") as fp:
+            cargo_lock = tomllib.load(fp)
         dependencies = []
         package = cargo_lock.get('package', [])
         for dep in package:

--- a/src/packagedcode/pypi.py
+++ b/src/packagedcode/pypi.py
@@ -29,7 +29,6 @@ import importlib_metadata
 import packvers as packaging
 import pip_requirements_parser
 import pkginfo2
-import toml
 from commoncode import fileutils
 from commoncode.fileutils import as_posixpath
 from commoncode.resource import Resource
@@ -45,6 +44,15 @@ from packagedcode.utils import parse_maintainer_name_email
 from packagedcode.utils import yield_dependencies_from_package_data
 from packagedcode.utils import yield_dependencies_from_package_resource
 from packagedcode.utils import get_base_purl
+
+# tomli was added to the stdlib as tomllib in Python 3.11.
+# It's the same code.
+# Still, prefer tomli if it's installed, as on newer Python versions, it is
+# compiled with mypyc and is more performant.
+try:
+    import tomli as tomllib
+except ImportError:
+    import tomllib
 
 try:
     from zipfile import Path as ZipPath
@@ -463,7 +471,8 @@ class PyprojectTomlHandler(BaseExtractedPythonLayout):
 
     @classmethod
     def parse(cls, location, package_only=False):
-        package_data = toml.load(location, _dict=dict)
+        with open(location, "rb") as fp:
+            package_data = tomllib.load(fp)
         project_data = package_data.get("project")
         if not project_data:
             return
@@ -647,7 +656,8 @@ class PoetryPyprojectTomlHandler(BasePoetryPythonLayout):
 
     @classmethod
     def parse(cls, location, package_only=False):
-        toml_data = toml.load(location, _dict=dict)
+        with open(location, "rb") as fp:
+            toml_data = tomllib.load(fp)
 
         tool_data = toml_data.get('tool')
         if not tool_data:
@@ -725,7 +735,8 @@ class PoetryLockHandler(BasePoetryPythonLayout):
 
     @classmethod
     def parse(cls, location, package_only=False):
-        toml_data = toml.load(location, _dict=dict)
+        with open(location, "rb") as fp:
+            toml_data = tomllib.load(fp)
 
         packages = toml_data.get('package')
         if not packages:


### PR DESCRIPTION
toml has been unmaintained for years and was superseded by tomli on PyPI which was eventually added to the stdlib as tomllib in Python 3.11.

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
