### PR TITLE
Add a new rule to Mulan PubL v1

### DIFF
--- a/src/licensedcode/data/rules/mulanpubl-1.0_1.RULE
+++ b/src/licensedcode/data/rules/mulanpubl-1.0_1.RULE
@@ -1,0 +1,15 @@
+---
+license_expression: mulanpubl-1.0
+is_license_notice: yes
+ignorable_urls:
+    - http://license.coscl.org.cn/MulanPubL-1.0
+---
+
+licensed under Mulan PubL v1.
+You can use this software according to the terms and conditions of the Mulan PubL v1.
+You may obtain a copy of Mulan PubL v1 at:
+         http://license.coscl.org.cn/MulanPubL-1.0
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PubL v1 for more details.


### PR DESCRIPTION
Hi, I am the contributor from RecLicense project of osslab-pku, taking on the issue "Contribute updates back to ScanCode?".
I observe that in Mulan License family, **the rule for detecting Mulan Public License, Version 1 (Mulan PubL v1) is not existed**.
I've done some tests in local environment to show that existing rules for Mulan PSL v1, ,Mulan PSL v2, Mulan PubL v2 can adequately detect and distinguish Mulan license.
Therefore, currently I only consider to add a new rule for Mulan PubL v1, which refers to the content of mulanpubl-2.0_1.RULE.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ]  Updated documentation pages (if applicable)
* [ ]  Updated CHANGELOG.rst (if applicable)

Signed-off-by: Jianlang Deng <csgarytang@gmail.com>
