### PR TITLE
docs: document Apple Silicon contributor setup in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -132,6 +132,29 @@ To set up ScanCode for local development:
    libraries (from the `thirdparty/ directory`), setup the paths, etc.
    See https://virtualenv.pypa.io/en/latest/ for more details.
 
+   .. warning::
+
+   **Apple Silicon (M1/M2/M3/M4) users**
+
+   Due to missing ARM64 wheels for some native dependencies, the contributor
+   setup may fail when using ARM-native Python.
+
+   Use an x86_64 Python installation under Rosetta and configure ScanCode to
+   use it explicitly:
+
+   .. code-block:: bash
+
+      # Install x86_64 Python via Rosetta
+      arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      arch -x86_64 /usr/local/bin/brew install python@3.12
+
+      # Tell configure to use it
+      echo "/usr/local/bin/python3.12" > PYTHON_EXECUTABLE
+      ./configure --dev
+
+   See issue #3205 for more context on Apple Silicon compatibility.
+
+
    Run this command to configure ScanCode::
 
         ./configure --dev

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -139,20 +139,12 @@ To set up ScanCode for local development:
    Due to missing ARM64 wheels for some native dependencies, the contributor
    setup may fail when using ARM-native Python.
 
-   Use an x86_64 Python installation under Rosetta and configure ScanCode to
-   use it explicitly:
+   Use an x86_64 Python installation under Rosetta and configure ScanCode
+   to use it explicitly before running ``./configure --dev``.
 
-   .. code-block:: bash
-
-      # Install x86_64 Python via Rosetta
-      arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-      arch -x86_64 /usr/local/bin/brew install python@3.12
-
-      # Tell configure to use it
-      echo "/usr/local/bin/python3.12" > PYTHON_EXECUTABLE
-      ./configure --dev
-
-   See issue #3205 for more context on Apple Silicon compatibility.
+   See the Homebrew and Python documentation for installing x86_64 Python
+   under Rosetta, and issue #3205 for more context on Apple Silicon
+   compatibility.
 
 
    Run this command to configure ScanCode::


### PR DESCRIPTION
Fixes #3205

### Problem
New contributors on Apple Silicon (M1/M2/M3/M4) following CONTRIBUTING.rst
encounter dependency installation failures when using ARM-native Python.
The contributor guide currently provides no warning or workaround for this
platform, despite the setup failing for Apple Silicon users.

### Root cause
Several development dependencies do not provide ARM64 wheels. When using
ARM-native Python (the default on Apple Silicon), pip attempts to build
these dependencies from source and fails.

### Change in this PR
Adds a warning to CONTRIBUTING.rst immediately before the `./configure --dev`
step explaining:
- why the setup fails on Apple Silicon
- how to use an x86_64 Python installation under Rosetta
- how to configure ScanCode to use that Python explicitly

This aligns the contributor documentation with existing installation docs
and prevents new contributors from hitting a blocking error.
