### PR TITLE
Add edge case tests for clean_string empty input

### DIFF
--- a/tests/textcode/test_strings.py
+++ b/tests/textcode/test_strings.py
@@ -47,6 +47,10 @@ class TestStrings(FileBasedTesting):
         assert list(strings.clean_string('abababa'))
         assert not list(strings.clean_string('  tt\nf   '))
         assert list(strings.clean_string('  tt\nfb   '))
+        # Edge cases: empty and whitespace-only inputs
+        assert not list(strings.clean_string(''))
+        assert not list(strings.clean_string('   '))
+        assert not list(strings.clean_string('\t\n  '))
 
     def test_strings_in_file(self):
         expected = [


### PR DESCRIPTION
## Description
Add edge case tests for [clean_string()](cci:1://file:///Users/harshareddy/Desktop/scancode-toolkit/src/textcode/strings.py:137:0-156:23) to verify behavior with empty and whitespace-only input.

These tests improve coverage without changing existing behavior.

## Changes
- Add assertions for empty string input
- Add assertions for whitespace-only input (spaces, tabs, newlines)

## Testing
- Tests added to existing [test_clean_string()](cci:1://file:///Users/harshareddy/Desktop/scancode-toolkit/tests/textcode/test_strings.py:37:4-52:55) method
- Follow existing assertion style and structure
- No functional changes introduced