### PR TITLE
Add Gradle Module Metadata (`*.module`) package handler

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -105,3 +105,4 @@ The following organizations or individuals have contributed to ScanCode:
 - Yash Sharma @yasharmaster
 - Yunus Rahbar @yns88
 - Stefano Zacchiroli @zacchiro
+- Uttam Raj @uttam282005

--- a/src/packagedcode/__init__.py
+++ b/src/packagedcode/__init__.py
@@ -15,13 +15,13 @@ from packagedcode import build
 from packagedcode import build_gradle
 from packagedcode import cargo
 from packagedcode import chef
+from packagedcode import cocoapods
+from packagedcode import conan
+from packagedcode import conda
+from packagedcode import cran
 from packagedcode import debian
 from packagedcode import debian_copyright
 from packagedcode import distro
-from packagedcode import conda
-from packagedcode import conan
-from packagedcode import cocoapods
-from packagedcode import cran
 from packagedcode import freebsd
 from packagedcode import godeps
 from packagedcode import golang
@@ -49,76 +49,56 @@ if on_linux:
 # a handler classes MUST be added to this list to be active
 APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     about.AboutFileHandler,
-
     alpine.AlpineApkArchiveHandler,
     alpine.AlpineApkbuildHandler,
-
     bower.BowerJsonHandler,
-
     build_gradle.BuildGradleHandler,
-
     build.AutotoolsConfigureHandler,
     build.BazelBuildHandler,
     build.BuckMetadataBzlHandler,
     build.BuckPackageHandler,
-
     cargo.CargoLockHandler,
     cargo.CargoTomlHandler,
-
     chef.ChefMetadataJsonHandler,
     chef.ChefMetadataRbHandler,
-
     cocoapods.PodspecHandler,
     cocoapods.PodspecJsonHandler,
     cocoapods.PodfileLockHandler,
     cocoapods.PodfileHandler,
-
     conda.CondaMetaJsonHandler,
     conda.CondaMetaYamlHandler,
     conda.CondaYamlHandler,
-
     conan.ConanFileHandler,
     conan.ConanDataHandler,
-
     cran.CranDescriptionFileHandler,
-
     debian_copyright.DebianCopyrightFileInPackageHandler,
     debian_copyright.StandaloneDebianCopyrightFileHandler,
     debian.DebianDscFileHandler,
-
     debian.DebianControlFileInExtractedDebHandler,
     debian.DebianControlFileInSourceHandler,
-
     debian.DebianDebPackageHandler,
     debian.DebianMd5sumFilelistInPackageHandler,
-
     debian.DebianSourcePackageMetadataTarballHandler,
     debian.DebianSourcePackageTarballHandler,
-
     distro.EtcOsReleaseHandler,
-
     freebsd.CompactManifestHandler,
-
     godeps.GodepsHandler,
     golang.GoModHandler,
     golang.GoSumHandler,
-
     haxe.HaxelibJsonHandler,
-
     maven.MavenPomXmlHandler,
     maven.MavenPomPropertiesHandler,
     maven.JavaJarManifestHandler,
     maven.JavaOSGiManifestHandler,
-    maven.GradleModuleMetaDataHandler,
-
+    maven.GradleModuleMetadataHandler,
     misc.AndroidAppArchiveHandler,
     misc.AndroidLibraryHandler,
     misc.AppleDmgHandler,
-    misc.Axis2MarArchiveHandler ,
-    misc.Axis2MarModuleXmlHandler ,
+    misc.Axis2MarArchiveHandler,
+    misc.Axis2MarModuleXmlHandler,
     misc.CabArchiveHandler,
     misc.ChromeExtensionHandler,
-    misc.CpanDistIniHandler ,
+    misc.CpanDistIniHandler,
     misc.CpanMakefilePlHandler,
     misc.CpanManifestHandler,
     misc.CpanMetaJsonHandler,
@@ -127,19 +107,14 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     misc.IosAppIpaHandler,
     misc.IsoImageHandler,
     misc.IvyXmlHandler,
-
-    misc.JavaEarAppXmlHandler ,
-    misc.JavaEarHandler ,
-
+    misc.JavaEarAppXmlHandler,
+    misc.JavaEarHandler,
     # is this redundant with Jar manifest?
     misc.JavaJarHandler,
-
     misc.JavaWarHandler,
     misc.JavaWarWebXmlHandler,
-
-    misc.JBossSarHandler ,
-    misc.JBossServiceXmlHandler ,
-
+    misc.JBossSarHandler,
+    misc.JBossServiceXmlHandler,
     misc.MeteorPackageHandler,
     misc.MozillaExtensionHandler,
     misc.NsisInstallerHandler,
@@ -153,19 +128,14 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     npm.PnpmShrinkwrapYamlHandler,
     npm.PnpmLockYamlHandler,
     npm.PnpmWorkspaceYamlHandler,
-
     nuget.NugetNupkgHandler,
     nuget.NugetNuspecHandler,
     nuget.NugetPackagesLockHandler,
-
     opam.OpamFileHandler,
-
     phpcomposer.PhpComposerJsonHandler,
     phpcomposer.PhpComposerLockHandler,
-
     pubspec.DartPubspecYamlHandler,
     pubspec.DartPubspecLockHandler,
-
     pypi.PipfileHandler,
     pypi.PipfileLockHandler,
     pypi.PipRequirementsFileHandler,
@@ -181,36 +151,26 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     pypi.PythonSdistPkgInfoFile,
     pypi.PythonSetupPyHandler,
     pypi.SetupCfgHandler,
-
     readme.ReadmeHandler,
-
     rpm.RpmArchiveHandler,
     rpm.RpmSpecfileHandler,
-
     rubygems.GemMetadataArchiveExtractedHandler,
     rubygems.GemArchiveHandler,
-
     # the order of these handlers matter
     rubygems.GemfileInExtractedGemHandler,
     rubygems.GemfileHandler,
-
     # the order of these handlers matter
     rubygems.GemfileLockInExtractedGemHandler,
     rubygems.GemfileLockHandler,
-
     # the order of these handlers matter
     rubygems.GemspecInInstalledVendorBundleSpecificationsHandler,
     rubygems.GemspecInExtractedGemHandler,
     rubygems.GemspecHandler,
-
     swift.SwiftManifestJsonHandler,
     swift.SwiftPackageResolvedHandler,
     swift.SwiftShowDependenciesDepLockHandler,
-
     windows.MicrosoftUpdateManifestHandler,
-
     win_pe.WindowsExecutableHandler,
-
     # These are handlers for deplock generated files
     pypi.PipInspectDeplockHandler,
 ]
@@ -222,18 +182,14 @@ if on_linux:
 
 SYSTEM_PACKAGE_DATAFILE_HANDLERS = [
     alpine.AlpineInstalledDatabaseHandler,
-
     debian_copyright.DebianCopyrightFileInPackageHandler,
     debian_copyright.DebianCopyrightFileInSourceHandler,
-
     debian.DebianDistrolessInstalledDatabaseHandler,
-
     debian.DebianInstalledFilelistHandler,
     debian.DebianInstalledMd5sumFilelistHandler,
     debian.DebianInstalledStatusDatabaseHandler,
-
     rpm.RpmLicenseFilesHandler,
-    rpm.RpmMarinerContainerManifestHandler
+    rpm.RpmMarinerContainerManifestHandler,
 ]
 
 if on_linux:
@@ -241,7 +197,6 @@ if on_linux:
         rpm.RpmInstalledBdbDatabaseHandler,
         rpm.RpmInstalledSqliteDatabaseHandler,
         rpm.RpmInstalledNdbDatabaseHandler,
-
         win_reg.InstalledProgramFromDockerSoftwareDeltaHandler,
         win_reg.InstalledProgramFromDockerFilesSoftwareHandler,
         win_reg.InstalledProgramFromDockerUtilityvmSoftwareHandler,
@@ -249,22 +204,21 @@ if on_linux:
 
 try:
     from go_inspector.binary import get_go_binary_handler
+
     APPLICATION_PACKAGE_DATAFILE_HANDLERS.append(get_go_binary_handler())
 except ImportError:
     pass
 
 try:
     from rust_inspector.packages import get_rust_binary_handler
+
     APPLICATION_PACKAGE_DATAFILE_HANDLERS.append(get_rust_binary_handler())
 except ImportError:
     pass
 
-ALL_DATAFILE_HANDLERS = (
-    APPLICATION_PACKAGE_DATAFILE_HANDLERS + [
-        p for p in SYSTEM_PACKAGE_DATAFILE_HANDLERS
-        if p not in APPLICATION_PACKAGE_DATAFILE_HANDLERS
-    ]
-)
+ALL_DATAFILE_HANDLERS = APPLICATION_PACKAGE_DATAFILE_HANDLERS + [
+    p for p in SYSTEM_PACKAGE_DATAFILE_HANDLERS if p not in APPLICATION_PACKAGE_DATAFILE_HANDLERS
+]
 
 # registry of all handler classes keyed by datasource_id
 HANDLER_BY_DATASOURCE_ID = {handler.datasource_id: handler for handler in ALL_DATAFILE_HANDLERS}
@@ -286,6 +240,4 @@ def get_package_handler(package_data):
     return ppc
 
 
-PACKAGE_DATA_CLASS_BY_DATASOURCE_ID = {
-    maven.MavenPackageData.datasource_id: maven.MavenPackageData
-}
+PACKAGE_DATA_CLASS_BY_DATASOURCE_ID = {maven.MavenPackageData.datasource_id: maven.MavenPackageData}

--- a/src/packagedcode/__init__.py
+++ b/src/packagedcode/__init__.py
@@ -109,6 +109,7 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     maven.MavenPomPropertiesHandler,
     maven.JavaJarManifestHandler,
     maven.JavaOSGiManifestHandler,
+    maven.GradleModuleMetaDataHandler,
 
     misc.AndroidAppArchiveHandler,
     misc.AndroidLibraryHandler,

--- a/src/packagedcode/__init__.py
+++ b/src/packagedcode/__init__.py
@@ -15,13 +15,13 @@ from packagedcode import build
 from packagedcode import build_gradle
 from packagedcode import cargo
 from packagedcode import chef
-from packagedcode import cocoapods
-from packagedcode import conan
-from packagedcode import conda
-from packagedcode import cran
 from packagedcode import debian
 from packagedcode import debian_copyright
 from packagedcode import distro
+from packagedcode import conda
+from packagedcode import conan
+from packagedcode import cocoapods
+from packagedcode import cran
 from packagedcode import freebsd
 from packagedcode import godeps
 from packagedcode import golang
@@ -49,56 +49,76 @@ if on_linux:
 # a handler classes MUST be added to this list to be active
 APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     about.AboutFileHandler,
+
     alpine.AlpineApkArchiveHandler,
     alpine.AlpineApkbuildHandler,
+
     bower.BowerJsonHandler,
+
     build_gradle.BuildGradleHandler,
+
     build.AutotoolsConfigureHandler,
     build.BazelBuildHandler,
     build.BuckMetadataBzlHandler,
     build.BuckPackageHandler,
+
     cargo.CargoLockHandler,
     cargo.CargoTomlHandler,
+
     chef.ChefMetadataJsonHandler,
     chef.ChefMetadataRbHandler,
+
     cocoapods.PodspecHandler,
     cocoapods.PodspecJsonHandler,
     cocoapods.PodfileLockHandler,
     cocoapods.PodfileHandler,
+
     conda.CondaMetaJsonHandler,
     conda.CondaMetaYamlHandler,
     conda.CondaYamlHandler,
+
     conan.ConanFileHandler,
     conan.ConanDataHandler,
+
     cran.CranDescriptionFileHandler,
+
     debian_copyright.DebianCopyrightFileInPackageHandler,
     debian_copyright.StandaloneDebianCopyrightFileHandler,
     debian.DebianDscFileHandler,
+
     debian.DebianControlFileInExtractedDebHandler,
     debian.DebianControlFileInSourceHandler,
+
     debian.DebianDebPackageHandler,
     debian.DebianMd5sumFilelistInPackageHandler,
+
     debian.DebianSourcePackageMetadataTarballHandler,
     debian.DebianSourcePackageTarballHandler,
+
     distro.EtcOsReleaseHandler,
+
     freebsd.CompactManifestHandler,
+
     godeps.GodepsHandler,
     golang.GoModHandler,
     golang.GoSumHandler,
+
     haxe.HaxelibJsonHandler,
+
     maven.MavenPomXmlHandler,
     maven.MavenPomPropertiesHandler,
     maven.JavaJarManifestHandler,
     maven.JavaOSGiManifestHandler,
     maven.GradleModuleMetadataHandler,
+
     misc.AndroidAppArchiveHandler,
     misc.AndroidLibraryHandler,
     misc.AppleDmgHandler,
-    misc.Axis2MarArchiveHandler,
-    misc.Axis2MarModuleXmlHandler,
+    misc.Axis2MarArchiveHandler ,
+    misc.Axis2MarModuleXmlHandler ,
     misc.CabArchiveHandler,
     misc.ChromeExtensionHandler,
-    misc.CpanDistIniHandler,
+    misc.CpanDistIniHandler ,
     misc.CpanMakefilePlHandler,
     misc.CpanManifestHandler,
     misc.CpanMetaJsonHandler,
@@ -107,14 +127,19 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     misc.IosAppIpaHandler,
     misc.IsoImageHandler,
     misc.IvyXmlHandler,
-    misc.JavaEarAppXmlHandler,
-    misc.JavaEarHandler,
+
+    misc.JavaEarAppXmlHandler ,
+    misc.JavaEarHandler ,
+
     # is this redundant with Jar manifest?
     misc.JavaJarHandler,
+
     misc.JavaWarHandler,
     misc.JavaWarWebXmlHandler,
-    misc.JBossSarHandler,
-    misc.JBossServiceXmlHandler,
+
+    misc.JBossSarHandler ,
+    misc.JBossServiceXmlHandler ,
+
     misc.MeteorPackageHandler,
     misc.MozillaExtensionHandler,
     misc.NsisInstallerHandler,
@@ -128,14 +153,19 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     npm.PnpmShrinkwrapYamlHandler,
     npm.PnpmLockYamlHandler,
     npm.PnpmWorkspaceYamlHandler,
+
     nuget.NugetNupkgHandler,
     nuget.NugetNuspecHandler,
     nuget.NugetPackagesLockHandler,
+
     opam.OpamFileHandler,
+
     phpcomposer.PhpComposerJsonHandler,
     phpcomposer.PhpComposerLockHandler,
+
     pubspec.DartPubspecYamlHandler,
     pubspec.DartPubspecLockHandler,
+
     pypi.PipfileHandler,
     pypi.PipfileLockHandler,
     pypi.PipRequirementsFileHandler,
@@ -151,26 +181,36 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     pypi.PythonSdistPkgInfoFile,
     pypi.PythonSetupPyHandler,
     pypi.SetupCfgHandler,
+
     readme.ReadmeHandler,
+
     rpm.RpmArchiveHandler,
     rpm.RpmSpecfileHandler,
+
     rubygems.GemMetadataArchiveExtractedHandler,
     rubygems.GemArchiveHandler,
+
     # the order of these handlers matter
     rubygems.GemfileInExtractedGemHandler,
     rubygems.GemfileHandler,
+
     # the order of these handlers matter
     rubygems.GemfileLockInExtractedGemHandler,
     rubygems.GemfileLockHandler,
+
     # the order of these handlers matter
     rubygems.GemspecInInstalledVendorBundleSpecificationsHandler,
     rubygems.GemspecInExtractedGemHandler,
     rubygems.GemspecHandler,
+
     swift.SwiftManifestJsonHandler,
     swift.SwiftPackageResolvedHandler,
     swift.SwiftShowDependenciesDepLockHandler,
+
     windows.MicrosoftUpdateManifestHandler,
+
     win_pe.WindowsExecutableHandler,
+
     # These are handlers for deplock generated files
     pypi.PipInspectDeplockHandler,
 ]
@@ -182,14 +222,18 @@ if on_linux:
 
 SYSTEM_PACKAGE_DATAFILE_HANDLERS = [
     alpine.AlpineInstalledDatabaseHandler,
+
     debian_copyright.DebianCopyrightFileInPackageHandler,
     debian_copyright.DebianCopyrightFileInSourceHandler,
+
     debian.DebianDistrolessInstalledDatabaseHandler,
+
     debian.DebianInstalledFilelistHandler,
     debian.DebianInstalledMd5sumFilelistHandler,
     debian.DebianInstalledStatusDatabaseHandler,
+
     rpm.RpmLicenseFilesHandler,
-    rpm.RpmMarinerContainerManifestHandler,
+    rpm.RpmMarinerContainerManifestHandler
 ]
 
 if on_linux:
@@ -197,6 +241,7 @@ if on_linux:
         rpm.RpmInstalledBdbDatabaseHandler,
         rpm.RpmInstalledSqliteDatabaseHandler,
         rpm.RpmInstalledNdbDatabaseHandler,
+
         win_reg.InstalledProgramFromDockerSoftwareDeltaHandler,
         win_reg.InstalledProgramFromDockerFilesSoftwareHandler,
         win_reg.InstalledProgramFromDockerUtilityvmSoftwareHandler,
@@ -204,21 +249,22 @@ if on_linux:
 
 try:
     from go_inspector.binary import get_go_binary_handler
-
     APPLICATION_PACKAGE_DATAFILE_HANDLERS.append(get_go_binary_handler())
 except ImportError:
     pass
 
 try:
     from rust_inspector.packages import get_rust_binary_handler
-
     APPLICATION_PACKAGE_DATAFILE_HANDLERS.append(get_rust_binary_handler())
 except ImportError:
     pass
 
-ALL_DATAFILE_HANDLERS = APPLICATION_PACKAGE_DATAFILE_HANDLERS + [
-    p for p in SYSTEM_PACKAGE_DATAFILE_HANDLERS if p not in APPLICATION_PACKAGE_DATAFILE_HANDLERS
-]
+ALL_DATAFILE_HANDLERS = (
+    APPLICATION_PACKAGE_DATAFILE_HANDLERS + [
+        p for p in SYSTEM_PACKAGE_DATAFILE_HANDLERS
+        if p not in APPLICATION_PACKAGE_DATAFILE_HANDLERS
+    ]
+)
 
 # registry of all handler classes keyed by datasource_id
 HANDLER_BY_DATASOURCE_ID = {handler.datasource_id: handler for handler in ALL_DATAFILE_HANDLERS}
@@ -240,4 +286,6 @@ def get_package_handler(package_data):
     return ppc
 
 
-PACKAGE_DATA_CLASS_BY_DATASOURCE_ID = {maven.MavenPackageData.datasource_id: maven.MavenPackageData}
+PACKAGE_DATA_CLASS_BY_DATASOURCE_ID = {
+    maven.MavenPackageData.datasource_id: maven.MavenPackageData
+}

--- a/src/packagedcode/maven.py
+++ b/src/packagedcode/maven.py
@@ -1592,7 +1592,7 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
         }
  
         # Remove empty values
-        extra_data = {k: v for k, v in extra_data.items() if v is not None}
+        extra_data = {k: v for k, v in extra_data.items() if v}
  
         urls = cls._build_urls(namespace, name, version, base_url)
         description = cls._build_description(name, version, gradle_status)

--- a/src/packagedcode/maven.py
+++ b/src/packagedcode/maven.py
@@ -1536,11 +1536,9 @@ def get_extension(packaging):
 class GradleModuleMetadataHandler(MavenBasePackageHandler):
     """
     Handler for Gradle Module Metadata files (.module).
-    
     Specification: https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md   
     Example: https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.module
     """
-    
     datasource_id = 'gradle_module_metadata'
     path_patterns = ('*.module',)
     default_package_type = 'maven'
@@ -1555,15 +1553,15 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
         """
         with io.open(location, encoding='utf-8') as f:
             module_data = json.load(f)
-        
+ 
         if TRACE:
             logger.debug(f'GradleModuleMetadataHandler.parse: module_data: {module_data!r}')
-        
+ 
         component = module_data.get('component', {})
         namespace = component.get('group')
         name = component.get('module')
         version = component.get('version')
-        
+ 
         if not (namespace and name and version):
             if TRACE:
                 logger.debug(
@@ -1571,20 +1569,20 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
                     f'"{namespace}":"{name}":"{version}"'
                 )
             return
-        
+ 
         format_version = module_data.get('formatVersion')
-        
+ 
         created_by = module_data.get('createdBy', {})
         gradle_info = created_by.get('gradle', {})
         gradle_version = gradle_info.get('version')
-        
+ 
         component_attributes = component.get('attributes', {})
         gradle_status = component_attributes.get('org.gradle.status')
-        
+ 
         variants = module_data.get('variants', [])
         primary_file_data = cls._extract_primary_file_data(variants, name, version)
         variants_data = cls._extract_variants_metadata(variants)
-        
+ 
         extra_data = {
             'format_version': format_version,
             'gradle_version': gradle_version,
@@ -1592,14 +1590,13 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
             'component_attributes': component_attributes,
             'variants': variants_data,
         }
-        
+ 
         # Remove empty values
         extra_data = {k: v for k, v in extra_data.items() if v is not None}
-        
+ 
         urls = cls._build_urls(namespace, name, version, base_url)
-        
         description = cls._build_description(name, version, gradle_status)
-        
+ 
         package_data = dict(
             datasource_id=cls.datasource_id,
             type=cls.default_package_type,
@@ -1612,79 +1609,77 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
             **urls,
             **primary_file_data,
         )
-        
+ 
         yield models.PackageData.from_data(package_data, package_only)
-    
+ 
     @classmethod
     def _extract_primary_file_data(cls, variants, name, version):
         """
         Extract checksum and size information from the primary JAR file.
-    
         Preference order:
         1. apiElements
         2. runtimeElements
         3. any variant containing the primary JAR
         """
         primary_jar_name = f'{name}-{version}.jar'
-    
+ 
         def iter_files(variants):
             for variant in variants:
                 for file_info in variant.get('files', []) or []:
                     yield variant.get('name'), file_info
-    
+ 
         # Index files by variant name
         files_by_variant = {}
         for variant_name, file_info in iter_files(variants):
             if file_info.get('name') == primary_jar_name:
                 files_by_variant.setdefault(variant_name, []).append(file_info)
-    
+ 
         # Try preferred variants first
         for preferred in ('apiElements', 'runtimeElements'):
             for file_info in files_by_variant.get(preferred, []):
                 data = cls._extract_file_checksums(file_info)
                 if data:
                     return data
-    
+ 
         # Fallback to any variant
         for files in files_by_variant.values():
             for file_info in files:
                 data = cls._extract_file_checksums(file_info)
                 if data:
                     return data
-    
+ 
         return {}
-    
+ 
     @classmethod
     def _extract_file_checksums(cls, file_info):
         """
         Extract checksum and size information from a file info dictionary.
         """
-        
         checksums = {}
-        checksum_fields = ['sha1', 'sha256', 'sha512', 'md5', 'size'] 
-        
+        checksum_fields = ['sha1', 'sha256', 'sha512', 'md5', 'size']
+ 
         for field in checksum_fields:
             if file_info.get(field):
                 checksums[field] = file_info[field]
-        
+ 
         return checksums
-    
+ 
     @classmethod
     def _extract_variants_metadata(cls, variants):
         """
         Extract non-semantic metadata about each variant.
         """
         variants_metadata = []
-    
+ 
         for variant in variants:
             variant_info = {
                 'name': variant.get('name'),
             }
-    
+ 
             attributes = variant.get('attributes')
             if attributes:
                 variant_info['attributes'] = attributes
-    
+ 
             files = variant.get('files') or []
             if files:
                 variant_info['files'] = [
@@ -1695,27 +1690,26 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
                     }
                     for f in files
                 ]
-    
+ 
             variants_metadata.append(variant_info)
-    
+ 
         return variants_metadata
-    
+ 
     @classmethod
     def _build_urls(cls, namespace, name, version, base_url):
         """
         Build repository URLs for the package.
         """
-        
         # Build repository path
         namespace_path = namespace.replace('.', '/')
         repo_path = f'{namespace_path}/{name}/{version}'
-        
+ 
         return {
             'repository_homepage_url': f'{base_url}/{repo_path}/',
             'repository_download_url': f'{base_url}/{repo_path}/{name}-{version}.jar',
             'api_data_url': f'{base_url}/{repo_path}/{name}-{version}.module',
         }
-    
+ 
     @classmethod
     def _build_description(cls, name, version, gradle_status):
         """
@@ -1726,9 +1720,9 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
             desc_parts.append(f'version {version}')
         if gradle_status:
             desc_parts.append(f'(status: {gradle_status})')
-        
+ 
         return ' '.join(desc_parts)
-    
+ 
     @classmethod
     def assign_package_to_resources(cls, package, resource, codebase, package_adder):
         """
@@ -1741,7 +1735,7 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
                 codebase,
                 package_adder
             )
-            
+  
         return models.DatafileHandler.assign_package_to_resources(
             package,
             resource=resource,

--- a/src/packagedcode/maven.py
+++ b/src/packagedcode/maven.py
@@ -7,6 +7,9 @@
 # See https://aboutcode.org for more information about nexB OSS projects.
 #
 
+import io
+import json
+
 import logging
 import os.path
 from pprint import pformat
@@ -1529,3 +1532,223 @@ def get_extension(packaging):
         return packaging
     else:
         return 'jar'
+        
+class GradleModuleMetadataHandler(MavenBasePackageHandler):
+    """
+    Handler for Gradle Module Metadata files (.module).
+    
+    Gradle Module Metadata is a JSON format that provides richer metadata than
+    traditional Maven POMs, including multiple variants, comprehensive checksums,
+    and Gradle-specific attributes.
+    
+    Specification: https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
+    Example: https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.module
+    """
+    
+    datasource_id = 'gradle_module_metadata'
+    path_patterns = ('*.module',)
+    default_package_type = 'maven'
+    default_primary_language = 'Java'
+    description = 'Gradle Module Metadata'
+    documentation_url = 'https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md'
+
+    @classmethod
+    def parse(cls, location, package_only=False, base_url='https://repo1.maven.org/maven2'):
+        """
+        Parse a Gradle Module Metadata file and yield PackageData.
+        """
+        with io.open(location, encoding='utf-8') as f:
+            module_data = json.load(f)
+        
+        if TRACE:
+            logger.debug(f'GradleModuleMetadataHandler.parse: module_data: {module_data!r}')
+        
+        component = module_data.get('component', {})
+        namespace = component.get('group')
+        name = component.get('module')
+        version = component.get('version')
+        
+        if not (namespace and name and version):
+            if TRACE:
+                logger.debug(
+                    f'GradleModuleMetadataHandler.parse: Incomplete GAV: '
+                    f'"{namespace}":"{name}":"{version}"'
+                )
+            return
+        
+        format_version = module_data.get('formatVersion')
+        
+        created_by = module_data.get('createdBy', {})
+        gradle_info = created_by.get('gradle', {})
+        gradle_version = gradle_info.get('version')
+        
+        component_attributes = component.get('attributes', {})
+        gradle_status = component_attributes.get('org.gradle.status')
+        
+        variants = module_data.get('variants', [])
+        primary_file_data = cls._extract_primary_file_data(variants, name, version)
+        variants_data = cls._extract_variants_metadata(variants)
+        
+        extra_data = {
+            'format_version': format_version,
+            'gradle_version': gradle_version,
+            'gradle_status': gradle_status,
+            'component_attributes': component_attributes,
+            'variants': variants_data,
+        }
+        
+        # Remove empty values
+        extra_data = {k: v for k, v in extra_data.items() if v is not None}
+        
+        urls = cls._build_urls(namespace, name, version, base_url)
+        
+        description = cls._build_description(name, version, gradle_status)
+        
+        package_data = dict(
+            datasource_id=cls.datasource_id,
+            type=cls.default_package_type,
+            primary_language=cls.default_primary_language,
+            namespace=namespace,
+            name=name,
+            version=version,
+            description=description,
+            extra_data=extra_data,
+            **urls,
+            **primary_file_data,
+        )
+        
+        yield models.PackageData.from_data(package_data, package_only)
+    
+    @classmethod
+    def _extract_primary_file_data(cls, variants, name, version):
+        """
+        Extract checksum and size information from the primary JAR file.
+    
+        Preference order:
+        1. apiElements
+        2. runtimeElements
+        3. any variant containing the primary JAR
+        """
+        primary_jar_name = f'{name}-{version}.jar'
+    
+        def iter_files(variants):
+            for variant in variants:
+                for file_info in variant.get('files', []) or []:
+                    yield variant.get('name'), file_info
+    
+        # Index files by variant name
+        files_by_variant = {}
+        for variant_name, file_info in iter_files(variants):
+            if file_info.get('name') == primary_jar_name:
+                files_by_variant.setdefault(variant_name, []).append(file_info)
+    
+        # Try preferred variants first
+        for preferred in ('apiElements', 'runtimeElements'):
+            for file_info in files_by_variant.get(preferred, []):
+                data = cls._extract_file_checksums(file_info)
+                if data:
+                    return data
+    
+        # Fallback to any variant
+        for files in files_by_variant.values():
+            for file_info in files:
+                data = cls._extract_file_checksums(file_info)
+                if data:
+                    return data
+    
+        return {}
+    
+    @classmethod
+    def _extract_file_checksums(cls, file_info):
+        """
+        Extract checksum and size information from a file info dictionary.
+        """
+        
+        checksums = {}
+        checksum_fields = ['sha1', 'sha256', 'sha512', 'md5', 'size'] 
+        
+        for field in checksum_fields:
+            if file_info.get(field):
+                checksums[field] = file_info[field]
+        
+        return checksums
+    
+    @classmethod
+    def _extract_variants_metadata(cls, variants):
+        """
+        Extract non-semantic metadata about each variant.
+        """
+        variants_metadata = []
+    
+        for variant in variants:
+            variant_info = {
+                'name': variant.get('name'),
+            }
+    
+            attributes = variant.get('attributes')
+            if attributes:
+                variant_info['attributes'] = attributes
+    
+            files = variant.get('files') or []
+            if files:
+                variant_info['files'] = [
+                    {
+                        'name': f.get('name'),
+                        'url': f.get('url'),
+                        'size': f.get('size'),
+                    }
+                    for f in files
+                ]
+    
+            variants_metadata.append(variant_info)
+    
+        return variants_metadata
+    
+    @classmethod
+    def _build_urls(cls, namespace, name, version, base_url):
+        """
+        Build repository URLs for the package.
+        """
+        
+        # Build repository path
+        namespace_path = namespace.replace('.', '/')
+        repo_path = f'{namespace_path}/{name}/{version}'
+        
+        return {
+            'repository_homepage_url': f'{base_url}/{repo_path}/',
+            'repository_download_url': f'{base_url}/{repo_path}/{name}-{version}.jar',
+            'api_data_url': f'{base_url}/{repo_path}/{name}-{version}.module',
+        }
+    
+    @classmethod
+    def _build_description(cls, name, version, gradle_status):
+        """
+        Build a description string for the package.
+        """
+        desc_parts = [f'{name}']
+        if version:
+            desc_parts.append(f'version {version}')
+        if gradle_status:
+            desc_parts.append(f'(status: {gradle_status})')
+        
+        return ' '.join(desc_parts)
+    
+    @classmethod
+    def assign_package_to_resources(cls, package, resource, codebase, package_adder):
+        """
+        Assign package to resources in the codebase.
+        """
+        if resource.path.endswith('.module'):
+            return models.DatafileHandler.assign_package_to_parent_tree(
+                package,
+                resource,
+                codebase,
+                package_adder
+            )
+            
+        return models.DatafileHandler.assign_package_to_resources(
+            package,
+            resource=resource,
+            codebase=codebase,
+            package_adder=package_adder,
+        )

--- a/src/packagedcode/maven.py
+++ b/src/packagedcode/maven.py
@@ -1550,7 +1550,7 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
     default_package_type = 'maven'
     default_primary_language = 'Java'
     description = 'Gradle Module Metadata'
-    documentation_url = 'https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md'
+    documentation_url = 'https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md'
 
     @classmethod
     def parse(cls, location, package_only=False, base_url='https://repo1.maven.org/maven2'):

--- a/src/packagedcode/maven.py
+++ b/src/packagedcode/maven.py
@@ -1537,11 +1537,7 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
     """
     Handler for Gradle Module Metadata files (.module).
     
-    Gradle Module Metadata is a JSON format that provides richer metadata than
-    traditional Maven POMs, including multiple variants, comprehensive checksums,
-    and Gradle-specific attributes.
-    
-    Specification: https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
+    Specification: https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md   
     Example: https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.module
     """
     

--- a/src/packagedcode/maven.py
+++ b/src/packagedcode/maven.py
@@ -1532,13 +1532,14 @@ def get_extension(packaging):
         return packaging
     else:
         return 'jar'
-        
+
 class GradleModuleMetadataHandler(MavenBasePackageHandler):
     """
     Handler for Gradle Module Metadata files (.module).
-    Specification: https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md   
+    Specification: https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md
     Example: https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.module
     """
+
     datasource_id = 'gradle_module_metadata'
     path_patterns = ('*.module',)
     default_package_type = 'maven'
@@ -1553,15 +1554,15 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
         """
         with io.open(location, encoding='utf-8') as f:
             module_data = json.load(f)
- 
+
         if TRACE:
             logger.debug(f'GradleModuleMetadataHandler.parse: module_data: {module_data!r}')
- 
+
         component = module_data.get('component', {})
         namespace = component.get('group')
         name = component.get('module')
         version = component.get('version')
- 
+
         if not (namespace and name and version):
             if TRACE:
                 logger.debug(
@@ -1569,20 +1570,20 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
                     f'"{namespace}":"{name}":"{version}"'
                 )
             return
- 
+
         format_version = module_data.get('formatVersion')
- 
+
         created_by = module_data.get('createdBy', {})
         gradle_info = created_by.get('gradle', {})
         gradle_version = gradle_info.get('version')
- 
+
         component_attributes = component.get('attributes', {})
         gradle_status = component_attributes.get('org.gradle.status')
- 
+
         variants = module_data.get('variants', [])
         primary_file_data = cls._extract_primary_file_data(variants, name, version)
         variants_data = cls._extract_variants_metadata(variants)
- 
+
         extra_data = {
             'format_version': format_version,
             'gradle_version': gradle_version,
@@ -1590,13 +1591,13 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
             'component_attributes': component_attributes,
             'variants': variants_data,
         }
- 
+
         # Remove empty values
         extra_data = {k: v for k, v in extra_data.items() if v}
- 
+
         urls = cls._build_urls(namespace, name, version, base_url)
         description = cls._build_description(name, version, gradle_status)
- 
+
         package_data = dict(
             datasource_id=cls.datasource_id,
             type=cls.default_package_type,
@@ -1609,9 +1610,9 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
             **urls,
             **primary_file_data,
         )
- 
+
         yield models.PackageData.from_data(package_data, package_only)
- 
+
     @classmethod
     def _extract_primary_file_data(cls, variants, name, version):
         """
@@ -1622,34 +1623,34 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
         3. any variant containing the primary JAR
         """
         primary_jar_name = f'{name}-{version}.jar'
- 
+
         def iter_files(variants):
             for variant in variants:
                 for file_info in variant.get('files', []) or []:
                     yield variant.get('name'), file_info
- 
+
         # Index files by variant name
         files_by_variant = {}
         for variant_name, file_info in iter_files(variants):
             if file_info.get('name') == primary_jar_name:
                 files_by_variant.setdefault(variant_name, []).append(file_info)
- 
+
         # Try preferred variants first
         for preferred in ('apiElements', 'runtimeElements'):
             for file_info in files_by_variant.get(preferred, []):
                 data = cls._extract_file_checksums(file_info)
                 if data:
                     return data
- 
+
         # Fallback to any variant
         for files in files_by_variant.values():
             for file_info in files:
                 data = cls._extract_file_checksums(file_info)
                 if data:
                     return data
- 
+
         return {}
- 
+
     @classmethod
     def _extract_file_checksums(cls, file_info):
         """
@@ -1657,29 +1658,28 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
         """
         checksums = {}
         checksum_fields = ['sha1', 'sha256', 'sha512', 'md5', 'size']
- 
+
         for field in checksum_fields:
             if file_info.get(field):
                 checksums[field] = file_info[field]
- 
+
         return checksums
- 
+
     @classmethod
     def _extract_variants_metadata(cls, variants):
         """
         Extract non-semantic metadata about each variant.
         """
         variants_metadata = []
- 
         for variant in variants:
             variant_info = {
                 'name': variant.get('name'),
             }
- 
+
             attributes = variant.get('attributes')
             if attributes:
                 variant_info['attributes'] = attributes
- 
+
             files = variant.get('files') or []
             if files:
                 variant_info['files'] = [
@@ -1690,11 +1690,11 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
                     }
                     for f in files
                 ]
- 
+
             variants_metadata.append(variant_info)
- 
+
         return variants_metadata
- 
+
     @classmethod
     def _build_urls(cls, namespace, name, version, base_url):
         """
@@ -1703,13 +1703,13 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
         # Build repository path
         namespace_path = namespace.replace('.', '/')
         repo_path = f'{namespace_path}/{name}/{version}'
- 
+
         return {
             'repository_homepage_url': f'{base_url}/{repo_path}/',
             'repository_download_url': f'{base_url}/{repo_path}/{name}-{version}.jar',
             'api_data_url': f'{base_url}/{repo_path}/{name}-{version}.module',
         }
- 
+
     @classmethod
     def _build_description(cls, name, version, gradle_status):
         """
@@ -1720,9 +1720,9 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
             desc_parts.append(f'version {version}')
         if gradle_status:
             desc_parts.append(f'(status: {gradle_status})')
- 
+
         return ' '.join(desc_parts)
- 
+
     @classmethod
     def assign_package_to_resources(cls, package, resource, codebase, package_adder):
         """
@@ -1735,7 +1735,7 @@ class GradleModuleMetadataHandler(MavenBasePackageHandler):
                 codebase,
                 package_adder
             )
-  
+
         return models.DatafileHandler.assign_package_to_resources(
             package,
             resource=resource,

--- a/tests/packagedcode/data/gradle_module_metadata/opentest4j-1.3.0/opentest4j-1.3.0.module
+++ b/tests/packagedcode/data/gradle_module_metadata/opentest4j-1.3.0/opentest4j-1.3.0.module
@@ -1,0 +1,100 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "org.opentest4j",
+    "module": "opentest4j",
+    "version": "1.3.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "createdBy": {
+    "gradle": {
+      "version": "8.2"
+    }
+  },
+  "variants": [
+    {
+      "name": "apiElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 6,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api"
+      },
+      "files": [
+        {
+          "name": "opentest4j-1.3.0.jar",
+          "url": "opentest4j-1.3.0.jar",
+          "size": 14304,
+          "sha512": "78fc698a7871bb50305e3657893c10500595f043348d875f57bc39ca4a6a51eda3967b7c8c8a7ec3e8f85f2171bca4aa98823e912e416e87e81c6ba5b70a37c3",
+          "sha256": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+          "sha1": "152ea56b3a72f655d4fd677fc0ef2596c3dd5e6e",
+          "md5": "03c404f727531f3fd3b4c73997899327"
+        }
+      ]
+    },
+    {
+      "name": "runtimeElements",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 6,
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [
+        {
+          "name": "opentest4j-1.3.0.jar",
+          "url": "opentest4j-1.3.0.jar",
+          "size": 14304,
+          "sha512": "78fc698a7871bb50305e3657893c10500595f043348d875f57bc39ca4a6a51eda3967b7c8c8a7ec3e8f85f2171bca4aa98823e912e416e87e81c6ba5b70a37c3",
+          "sha256": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+          "sha1": "152ea56b3a72f655d4fd677fc0ef2596c3dd5e6e",
+          "md5": "03c404f727531f3fd3b4c73997899327"
+        }
+      ]
+    },
+    {
+      "name": "javadocElements",
+      "attributes": {
+        "org.gradle.category": "documentation",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.docstype": "javadoc",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [
+        {
+          "name": "opentest4j-1.3.0-javadoc.jar",
+          "url": "opentest4j-1.3.0-javadoc.jar",
+          "size": 107825,
+          "sha512": "86e0b9433d0fd5d0abdd9ef37ea307ce03190edf90f5d3db27ec532e5e3ffdbfe97fda24020f2ef44617f270919ddfaded46ea08770055a90de4fe98af397222",
+          "sha256": "81180249eda3054cbcff83b52d0e99302d049cfb6cc1c85550e2c498b2a91223",
+          "sha1": "268a5a3f089341f0755f304337d733e70671884d",
+          "md5": "c5f81d7e097aa6c8c01608ac27f0b6fc"
+        }
+      ]
+    },
+    {
+      "name": "sourcesElements",
+      "attributes": {
+        "org.gradle.category": "documentation",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.docstype": "sources",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [
+        {
+          "name": "opentest4j-1.3.0-sources.jar",
+          "url": "opentest4j-1.3.0-sources.jar",
+          "size": 10280,
+          "sha512": "f54436dbd733fdae98b984c2c42ef4d1fc114217155b044c21f6e44f0c9e509156423c16aa73aa2d6acae00d2677e7c072aaea36836b21a440df6abe08d44b8d",
+          "sha256": "724a24e3a68267d5ebac9411389a15638a71e50c62448ffa58f59c34d5c1ebb2",
+          "sha1": "afb8ff23cffb021c56f333953aebfe6e8818568e",
+          "md5": "6f9ee997107418d6295a0e32f8695a83"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/packagedcode/data/plugin/plugins_list_linux.txt
+++ b/tests/packagedcode/data/plugin/plugins_list_linux.txt
@@ -553,6 +553,13 @@ Package type:  maven
   path_patterns:    '*/build.gradle', '*/build.gradle.kts'
 --------------------------------------------
 Package type:  maven
+  datasource_id:     gradle_module_metadata
+  documentation URL: https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/design/gradle-module-metadata-latest-specification.md
+  primary language:  Java
+  description:       Gradle Module Metadata
+  path_patterns:    '*.module'
+--------------------------------------------
+Package type:  maven
   datasource_id:     maven_pom
   documentation URL: https://maven.apache.org/pom.html
   primary language:  Java

--- a/tests/packagedcode/test_gradle_module_metadata.py
+++ b/tests/packagedcode/test_gradle_module_metadata.py
@@ -1,0 +1,122 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# ScanCode is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/scancode-toolkit for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+import json
+import os.path
+
+from commoncode import testcase
+from packagedcode.maven import GradleModuleMetadataHandler
+
+
+class TestGradleModuleMetadataHandler(testcase.FileBasedTesting):
+    test_data_dir = os.path.join(os.path.dirname(__file__), "data")
+
+    def test_parse_opentest4j_1_3_0_module_basic_fields(self):
+        test_file = self.get_test_loc(
+            "gradle_module_metadata/opentest4j-1.3.0/opentest4j-1.3.0.module"
+        )
+
+        packages = list(GradleModuleMetadataHandler.parse(test_file))
+        assert len(packages) == 1
+        pkg = packages[0]
+
+        assert pkg.datasource_id == "gradle_module_metadata"
+        assert pkg.type == "maven"
+        assert pkg.primary_language == "Java"
+
+        assert pkg.namespace == "org.opentest4j"
+        assert pkg.name == "opentest4j"
+        assert pkg.version == "1.3.0"
+
+        assert pkg.repository_homepage_url == (
+            "https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.3.0/"
+        )
+        assert pkg.repository_download_url == (
+            "https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
+        )
+        assert pkg.api_data_url == (
+            "https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.module"
+        )
+
+        # From apiElements/runtimeElements file checksums
+        assert pkg.size == 14304
+        assert pkg.sha1 == "152ea56b3a72f655d4fd677fc0ef2596c3dd5e6e"
+        assert pkg.sha256 == "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b"
+        assert pkg.sha512 == (
+            "78fc698a7871bb50305e3657893c10500595f043348d875f57bc39ca4a6a51eda3967b7c8c8a7ec3e8f85f2171bca4aa98823e912e416e87e81c6ba5b70a37c3"
+        )
+        assert pkg.md5 == "03c404f727531f3fd3b4c73997899327"
+
+        # Extra data should include gradle metadata
+        assert pkg.extra_data.get("format_version") == "1.1"
+        assert pkg.extra_data.get("gradle_version") == "8.2"
+        assert pkg.extra_data.get("gradle_status") == "release"
+
+        component_attributes = pkg.extra_data.get("component_attributes") or {}
+        assert component_attributes.get("org.gradle.status") == "release"
+
+    def test_parse_opentest4j_1_3_0_module_variants_metadata(self):
+        test_file = self.get_test_loc(
+            "gradle_module_metadata/opentest4j-1.3.0/opentest4j-1.3.0.module"
+        )
+
+        packages = list(GradleModuleMetadataHandler.parse(test_file))
+        assert len(packages) == 1
+        pkg = packages[0]
+
+        variants = pkg.extra_data.get("variants") or []
+        assert variants, "Expected variants in extra_data"
+
+        variant_names = {v.get("name") for v in variants}
+        assert "apiElements" in variant_names
+        assert "runtimeElements" in variant_names
+        assert "javadocElements" in variant_names
+        assert "sourcesElements" in variant_names
+
+        # Ensure at least the apiElements variant contains expected file details
+        api_variants = [v for v in variants if v.get("name") == "apiElements"]
+        assert len(api_variants) == 1
+        api_variant = api_variants[0]
+
+        api_files = api_variant.get("files") or []
+        assert api_files, "Expected files list for apiElements variant"
+        assert api_files[0].get("name") == "opentest4j-1.3.0.jar"
+        assert api_files[0].get("url") == "opentest4j-1.3.0.jar"
+        assert api_files[0].get("size") == 14304
+
+    def test_parse_returns_nothing_when_component_is_missing_required_fields(self):
+        # Minimal invalid Gradle module metadata: missing group/module/version
+        invalid_module = {
+            "formatVersion": "1.1",
+            "component": {
+                # 'group': 'org.example',  # missing
+                "module": "demo",
+                "version": "1.0.0",
+            },
+            "variants": [],
+        }
+
+        test_dir = self.get_temp_dir()
+        test_file = os.path.join(test_dir, "invalid.module")
+        with open(test_file, "w", encoding="utf-8") as f:
+            json.dump(invalid_module, f)
+
+        packages = list(GradleModuleMetadataHandler.parse(test_file))
+        assert packages == []
+
+    def test_description_contains_status_when_present(self):
+        test_file = self.get_test_loc(
+            "gradle_module_metadata/opentest4j-1.3.0/opentest4j-1.3.0.module"
+        )
+        packages = list(GradleModuleMetadataHandler.parse(test_file))
+        assert len(packages) == 1
+        pkg = packages[0]
+
+        # Format is defined by _build_description()
+        assert pkg.description == "opentest4j version 1.3.0 (status: release)"


### PR DESCRIPTION
Fixes #4624 

### Summary
Add support for parsing Gradle Module Metadata (`*.module`) files published alongside Maven artifacts (e.g. on Maven Central). The new handler extracts core GAV coordinates, checksums/size for the primary jar, Gradle metadata, and variants information.

### What changed
- Added `GradleModuleMetadataHandler` to parse `*.module` JSON metadata files.
- Registered the new handler in `APPLICATION_PACKAGE_DATAFILE_HANDLERS`.
- Added tests + fixture using `opentest4j-1.3.0.module`.
- Updated `--list-packages` fixture output (Linux) after registering the handler.

### Tests
- `py.test tests/packagedcode/test_gradle_module_metadata.py`
- `py.test tests/packagedcode/test_plugin_package.py::TestPlugins::test_package_list_command`

### Tasks
* [x] Reviewed contribution guidelines
* [x] PR is descriptively titled and links the original issue above
* [x] Tests pass locally
* [x] Commits are in a uniquely-named feature branch and has no merge conflicts
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)

Signed-off-by: uttam282005 <uttam282005@gmail.com>
