### PR TITLE
Add rule for CKSource Holding copyright

### DIFF
--- a/src/licensedcode/data/rules/gpl-2.0-plus_or_commercial-license_cksource_1.RULE
+++ b/src/licensedcode/data/rules/gpl-2.0-plus_or_commercial-license_cksource_1.RULE
@@ -1,0 +1,14 @@
+---
+license_expression: gpl-2.0-plus OR commercial-license
+is_license_notice: yes
+relevance: 100
+minimum_coverage: 80
+notes: |
+  Specific rule for CKEditor 5 CKSource Holding sp. z o.o. copyright headers.
+  Matches the distinctive "CKSource Holding sp. z o.o." entity name and the
+  specific LICENSE.md reference pattern used in CKEditor 5, regardless of year.
+  This prevents false positive detection of LGPL-2.1-plus and MPL-1.1 by the
+  generic CKSource rule which was designed for CKEditor 4.
+---
+CKSource Holding sp. z o.o. All rights reserved.
+For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license


### PR DESCRIPTION
Fixes #4583

### Problem
CKEditor 5 files are incorrectly detected with extra licenses they don't contain.

**Current (incorrect):**
```
(gpl-2.0-plus AND (gpl-2.0-plus OR lgpl-2.1-plus OR mpl-1.1)) OR commercial-license
```

**Expected (correct):**
```
gpl-2.0-plus OR commercial-license
```

### Root Cause
The generic CKSource rule matches both CKEditor 4 and CKEditor 5, but CKEditor 5 uses a different copyright holder ("CKSource Holding sp. z o.o.") and doesn't include LGPL/MPL licenses

### Solution
Added a specific rule that matches the "CKSource Holding sp. z o.o." copyright header used exclusively in CKEditor 5 packages. This rule takes precedence and returns the correct license expression

### Testing
Works across different copyright years
All license detection tests passing

### Changes
Added `gpl-2.0-plus_or_commercial-license_cksource_1.RULE`



**Tasks:**
- [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
- [x] PR is descriptively titled 📑 and links the original issue above 🔗
- [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- Run [tests](https://scancode-toolkit.readthedocs.io/en/stable/contribute/contrib_dev.html#tests) locally to check for errors
- [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
- [ ] Updated documentation pages (if applicable)
- [ ] Updated CHANGELOG.rst (if applicable)