### PR TITLE
Fix missing strip_root behavior in Codebase return path

### DIFF
--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -1070,6 +1070,24 @@ def run_scan(
             results = get_results(codebase, as_list=True, **requested_options)
         elif return_codebase:
             results = codebase
+            # Strip root from Resource paths. See #2985
+            if strip_root and not codebase.has_single_resource:
+                from commoncode.resource import strip_first_path_segment
+                new_resources_by_path = {}
+                for old_path, resource in list(codebase.resources_by_path.items()):
+                    stripped_path = strip_first_path_segment(old_path)
+                    resource.path = stripped_path
+                    new_resources_by_path[stripped_path] = resource
+                codebase.resources_by_path = new_resources_by_path
+
+                # Patch parent() for direct children of root with empty parent path.
+                original_parent = codebase.resource_class.parent
+                def patched_parent(self, codebase_arg):
+                    parent_path = self.parent_path()
+                    if parent_path == '':
+                        return codebase_arg.root
+                    return original_parent(self, codebase_arg)
+                codebase.resource_class.parent = patched_parent
 
     finally:
         # remove temporary files

--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -120,6 +120,80 @@ def test_run_scan_includes_outdated_in_extra():
     assert results['headers'][0]['extra_data']['OUTDATED'] == 'out of date'
 
 
+def test_run_scan_return_codebase_with_strip_root_strips_paths():
+    from scancode.cli import run_scan
+    test_dir = test_env.extract_test_tar('info/basic.tgz')
+    rc, codebase = run_scan(
+        test_dir,
+        info=True,
+        strip_root=True,
+        return_results=False,
+        return_codebase=True,
+    )
+    assert rc
+    assert codebase.root.path == ''
+    paths = [r.path for r in codebase.walk(skip_root=True)]
+    root_dir_name = os.path.basename(test_dir)
+    assert all(not p.startswith(root_dir_name) for p in paths)
+    assert 'basic' in paths
+    assert 'basic/main.c' in paths
+
+
+def test_run_scan_return_codebase_with_strip_root_single_file_does_not_strip():
+    from scancode.cli import run_scan
+    test_file = test_env.get_test_loc('single/iproute.c')
+    rc, codebase = run_scan(
+        test_file,
+        info=True,
+        strip_root=True,
+        return_results=False,
+        return_codebase=True,
+    )
+    assert rc
+    assert codebase.root.path != ''
+    assert 'iproute.c' in codebase.root.path
+
+
+def test_run_scan_return_codebase_with_strip_root_parent_traversal_works():
+    from scancode.cli import run_scan
+    test_dir = test_env.extract_test_tar('info/basic.tgz')
+    rc, codebase = run_scan(
+        test_dir,
+        info=True,
+        strip_root=True,
+        return_results=False,
+        return_codebase=True,
+    )
+    assert rc
+    basic_resource = codebase.get_resource('basic')
+    assert basic_resource is not None
+    parent = basic_resource.parent(codebase)
+    assert parent is not None
+    assert parent.is_root
+
+    main_c = codebase.get_resource('basic/main.c')
+    assert main_c is not None
+    main_parent = main_c.parent(codebase)
+    assert main_parent is not None
+    assert main_parent.path == 'basic'
+
+
+def test_run_scan_return_codebase_without_strip_root_keeps_original_paths():
+    from scancode.cli import run_scan
+    test_dir = test_env.extract_test_tar('info/basic.tgz')
+    rc, codebase = run_scan(
+        test_dir,
+        info=True,
+        return_results=False,
+        return_codebase=True,
+    )
+    assert rc
+    root_path = codebase.root.path
+    assert root_path != ''
+    paths = [r.path for r in codebase.walk(skip_root=True)]
+    assert all(p.startswith(root_path) for p in paths)
+
+
 def test_no_version_check_run_is_successful():
     test_file = test_env.get_test_loc('single/iproute.c')
     result_file = test_env.get_temp_file('json')


### PR DESCRIPTION
Fixes #2985

### Summary

Fixed strip_root parameter not stripping root directory from Resource paths when using cli.run_scan() programmatically.

### Problem

- CLI `--strip-root` worked correctly
- but, API mode with `return_codebase=True` did not strip root from Resource paths
- this is the API mode that returns a `Codebase` object instead of JSON

### Solution

- rebuilt `resources_by_path` with stripped paths after Codebase creation
- used `strip_first_path_segment()` to remove root prefix from each Resource
- fixed `Resource.parent()` method to return root Resource (not empty string) for direct children of root by monkey-patching when `strip_root` is enabled

### Changes

- `src/scancode/cli.py`: Added path stripping logic and parent() fix for `return_codebase` branch

### Verification

- all existing tests pass
- manual testing confirms root directory is now stripped from paths
- `Resource.parent(codebase)` correctly returns root Resource for direct children

### Screenshots of Fix

**BEFORE fix:**
<img width="955" height="308" alt="Screenshot 2026-01-29 212317" src="https://github.com/user-attachments/assets/2cfb3cf5-7107-417a-a815-4fac51b5b051" />




**AFTER Fix**
<img width="951" height="296" alt="Screenshot 2026-01-29 211836" src="https://github.com/user-attachments/assets/a6041d0e-77dc-4cb6-9828-f864de264477" />


### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst  )
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests  ) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)