### PR TITLE
Improve archive release tests

### DIFF
--- a/.github/workflows/scancode-release.yml
+++ b/.github/workflows/scancode-release.yml
@@ -348,15 +348,7 @@ jobs:
           path: dist
 
       - name: test install app archive
-        run: |
-          for f in `find dist -type f -name "*.zip"`; \
-            do \
-                unzip file.zip $f; \
-            done
-          for f in `find dist -type f -name "*.tar.gz"`; \
-            do \
-                python etc/release/scancode_release_tests.py $f; \
-            done
+        run: python etc/release/scancode_release_tests.py --directory dist
 
 
   smoke_test_install_and_run_app_archives_on_macos:
@@ -393,15 +385,7 @@ jobs:
           path: dist
 
       - name: test install app archive
-        run: |
-          for f in `find dist -type f -name "*.zip"`; \
-            do \
-                unzip file.zip $f; \
-            done
-          for f in `find dist -type f -name "*.tar.gz"`; \
-            do \
-                python etc/release/scancode_release_tests.py $f; \
-            done
+        run: python etc/release/scancode_release_tests.py --directory dist
 
 
   smoke_test_install_and_run_app_archives_on_windows:
@@ -438,8 +422,7 @@ jobs:
           path: dist
 
       - name: test install app archive
-        run: |
-          for %%F in (dist/*.zip) do python etc/release/scancode_release_tests.py dist/%%F
+        run: python etc/release/scancode_release_tests.py --directory dist
 
   publish_to_gh_release:
     permissions:

--- a/etc/release/scancode_release_tests.py
+++ b/etc/release/scancode_release_tests.py
@@ -11,11 +11,34 @@
 
 import os
 import shutil
+import glob
 import subprocess
 import sys
 
 on_windows = "win32" in str(sys.platform).lower()
 
+
+def find_app_archives(directory: str):
+    """
+    Find all application archives in the given directory.
+    Supported formats:
+      - .tar.gz
+      - .zip
+    """
+    if not os.path.isdir(directory):
+        print(f"Directory does not exist: {directory}")
+
+    patterns = ("*.tar.gz", "*.zip")
+
+    archives = []
+    for pattern in patterns:
+        archives.extend(glob.glob(os.path.join(directory, pattern)))
+
+    if not archives:
+        print(f"No app archives found in {directory}")
+        sys.exit(1)
+
+    return archives
 
 def run_app_smoke_tests(app_archive):
     """
@@ -112,8 +135,31 @@ def run_command(args):
         print(cpe.output)
         sys.exit(128)
 
+def main():
+    args = sys.argv[1:]
+
+    if not args:
+        print("ERROR: No arguments provided")
+        print("Usage:")
+        print("  python scancode_release_tests.py <archive_path>")
+        print("  python scancode_release_tests.py --directory <dir_path>")
+        sys.exit(1)
+
+    if args[0] == "--directory":
+        if len(args) < 2:
+            print("--directory flag requires a directory path")
+            sys.exit(1)
+        directory = args[1]
+        if not os.path.isdir(directory):
+            print(f"Directory does not exist: {directory}")
+            sys.exit(1)
+
+        archives = find_app_archives(directory)
+        for archive in archives:
+            run_app_smoke_tests(archive)
+    else:
+        archive = args[0]
+        run_app_smoke_tests(archive)
 
 if __name__ == "__main__":
-    args = sys.argv[1:]
-    archive = args[0]
-    run_app_smoke_tests(archive)
+    main()

--- a/etc/release/scancode_release_tests.py
+++ b/etc/release/scancode_release_tests.py
@@ -25,9 +25,6 @@ def find_app_archives(directory: str):
       - .tar.gz
       - .zip
     """
-    if not os.path.isdir(directory):
-        print(f"Directory does not exist: {directory}")
-
     patterns = ("*.tar.gz", "*.zip")
 
     archives = []


### PR DESCRIPTION
Fixes #4483 

### Summary

This PR improves the robustness of release archive tests by moving all archive discovery and extraction logic into the Python release test script and enforcing loud failure modes.

Previously, archive unpacking and validation were split between the CI workflow and shell commands, which allowed broken or missing app archives to pass CI undetected. This change ensures that release tests fail deterministically if archives are missing, broken, or not tested.

### What this PR changes

- Moves archive discovery and unpacking logic from GitHub Actions shell steps into the Python release test script.
- Ensures the script fails loudly when:
  - no app archive is found,
  - archive extraction fails,
- Simplifies CI workflows by delegating all validation responsibility to the Python script.
- Improves error messages and exit behavior for release-blocking failures.

### Why this is needed

This addresses a class of failures where broken app archives could pass CI without being properly tested, as reported in #4469. Centralizing archive handling in Python makes the release process easier to reason about, easier to test locally, and less error-prone across platforms.

### How this was tested

- Local testing of the release test script with:
  - valid archives,
  - deliberately broken archives,
  - missing archive scenarios.
- Local workflow validation using `act` to verify artifact wiring and failure behavior.
- Verified that failures result in non-zero exits and clear error output.

### Tasks

* [x] Reviewed contribution guidelines
* [x] PR is descriptively titled and links the original issue above
* [x] Tests pass (validated failure and success paths locally and via CI)
* [x] Commits are in a uniquely-named feature branch and has no merge conflicts
* [ ] Updated documentation pages (not applicable)
* [ ] Updated CHANGELOG.rst (not applicable)
