### PR TITLE
Replace assert with explicit exception in Query initialization

### DIFF
--- a/src/licensedcode/query.py
+++ b/src/licensedcode/query.py
@@ -209,7 +209,11 @@ class Query(object):
         or junk-only lines.
         Line numbers start at ``start_line`` which is 1-based by default.
         """
-        assert (location or query_string) and idx
+        if not ((location or query_string) and idx):
+        raise ValueError(
+        "Either location or query_string must be provided, and idx must be set"
+    )
+
 
         self.location = location
         self.query_string = query_string

--- a/src/packagedcode/maven.py
+++ b/src/packagedcode/maven.py
@@ -422,7 +422,11 @@ class MavenPom(pom.Pom):
         """
         Build a POM from a location or unicode text.
         """
-        assert (location or text) and (not (location and text))
+        if not ((location or text) and not (location and text)):
+    raise ValueError(
+        "Either location or text must be provided, but not both"
+    )
+
 
         if location:
             try:


### PR DESCRIPTION
Fixes #175

Replaced a runtime assert in src/licensedcode/query.py with a ValueError
to ensure the validation is not skipped when Python is run in optimized
mode (-O / -OO).
