### PR TITLE
Add new rule to Mulan PubL v1 License

### DIFF
--- a/src/licensedcode/data/rules/mulanpubl-1.0_1.RULE
+++ b/src/licensedcode/data/rules/mulanpubl-1.0_1.RULE
@@ -8,7 +8,7 @@ ignorable_urls:
 licensed under {{Mulan PubL v1}}.
 You can use this software according to the terms and conditions of the Mulan PubL v1.
 You may obtain a copy of Mulan PubL v1 at:
-         http://license.coscl.org.cn/MulanPubL-1.0
+         {{http://license.coscl.org.cn/MulanPubL-1.0}}
 THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
 EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
 MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.

--- a/src/licensedcode/data/rules/mulanpubl-1.0_1.RULE
+++ b/src/licensedcode/data/rules/mulanpubl-1.0_1.RULE
@@ -1,0 +1,15 @@
+---
+license_expression: mulanpubl-1.0
+is_license_notice: yes
+ignorable_urls:
+    - http://license.coscl.org.cn/MulanPubL-1.0
+---
+
+licensed under Mulan PubL v1.
+You can use this software according to the terms and conditions of the Mulan PubL v1.
+You may obtain a copy of Mulan PubL v1 at:
+         http://license.coscl.org.cn/MulanPubL-1.0
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PubL v1 for more details.

--- a/src/licensedcode/data/rules/mulanpubl-1.0_1.RULE
+++ b/src/licensedcode/data/rules/mulanpubl-1.0_1.RULE
@@ -5,7 +5,7 @@ ignorable_urls:
     - http://license.coscl.org.cn/MulanPubL-1.0
 ---
 
-licensed under Mulan PubL v1.
+licensed under {{Mulan PubL v1}}.
 You can use this software according to the terms and conditions of the Mulan PubL v1.
 You may obtain a copy of Mulan PubL v1 at:
          http://license.coscl.org.cn/MulanPubL-1.0


### PR DESCRIPTION
Hi, I am the contributor from RecLicense project of osslab-pku, taking on the issue "[Contribute updates back to ScanCode?](https://github.com/osslab-pku/RecLicense/issues/2)".
I observe that in Mulan License family, **the rule for detecting Mulan Public License, Version 1 (Mulan PubL v1) is not existed**.
I've done some tests in local environment to show that existing rules for Mulan PSL v1, ,Mulan PSL v2, Mulan PubL v2 can adequately detect and distinguish Mulan license.
Therefore, currently I only consider to add a new rule [mulanpubl-1.0_1.RULE](https://github.com/aboutcode-org/scancode-toolkit/pull/4627/commits/b6444ee6f30b546dbb9edf2e6cefd05c7c5f3949) for Mulan PubL v1, which takes the content of [mulanpubl-2.0_1.RULE](https://github.com/aboutcode-org/scancode-toolkit/blob/develop/src/licensedcode/data/rules/mulanpubl-2.0_1.RULE) as reference.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)

Signed-off-by: Jianlang Deng <csgarytang@gmail.com>
