### PR TITLE
Add Apache-2.0 license aliases used by Bintray

### DIFF
--- a/src/licensedcode/data/licenses/apache-2.0.LICENSE
+++ b/src/licensedcode/data/licenses/apache-2.0.LICENSE
@@ -2,6 +2,14 @@
 key: apache-2.0
 short_name: Apache 2.0
 name: Apache License 2.0
+
+aliases:
+  - Apache 2
+  - Apache-2
+  - Apache License Version 2.0
+  - Apache License, Version 2.0
+
+
 category: Permissive
 owner: Apache Software Foundation
 homepage_url: http://www.apache.org/licenses/


### PR DESCRIPTION
Fixes #3295

### Summary
Adds missing aliases for the Apache License 2.0 so ScanCode can correctly
detect the license when referenced using alternate names (for example from
Bintray metadata).

### Tasks

* [x] Reviewed contribution guidelines
* [x] PR is descriptively titled and links the original issue
* [ ] Tests pass (CI awaiting maintainer approval for first-time contributor)
* [x] Commits are in a uniquely named feature branch with no merge conflicts
* [ ] Updated documentation pages (not applicable)
* [ ] Updated CHANGELOG.rst (not applicable)

Signed-off-by: B R GOVIND <brgovind2005@gmail.com>
