### PR TITLE
Add bintray license aliases for Apache-2.0

### DIFF
--- a/src/licensedcode/data/licenses/apache-2.0.LICENSE
+++ b/src/licensedcode/data/licenses/apache-2.0.LICENSE
@@ -2,6 +2,11 @@
 key: apache-2.0
 short_name: Apache 2.0
 name: Apache License 2.0
+aliases:
+  - Apache 2
+  - Apache License Version 2.0
+  - Apache License, Version 2.0
+  - Apache-2
 category: Permissive
 owner: Apache Software Foundation
 homepage_url: http://www.apache.org/licenses/


### PR DESCRIPTION
Fixes #974

### Summary

This PR adds Bintray-related license aliases to the Apache-2.0 license
to improve license detection accuracy in ScanCode.

The change ensures that licenses previously referenced via Bintray
are correctly mapped to Apache-2.0 during scanning.

This addresses the missing alias mappings reported in issue #974.

Note: This is my first contribution to this repository, so CI workflows
may require maintainer approval.

### Tasks

* [x] Reviewed contribution guidelines
* [x] PR is descriptively titled and links the original issue
* [x] Tests pass locally
* [x] Commits are in a uniquely-named feature branch with no merge conflicts
* [ ] Updated documentation pages (not applicable)
* [ ] Updated CHANGELOG.rst (not applicable)
