### PR TITLE
Rules for golang related false positives

### DIFF
--- a/src/licensedcode/data/rules/false-positive_830.RULE
+++ b/src/licensedcode/data/rules/false-positive_830.RULE
@@ -1,0 +1,6 @@
+---
+is_false_positive: yes
+notes: Seen in go-go1.24.11/src/hash/crc32/crc32_ppc64le.s. This is about the license of an other open source component (antonblanchard/crc32-vpmsum).
+---
+
+ The vectorized implementation found below is a derived work from code written by Anton Blanchard <anton@au.ibm.com> found at https://github.com/antonblanchard/crc32-vpmsum. The original is dual licensed under GPL and Apache 2.

--- a/src/licensedcode/data/rules/false-positive_831.RULE
+++ b/src/licensedcode/data/rules/false-positive_831.RULE
@@ -1,0 +1,6 @@
+---
+is_false_positive: yes
+notes: Seen in go-go1.24.11/src/hash/crc32/gen_const_ppc64le.go. This is about the license of an other open source component (antonblanchard/crc32-vpmsum).
+---
+
+The following is derived from code written by Anton Blanchard <anton@au.ibm.com> found at https://github.com/antonblanchard/crc32-vpmsum. The original is dual licensed under GPL and Apache 2. 


### PR DESCRIPTION
Both gen_const_ppc64le.go and crc32_ppc64le.s has a reference to antonblanchard/crc32-vpmsum mentioning that antonblanchard/crc32-vpmsum is dual licenses under Apache License 2.0 and GPLv2. This creates a false GPL hit for Golang in ScanCode.

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable)
