### PR TITLE
Make apache-2.0 and lgpl rules more specific

### DIFF
--- a/src/licensedcode/data/rules/apache-2.0_and_lgpl-2.1_1.RULE
+++ b/src/licensedcode/data/rules/apache-2.0_and_lgpl-2.1_1.RULE
@@ -9,6 +9,6 @@ referenced_filenames:
 
 distributed pursuant to the terms of two different licenses.
 The user interface (located in ui/ in this distribution) is governed by
-the Apache License version 2.0.  The rest of this distribution is
-governed by the GNU Lesser General Public License version 2.1.
+the {{Apache License version 2.0}}.  The rest of this distribution is
+governed by the {{GNU Lesser General Public License version 2.1}}.
 See COPYING.LGPL and COPYING.ASL2.

--- a/src/licensedcode/data/rules/apache-2.0_and_lgpl-2.1_2.RULE
+++ b/src/licensedcode/data/rules/apache-2.0_and_lgpl-2.1_2.RULE
@@ -9,7 +9,7 @@ ignorable_urls:
     - http://www.apache.org/licenses/LICENSE-2.0
 ---
 
-Licensed under the Apache License, Version 2.0 (the "License");
+Licensed under the {{Apache License, Version 2.0}} (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
  .
@@ -21,5 +21,5 @@ Licensed under the Apache License, Version 2.0 (the "License");
  See the License for the specific language governing permissions and
  limitations under the License.
  .
- On Debian systems a full copy of the LGPL 2.1 can be found at
+ On Debian systems a full copy of the {{LGPL 2.1}} can be found at
  /usr/share/common-licenses/Apache-2.0

--- a/src/licensedcode/data/rules/apache-2.0_and_lgpl-2.1_4.RULE
+++ b/src/licensedcode/data/rules/apache-2.0_and_lgpl-2.1_4.RULE
@@ -10,7 +10,7 @@ ignorable_urls:
     - http://www.apache.org/licenses/LICENSE-2.0
 ---
 
-Licensed under the Apache License, Version 2.0 (the "License");
+Licensed under the {{Apache License, Version 2.0}} (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
  .
@@ -22,5 +22,5 @@ Licensed under the Apache License, Version 2.0 (the "License");
  See the License for the specific language governing permissions and
  limitations under the License.
  .
- On Debian GNU/Linux systems a full copy of the LGPL 2.1 can be found at
+ On Debian GNU/Linux systems a full copy of the {{LGPL 2.1}} can be found at
  /usr/share/common-licenses/Apache-2.0


### PR DESCRIPTION
**Context**

The rules are AND rules but they also match if only Apache-2.0 is present. Of course, they should only match if both licenses are actually detected in the text.

**Summary**

Require Apache 2.0 and LGPL to be present in the text for these rules to match.

**Out of scope**

There are a bunch of rules that have similar problems. Since the rules touched in this diff caused problems for us,
I am just touching them and and consider remaining rules out of scope.

**Test Plan**

I would have added a test, but I can't run scancode locally on my arm mac due to #3539 (on recent versions of MacOS and Scancode) 

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
