### PR TITLE
Mark two-segment CamelCase code identifiers as JUNK - Fix #4736

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -833,6 +833,11 @@ PATTERNS = [
     # Repeated CamelCasedWords
     (r'^([A-Z][a-z]+){3,}$', 'JUNK'),
 
+    # Two-segment CamelCase code identifiers such as MeterProvider or
+    # TracerProvider or SpanProcessor that are not person or company names.
+    # These are common in code comments and trigger false author detections.
+    (r'^[A-Z][a-z]+(?:Provider|Processor|Exporter|Importer|Factory|Builder|Handler|Listener|Manager|Resolver|Adapter|Iterator|Observer|Visitor|Value|Logger|Counter|Tracker|Wrapper|Reader|Writer|Sender|Client|Server|Module|Record|Socket|Worker|Batcher|Sampler)s?$', 'JUNK'),
+
     ############################################################################
     # JUNK proper
     ############################################################################


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

This prevents false author detections.
Words like MeterProvider, TracerProvider, and SpanProcessor in code comments match the "created by a <NNP>" grammar pattern, producing false author detections. The existing CamelCase JUNK rule only catches three or more segments (e.g. GetQueueReference). This adds a targeted rule for two-segment CamelCase words ending in common code suffixes (Provider, Processor, Exporter, Handler, Factory, etc.) so they are tagged as JUNK.

Fixes #4736

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x]  Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->


----

Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
