### PR TITLE
 Fix #4576:  Add BSD license detection rule for JLine XML comments

### DIFF
--- a/src/licensedcode/data/rules/bsd-new_jline_xml.RULE
+++ b/src/licensedcode/data/rules/bsd-new_jline_xml.RULE
@@ -1,0 +1,17 @@
+---
+license_expression: bsd-new
+is_license_notice: yes
+relevance: 100
+ignorable_copyrights:
+    - Copyright (c) 2002-2020, the original author or authors
+ignorable_holders:
+    - the original author or authors
+ignorable_urls:
+    - https://opensource.org/licenses/BSD-3-Clause
+
+---
+
+This software is distributable under the BSD license. See the terms of the
+BSD license in the documentation provided with this software.
+
+https://opensource.org/licenses/BSD-3-Clause


### PR DESCRIPTION
Fixes #4576

**Problem**

ScanCode wasn't detecting the BSD-3-Clause license in JLine packages (jline-console, jline-style, jline-reader) because the license is in XML comments instead of the usual Maven <licenses> tags.
Solution
Added a detection rule bsd-new_jline_xml.RULE to catch the BSD license pattern used in JLine POM files.
Testing
Tested on jline-console-3.30.4-sources.jar:

License detected: BSD-3-Clause
Rule used: bsd-new_jline_xml.RULE

The same pattern shows up in jline-style and jline-reader, so this covers all three packages.

**Changes**

Added src/licensedcode/data/rules/bsd-new_jline_xml.RULE with proper metadata fields for copyright, holders, and URLs per maintainer feedback.
The license appears in POM files as:
xml<!--
  Copyright (c) 2002-2020, the original author or authors.
  This software is distributable under the BSD license.
  https://opensource.org/licenses/BSD-3-Clause
-->
ScanCode now picks this up correctly.

**Checklist:**
 Reviewed contribution guidelines
 PR links to original issue
 Tests pass
 Feature branch with no merge conflicts
 Updated CHANGELOG.rst (if needed)

Signed-off-by: Jayant Saxena [jayantmcom@gmail.com](mailto:jayantmcom@gmail.com)
