### PR TITLE
Add license rule for LGPL-3.0-or-later notice pattern

### DIFF
--- a/src/licensedcode/data/rules/lgpl-3.0-plus_309.RULE
+++ b/src/licensedcode/data/rules/lgpl-3.0-plus_309.RULE
@@ -1,0 +1,7 @@
+---
+license_expression: lgpl-3.0-plus
+is_license_notice: yes
+relevance: 100
+---
+Distributed under the terms of the GNU Lesser General Public License,
+either version 3 of the License, or (at your option) any later version.


### PR DESCRIPTION
Fixes #3935

Adds detection rule for the license notice pattern:
'Distributed under the terms of the GNU Lesser General Public License,
either version 3 of the License, or (at your option) any later version.'

This pattern was previously misdetected as `lgpl-2.1-plus` due to partial matching of 'GNU Lesser General Public License' without the version 3 context. The new rule matches the complete two-line notice and correctly identifies it as `lgpl-3.0-plus`.

**Testing done:**
- Created test file with the exact pattern from issue #3935
- Verified detection changed from `lgpl-2.1-plus AND lgpl-3.0-plus` to just `lgpl-3.0-plus`
- Rule passes `scancode-reindex-licenses`

### Tasks
* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)

Signed-off-by: Harpreet Kaur Gothra <harpreetk2146@gmail.com>
