### PR TITLE
Fix CAL-1.0 false positives on generic GPL headers

### DIFF
--- a/src/licensedcode/data/licenses/cal-1.0.LICENSE
+++ b/src/licensedcode/data/licenses/cal-1.0.LICENSE
@@ -6,10 +6,13 @@ category: Copyleft
 owner: Holochain
 homepage_url: https://opensource.org/licenses/CAL-1.0
 spdx_license_key: CAL-1.0
+minimum_coverage: 80
+minimum_match_length: 40
 other_urls:
     - http://cryptographicautonomylicense.com/license-text.html
 standard_notice: |
-    This Cryptographic Autonomy License (the “License”) applies to any Work
+    SPDX-License-Identifier: CAL-1.0
+    Licensed under the Cryptographic Autonomy License version 1.0    
     whose owner has marked it with any of the following notices, or a similar
     demonstration of intent:
     SPDX-License-Identifier: CAL-1.0

--- a/src/licensedcode/data/licenses/cal_false_positive_gpl/gpl_header.h
+++ b/src/licensedcode/data/licenses/cal_false_positive_gpl/gpl_header.h
@@ -1,0 +1,4 @@
+/*
+ * Example Linux header
+ * Licensed under the GPL-2.
+ */

--- a/src/licensedcode/data/licenses/cal_false_positive_gpl/gpl_header.h.expected.json
+++ b/src/licensedcode/data/licenses/cal_false_positive_gpl/gpl_header.h.expected.json
@@ -1,0 +1,4 @@
+{
+  "license_expressions": ["gpl-2.0"],
+  "licenses": ["gpl-2.0"]
+}


### PR DESCRIPTION
This PR reduces CAL-1.0 false positives caused by generic
“Licensed under the …” fragments that commonly appear in GPL headers.

Changes:
- Increase CAL detection strictness (minimum_coverage, minimum_match_length)
- Anchor detection on stronger CAL identifiers (SPDX / full license name)
- Add regression test using a simple GPL header to prevent cross-matching
