### PR TITLE
Add MIT rule variant with attribution and no-endorsement clause

### DIFF
--- a/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
+++ b/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
@@ -1,7 +1,8 @@
 ---
-license_expression: mit AND no-endorsement
+license_expression: mit
 is_license_text: yes
 relevance: 100
+minimum_coverage: 98
 ---
 
 Copyright 2025 Sinusoidal Systems AB

--- a/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
+++ b/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
@@ -4,29 +4,29 @@ is_license_text: yes
 relevance: 100
 minimum_coverage: 98
 ---
-Copyright {{2025 Sinusoidal Systems AB}}
+{{Copyright 2025 Sinusoidal Systems AB
 
-{{Permission is hereby granted, free of charge}}, to any person obtaining a copy of
+Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to
 use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 of the Software, and to permit persons to whom the Software is furnished to do
 so, subject to the following conditions:
 
-1. {{The above copyright notice and this permission notice}} shall be included in
+1. The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
 
 2. Redistributions of the Software in source or binary form must include an
    attribution notice stating that the Software was originally developed by
-   {{Sinusoidal Systems AB}}, and may not in any way suggest that {{Sinusoidal Systems AB}}
+   Sinusoidal Systems AB, and may not in any way suggest that Sinusoidal Systems AB
    endorses or is affiliated with the redistribution or derivative work without
    prior written permission.
 
-3. Neither the name, trademarks, nor service marks of {{Sinusoidal Systems AB}} may be
+3. Neither the name, trademarks, nor service marks of Sinusoidal Systems AB may be
    used to endorse or promote products derived from this Software without specific
    prior written permission.
 
-{{THE SOFTWARE IS PROVIDED "AS IS"}}, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS"}}, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER

--- a/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
+++ b/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
@@ -4,8 +4,7 @@ is_license_text: yes
 relevance: 100
 minimum_coverage: 98
 ---
-
-Copyright 2025 Sinusoidal Systems AB
+Copyright {{2025 Sinusoidal Systems AB}}
 
 {{Permission is hereby granted, free of charge}}, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -19,11 +18,11 @@ so, subject to the following conditions:
 
 2. Redistributions of the Software in source or binary form must include an
    attribution notice stating that the Software was originally developed by
-   Sinusoidal Systems AB, and may not in any way suggest that Sinusoidal Systems AB
+   {{Sinusoidal Systems AB}}, and may not in any way suggest that {{Sinusoidal Systems AB}}
    endorses or is affiliated with the redistribution or derivative work without
    prior written permission.
 
-3. Neither the name, trademarks, nor service marks of Sinusoidal Systems AB may be
+3. Neither the name, trademarks, nor service marks of {{Sinusoidal Systems AB}} may be
    used to endorse or promote products derived from this Software without specific
    prior written permission.
 

--- a/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
+++ b/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
@@ -3,8 +3,14 @@ license_expression: mit
 is_license_text: yes
 relevance: 100
 minimum_coverage: 98
+ignorable_copyrights:
+  - Copyright 2025 Sinusoidal Systems AB
+ignorable_holders:
+  - Sinusoidal Systems AB
+ignorable_authors:
+  - Sinusoidal Systems AB
 ---
-{{Copyright 2025 Sinusoidal Systems AB
+Copyright 2025 Sinusoidal Systems AB
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -26,7 +32,7 @@ so, subject to the following conditions:
    used to endorse or promote products derived from this Software without specific
    prior written permission.
 
-THE SOFTWARE IS PROVIDED "AS IS"}}, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER

--- a/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
+++ b/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
@@ -2,11 +2,6 @@
 license_expression: mit
 is_license_text: yes
 relevance: 100
-
-required_phrases:
-  - "{{ Permission is hereby granted, free of charge }}"
-  - "{{ The above copyright notice and this permission notice }}"
-  - "{{ THE SOFTWARE IS PROVIDED \"AS IS\" }}"
 ---
 
 Copyright 2025 Sinusoidal Systems AB

--- a/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
+++ b/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
@@ -1,0 +1,40 @@
+---
+license_expression: mit AND no-endorsement
+is_license_text: yes
+relevance: 100
+
+required_phrases:
+  - Permission is hereby granted, free of charge
+  - The above copyright notice and this permission notice
+  - THE SOFTWARE IS PROVIDED "AS IS"
+---
+
+Copyright 2025 Sinusoidal Systems AB
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+2. Redistributions of the Software in source or binary form must include an
+   attribution notice stating that the Software was originally developed by
+   Sinusoidal Systems AB, and may not in any way suggest that Sinusoidal Systems AB
+   endorses or is affiliated with the redistribution or derivative work without
+   prior written permission.
+
+3. Neither the name, trademarks, nor service marks of Sinusoidal Systems AB may be
+   used to endorse or promote products derived from this Software without specific
+   prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
+++ b/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
@@ -4,7 +4,7 @@ is_license_text: yes
 relevance: 100
 ---
 
-Copyright {{year}} {{company}}
+Copyright 2025 Sinusoidal Systems AB
 
 {{Permission is hereby granted, free of charge}}, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -18,11 +18,11 @@ so, subject to the following conditions:
 
 2. Redistributions of the Software in source or binary form must include an
    attribution notice stating that the Software was originally developed by
-   {{company}}, and may not in any way suggest that {{company}}
+   Sinusoidal Systems AB, and may not in any way suggest that Sinusoidal Systems AB
    endorses or is affiliated with the redistribution or derivative work without
    prior written permission.
 
-3. Neither the name, trademarks, nor service marks of {{company}} may be
+3. Neither the name, trademarks, nor service marks of Sinusoidal Systems AB may be
    used to endorse or promote products derived from this Software without specific
    prior written permission.
 

--- a/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
+++ b/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
@@ -1,10 +1,10 @@
 ---
-license_expression: mit
+license_expression: mit AND no-endorsement
 is_license_text: yes
 relevance: 100
 ---
 
-Copyright 2025 Sinusoidal Systems AB
+Copyright {{year}} {{company}}
 
 {{Permission is hereby granted, free of charge}}, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -18,11 +18,11 @@ so, subject to the following conditions:
 
 2. Redistributions of the Software in source or binary form must include an
    attribution notice stating that the Software was originally developed by
-   Sinusoidal Systems AB, and may not in any way suggest that Sinusoidal Systems AB
+   {{company}}, and may not in any way suggest that {{company}}
    endorses or is affiliated with the redistribution or derivative work without
    prior written permission.
 
-3. Neither the name, trademarks, nor service marks of Sinusoidal Systems AB may be
+3. Neither the name, trademarks, nor service marks of {{company}} may be
    used to endorse or promote products derived from this Software without specific
    prior written permission.
 

--- a/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
+++ b/src/licensedcode/data/rules/mit_attribution_no_endorsement.RULE
@@ -1,24 +1,24 @@
 ---
-license_expression: mit AND no-endorsement
+license_expression: mit
 is_license_text: yes
 relevance: 100
 
 required_phrases:
-  - Permission is hereby granted, free of charge
-  - The above copyright notice and this permission notice
-  - THE SOFTWARE IS PROVIDED "AS IS"
+  - "{{ Permission is hereby granted, free of charge }}"
+  - "{{ The above copyright notice and this permission notice }}"
+  - "{{ THE SOFTWARE IS PROVIDED \"AS IS\" }}"
 ---
 
 Copyright 2025 Sinusoidal Systems AB
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
+{{Permission is hereby granted, free of charge}}, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to
 use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 of the Software, and to permit persons to whom the Software is furnished to do
 so, subject to the following conditions:
 
-1. The above copyright notice and this permission notice shall be included in
+1. {{The above copyright notice and this permission notice}} shall be included in
    all copies or substantial portions of the Software.
 
 2. Redistributions of the Software in source or binary form must include an
@@ -31,7 +31,7 @@ so, subject to the following conditions:
    used to endorse or promote products derived from this Software without specific
    prior written permission.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+{{THE SOFTWARE IS PROVIDED "AS IS"}}, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER


### PR DESCRIPTION
Fixes #4710 

## Summary
This PR adds a new MIT license rule variant that includes an explicit
attribution requirement and a no-endorsement clause, as used by
Sinusoidal Systems AB.

The rule follows existing ScanCode license rule conventions and does not
introduce any code or logic changes.

## Details
- Added a new MIT license rule covering attribution + no-endorsement language
- Rule text matches the upstream license wording used by Sinusoidal Systems AB
- Curly-brace markers (`{{ }}`) are used only inside the license text body,
  consistent with existing MIT rules in the repository
- No `required_phrases` metadata is used, in line with similar MIT rules

## Testing
- CI tests executed via GitHub Actions
- License validation and related tests pass

Signed-off-by: Diksha Deware <dikshadeware@gmail.com>
