### PR TITLE
Fix outdated ScanCode license data base URL

### DIFF
--- a/src/scancode/api.py
+++ b/src/scancode/api.py
@@ -142,7 +142,8 @@ def get_urls(location, threshold=50, **kwargs):
 SPDX_LICENSE_URL = 'https://spdx.org/licenses/{}'
 DEJACODE_LICENSE_URL = 'https://enterprise.dejacode.com/urn/urn:dje:license:{}'
 SCANCODE_LICENSEDB_URL = 'https://scancode-licensedb.aboutcode.org/{}'
-SCANCODE_DATA_BASE_URL = 'https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data'
+SCANCODE_DATA_BASE_URL = 'https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data'
+
 SCANCODE_LICENSE_URL = f'{SCANCODE_DATA_BASE_URL}/licenses/{{}}.LICENSE'
 SCANCODE_RULE_URL = f'{SCANCODE_DATA_BASE_URL}/rules/{{}}'
 


### PR DESCRIPTION
### What this PR does
- Updates the `SCANCODE_DATA_BASE_URL` to point to the current `aboutcode-org` repository instead of the legacy `nexB` organization.

### Why this is needed
- The previous URL referenced an outdated repository path and no longer reflects the current project location.

### Related issue
- Fixes #4640
