### PR TITLE
Add BUSL vs BSL license detection test

### DIFF
--- a/tests/licensedcode/data/busl_vs_bsl/LICENSE.md
+++ b/tests/licensedcode/data/busl_vs_bsl/LICENSE.md
@@ -1,0 +1,10 @@
+Bussiness Source License 1.1 
+
+Licensor: Example Corp
+
+Parameters:
+- Change Date: 2027-01-01
+- Change License: Apache License, Version 2.0
+
+Terms:
+The Licensed Work is provided under the Bussiness Source License 1.1.

--- a/tests/licensedcode/data/busl_vs_bsl/busl_vs_bsl.expected.json
+++ b/tests/licensedcode/data/busl_vs_bsl/busl_vs_bsl.expected.json
@@ -1,3 +1,5 @@
 {
-  "license_expression": "BUSL-1.1"
+  "license_expression": "BUSL-1.1",
+  "expected_failure": true,
+  "failure_failure_reason": "BUSL-1.1 is currently misdetected as BSL"
 }

--- a/tests/licensedcode/data/busl_vs_bsl/busl_vs_bsl.expected.json
+++ b/tests/licensedcode/data/busl_vs_bsl/busl_vs_bsl.expected.json
@@ -1,0 +1,3 @@
+{
+  "license_expression": "BUSL-1.1"
+}

--- a/tests/licensedcode/data/busl_vs_bsl/busl_vs_bsl.expected.json
+++ b/tests/licensedcode/data/busl_vs_bsl/busl_vs_bsl.expected.json
@@ -1,5 +1,5 @@
 {
   "license_expression": "BUSL-1.1",
   "expected_failure": true,
-  "failure_failure_reason": "BUSL-1.1 is currently misdetected as BSL"
+  "expected_failure_reason": "BUSL-1.1 is currently misdetected as BSL"
 }

--- a/tests/licensedcode/data/busl_vs_bsl/test.txt
+++ b/tests/licensedcode/data/busl_vs_bsl/test.txt
@@ -1,0 +1,4 @@
+Business Source License 1.1
+
+Change License: Apache License, Version 2.0
+The Licensed Work is provided under the Business Source License 1.1.


### PR DESCRIPTION
### Summary
This PR adds a regression test documenting the current mis-detection of
`BUSL-1.1` as `BSL`.

### Details
- Adds a data-driven license detection test
- Captures current behavior without changing detection logic
- Intended to support a future fix by preventing regressions

### Scope
Test-only change. No production code modified.

Please let me know if you'd prefer the fix to be included in this PR
or handled separately.
<!-- Don't forget to Signoff -->
