### PR TITLE
Fix dead scancode documentation link

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -85,7 +85,7 @@ template. Your help and contribution make ScanCode docs better, we love hearing 
 
 The ScanCode documentation is hosted at `scancode-toolkit.readthedocs.io <https://scancode-toolkit.readthedocs.io/en/latest/>`_.
 
-If you want to contribute to Scancode Documentation, you'll find `this guide here <https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_doc.html>`_ helpful.
+If you want to contribute to Scancode Documentation, you'll find `this guide here https://scancode-toolkit.readthedocs.io/en/latest/getting-started/contribute/contributing-docs.html`_ helpful.
 
 Development
 ===========


### PR DESCRIPTION
This PR fixes a broken link to ScanCode Toolkit contribution
documentation in docs/source/contributing.rst.

The referenced page was returning 404 and caused the docs build
to fail. The link has been updated to a valid ScanCode
documentation page.
