### PR TITLE
Make CC-BY-NC-3 rule more specific

### DIFF
--- a/src/licensedcode/data/rules/cc-by-nc-3.0_5.RULE
+++ b/src/licensedcode/data/rules/cc-by-nc-3.0_5.RULE
@@ -7,7 +7,7 @@ ignorable_urls:
 
 Redistribution and use in source and binary forms,
  * with or without modification, are permitted under the terms of the license
- * 'Creative Commons Attribution-NonCommercial 3.0' which can be found at
+ * '{{Creative Commons Attribution-NonCommercial 3.0}}' which can be found at
  * http://creativecommons.org/licenses/by-nc/3.0
  *
  * THIS SOFTWARE IS PROVIDED ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,


### PR DESCRIPTION
### Summary

Make a cc-by-nc rule more specific which easily provides false positive non-commercial matches.

The rule also contains a simple warranty disclaimer which is not associated with cc-by-nc alone. Thus, require the license name to be present in a match.

### Test plan

Scan [this file](https://lab.netvisiontel.com/nodirmax/tram_ai/-/blob/342e4b019e045bbe1f70424cdc54852213dbdd03/lib/GenICam/xml/GenApi/GenApi_Ptr_h.xsl) with these flags

```
your_scancode_executable --license --license-text --json 'scancode.json' <path to the file>
```

to see the difference. With the more specific rule just a general warranty disclaimer rule matches.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
