### PR TITLE
docs: add direct URLs to NOTICE and .ABOUT files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -242,8 +242,9 @@ License
   BSD, GPL 2/3, etc.) for third-party components and test suite code and data.
 
 
-See the NOTICE file and the .ABOUT files that document the origin and license of
-the third-party code used in ScanCode for more details.
+See the NOTICE file ([NOTICE](https://github.com/nexB/scancode-toolkit/blob/develop/NOTICE))
+and the .ABOUT files ([.ABOUT](https://github.com/nexB/scancode-toolkit/tree/develop/src/aboutcode/data))
+that document the origin and license of the third-party code used in ScanCode for more details.
 
 
 


### PR DESCRIPTION
While going through README.rst, I noticed that the NOTICE and .ABOUT files were referenced, but no direct URLs were provided. 
**Before:**
<img width="1113" height="321" alt="Screenshot 2025-11-12 213019" src="https://github.com/user-attachments/assets/8f724e21-87e5-4038-8d74-2f353243ec44" />

So I have added the direct URLs to these files to make it easier for users to access licensing and attribution information.

This change improves the documentation clarity and usability for both users and contributors. No code or functionality is affected.

Signed-off-by:  Vaishnavi S  vaishnavibabblu@gmail.com





