### PR TITLE
Add gpl 3.0 only with GCC exception 3.1 rule

### DIFF
--- a/src/licensedcode/data/rules/gpl-3.0_with_gcc-exception-3.1_16.RULE
+++ b/src/licensedcode/data/rules/gpl-3.0_with_gcc-exception-3.1_16.RULE
@@ -1,0 +1,7 @@
+---
+license_expression: gpl-3.0 WITH gcc-exception-3.1
+is_license_reference: yes
+relevance: 100D
+---
+
+{{GPL 3.0}} with {{GCC Runtime Library Exception 3.1}}

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.


### PR DESCRIPTION
Add a rule that was missing in one of our scans.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
