### PR TITLE
Fix: Remove a confusing rule that misidentified 'See LICENSE' text

### DIFF
--- a/src/licensedcode/data/rules/unknown_10.RULE
+++ b/src/licensedcode/data/rules/unknown_10.RULE
@@ -1,8 +1,0 @@
----
-license_expression: unknown-license-reference
-is_license_reference: yes
-relevance: 100
-minimum_coverage: 100
----
-
-"See LICENSE file for details"

--- a/src/licensedcode/data/rules/unknown_10.RULE
+++ b/src/licensedcode/data/rules/unknown_10.RULE
@@ -1,0 +1,10 @@
+---
+license_expression: unknown-license-reference
+is_license_reference: yes
+referenced_filenames:
+    - LICENSE
+relevance: 100
+minimum_coverage: 100
+---
+
+"See LICENSE file for details"


### PR DESCRIPTION
## Problem

The rule unknown_10.RULE was flagging "See LICENSE file for details" text as unknown-license-reference, which caused false positives in projects like node-cookie-signature that have valid LICENSE file references.

I##nvestigation

This rule was added back in Aug 2017 for a specific license pattern
Got updated in Mar 2021 to match "See LICENSE file for details" with quotes
The problem is it only matches the exact quoted phrase, which is too specific
Other existing rules already handle "See LICENSE" patterns without needing quotes

##Solution

Instead of removing the rule, I added a referenced_filenames field pointing to LICENSE. Now ScanCode can follow the reference and detect the actual license from the LICENSE file.
## Testing
✅ No test files are affected
✅ The change is focused and minimal


## Related Issues

Fixes #4481
Related to #4387 (similar issue with same rule)

Signed-off-by: Jayant Saxena <jayantmcom@gmail.com>