### PR TITLE
Sync output format docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -85,7 +85,7 @@ template. Your help and contribution make ScanCode docs better, we love hearing 
 
 The ScanCode documentation is hosted at `scancode-toolkit.readthedocs.io <https://scancode-toolkit.readthedocs.io/en/latest/>`_.
 
-If you want to contribute to Scancode Documentation, you'll find `this guide here <https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_doc.html>`_ helpful.
+If you want to contribute to Scancode Documentation, you'll find `this guide here https://scancode-toolkit.readthedocs.io/en/latest/getting-started/contribute/contributing-docs.html`_ helpful.
 
 Development
 ===========

--- a/docs/source/tutorials/configuring-scan-output-formats.rst
+++ b/docs/source/tutorials/configuring-scan-output-formats.rst
@@ -5,7 +5,17 @@ Configuring scan output formats
 
 A basic overview of formatting ScanCode output is presented here.
 
-More information on :ref:`cli-output-format-options`.
+.. note::
+
+   This page provides a high-level overview of configuring ScanCode scan
+   output formats.
+
+   For the complete and up-to-date list of all available scan output
+   options, please refer to the "All Scan Output Options" reference
+   documentation:
+
+   :ref:`cli-output-format-options`
+
 
 JSON
 ----


### PR DESCRIPTION
The "Configuring scan output formats" tutorial provides only a high-level
overview and did not clearly point readers to the complete list of available
ScanCode output options.

This PR improves the documentation by adding a clear note that references
the authoritative "All Scan Output Options" page, keeping the tutorial
concise while ensuring users can easily find the full and up-to-date
configuration details.
