### PR TITLE
Fix copyright detection for bracket notation [C] and [c]

### DIFF
--- a/samples/brackets/copyright-bracket-c.txt
+++ b/samples/brackets/copyright-bracket-c.txt
@@ -1,1 +1,0 @@
-Copyright [c] 2001-2005 Python Software Foundation

--- a/samples/brackets/copyright-bracket-c.txt
+++ b/samples/brackets/copyright-bracket-c.txt
@@ -1,0 +1,1 @@
+Copyright [c] 2001-2005 Python Software Foundation

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -4502,11 +4502,8 @@ def prepare_text_line(line):
 
         # normalize copyright signs, quotes and spacing around them
         .replace('"Copyright', '" Copyright')
-        
-        # normalize [C] and [c] to (c) before bracket removal
         .replace('[C]', '(c)')
         .replace('[c]', '(c)')
-        
         .replace('( C)', ' (c) ')
         .replace('(C)', ' (c) ')
         .replace('(c)', ' (c) ')

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -4502,6 +4502,11 @@ def prepare_text_line(line):
 
         # normalize copyright signs, quotes and spacing around them
         .replace('"Copyright', '" Copyright')
+        
+        # normalize [C] and [c] to (c) before bracket removal
+        .replace('[C]', '(c)')
+        .replace('[c]', '(c)')
+        
         .replace('( C)', ' (c) ')
         .replace('(C)', ' (c) ')
         .replace('(c)', ' (c) ')

--- a/src/licensedcode/data/rules/umich-merit_1.RULE
+++ b/src/licensedcode/data/rules/umich-merit_1.RULE
@@ -2,6 +2,10 @@
 license_expression: umich-merit
 is_license_text: yes
 minimum_coverage: 95
+ignorable_copyrights:
+    - (c) The Regents of the University of Michigan and Merit Network, Inc. 1992, 1993, 1994, 1995
+ignorable_holders:
+    - The Regents of the University of Michigan and Merit Network, Inc.
 ---
 
 [C] The Regents of the University of Michigan and Merit Network, Inc. 1992,

--- a/tests/cluecode/test_copyrights_basic.py
+++ b/tests/cluecode/test_copyrights_basic.py
@@ -74,9 +74,9 @@ class TestTextPreparation(FileBasedTesting):
         assert result == '(c) The Regents of the University of Michigan and Merit Network, Inc. 1992, 1993, 1994, 1995 All Rights Reserved'
 
     def test_prepare_text_line_normalizes_bracket_c_lowercase(self):
-        cp = 'Copyright [c] 2023 Example Company'
+        cp = 'Copyright [c] 2005, 2017 by Alex McDonald (alex at rivadpm dot com)'
         result = prepare_text_line(cp)
-        assert result == 'Copyright (c) 2023 Example Company'
+        assert result == 'Copyright (c) 2005, 2017 by Alex McDonald (alex at rivadpm dot com)'
 
     def test_prepare_text_line_does_replace_copyright_signs(self):
         cp = 'Copyright \\A9 1991, 1999 Free Software Foundation, Inc.'

--- a/tests/cluecode/test_copyrights_basic.py
+++ b/tests/cluecode/test_copyrights_basic.py
@@ -68,6 +68,16 @@ class TestTextPreparation(FileBasedTesting):
         result = prepare_text_line(cp)
         assert result == 'copyright (c) 2000 World Wide Web Consortium, http://www.w3.org'
 
+    def test_prepare_text_line_normalizes_bracket_C_uppercase(self):
+        cp = '[C] The Regents of the University of Michigan and Merit Network, Inc. 1992, 1993, 1994, 1995 All Rights Reserved'
+        result = prepare_text_line(cp)
+        assert result == '(c) The Regents of the University of Michigan and Merit Network, Inc. 1992, 1993, 1994, 1995 All Rights Reserved'
+
+    def test_prepare_text_line_normalizes_bracket_c_lowercase(self):
+        cp = 'Copyright [c] 2023 Example Company'
+        result = prepare_text_line(cp)
+        assert result == 'Copyright (c) 2023 Example Company'
+
     def test_prepare_text_line_does_replace_copyright_signs(self):
         cp = 'Copyright \\A9 1991, 1999 Free Software Foundation, Inc.'
         result = prepare_text_line(cp)


### PR DESCRIPTION
Fixes #3659

Normalize bracketed copyright markers [C] and [c] so they are correctly detected.

### Summary

- [C] / [c] were stripped during preprocessing, leaving plain C / c
- This caused copyright detection to fail
- Added normalization in prepare_text_line() to convert [C] and [c] to (c) before bracket removal

### Tasks
* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)

Signed-off-by: Shekhar Suman levi42x@gmail.com