### PR TITLE
Fix Blue oak false positive

### DIFF
--- a/src/licensedcode/data/rules/gpl-2.0_with_classpath-exception-2.0_or_cddl-1.1_3.RULE
+++ b/src/licensedcode/data/rules/gpl-2.0_with_classpath-exception-2.0_or_cddl-1.1_3.RULE
@@ -2,6 +2,7 @@
 license_expression: gpl-2.0 WITH classpath-exception-2.0 OR cddl-1.1
 is_license_notice: yes
 relevance: 100
+minimum_coverage: 80
 referenced_filenames:
     - LICENSE.txt
 ---


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #4670

fix blue oak false positive by adding minimum_coverage: 80 for GPL-2.0 WITH Classpath Exception OR CDDL

rules changed-
`gpl-2.0_with_classpath-exception-2.0_or_cddl-1.1_3.RULE`

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
