### PR TITLE
Fix incorrect license detection in dragon4.c

### DIFF
--- a/src/licensedcode/data/rules/false-positive_dragon4.RULE
+++ b/src/licensedcode/data/rules/false-positive_dragon4.RULE
@@ -1,0 +1,6 @@
+---
+is_false_positive: yes
+notes: False positive seen in numpy dragon4.c
+---
+
+As a special exception the smallest normal value

--- a/src/licensedcode/data/rules/license-intro_8.RULE
+++ b/src/licensedcode/data/rules/license-intro_8.RULE
@@ -1,7 +1,7 @@
 ---
 license_expression: generic-exception
-is_license_intro: yes
-relevance: 99
+is_license_clue: yes
+relevance: 100
 ---
 
 As a special exception

--- a/tests/licensedcode/data/false_positive/dragon4.c
+++ b/tests/licensedcode/data/false_positive/dragon4.c
@@ -1,0 +1,1 @@
+As a special exception the smallest normal value

--- a/tests/licensedcode/data/false_positive/dragon4.c.yml
+++ b/tests/licensedcode/data/false_positive/dragon4.c.yml
@@ -1,0 +1,2 @@
+license_detections: []
+license_clues: []

--- a/tests/licensedcode/data/licenses_misc/negative/license-intro_8.txt
+++ b/tests/licensedcode/data/licenses_misc/negative/license-intro_8.txt
@@ -1,0 +1,1 @@
+As a special exception

--- a/tests/licensedcode/data/licenses_misc/negative/license-intro_8.txt.yml
+++ b/tests/licensedcode/data/licenses_misc/negative/license-intro_8.txt.yml
@@ -1,0 +1,14 @@
+license_detections: []
+license_clues:
+  - license_expression: generic-exception
+    license_expression_spdx: LicenseRef-scancode-generic-exception
+    from_file: license-intro_8.txt
+    start_line: 1
+    end_line: 1
+    matcher: 1-hash
+    score: 100.0
+    matched_length: 3
+    match_coverage: 100.0
+    rule_relevance: 100
+    rule_identifier: license-intro_8.RULE
+    rule_url: https://github.com/nexB/scancode-toolkit/tree/develop/src/licensedcode/data/rules/license-intro_8.RULE


### PR DESCRIPTION
Fixes #4584

### Description
This PR fixes an incorrect license detection in NumPy's `dragon4.c`, where the text "As a special exception" was incorrectly triggering a `generic-exception` match.

**Changes:**
- **Modified `license-intro_8.RULE`**: Downgraded this rule from `is_license_intro` to `is_license_clue`. This ensures the phrase contributes to evidence but does not trigger a false positive when found alone.
- **Added `false-positive_dragon4.RULE`**: Added a specific false positive rule to ignore the misleading text ("As a special exception the smallest normal value") found in `dragon4.c`.

**Verification:**
- Reproduced the issue locally: confirmed `generic-exception` was originally detected.
- Verified the fix: confirmed the detection is gone after the changes.
- Validated the rule downgrade: confirmed that `license-intro_8.RULE` correctly behaves as a clue (no detection) when isolated.

### Tasks
- [x] Reviewed [contribution guidelines](https://github.com/aboutcode-org/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
- [x] PR is descriptively titled 📄 and links the original issue above 🔗
- [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR (Verified fix locally)
- [x] Commits are in uniquely-named feature branch and has no merge conflicts 📂
- [ ] Updated documentation pages (if applicable)
- [ ] Updated CHANGELOG.rst (if applicable)