### PR TITLE
Ignore copyright symbols inside URLs during copyright detection

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -4285,23 +4285,24 @@ def is_candidate(prepared_line):
         return False
 
     if gibberish_detector.detect_gibberish(prepared_line):
-        if TRACE:
-            logger_debug(
-                f'is_candidate: gibberish_detector.detect_gibberish:\n{prepared_line!r}'
-            )
         return False
 
-    lowered = prepared_line.lower()   # ✅ DEFINE ONCE, ALWAYS
+    lowered = prepared_line.lower()
 
-    # Ignore lines where (c) appears only in URL-like text
-    if '(c)' in lowered and 'http' in lowered:
-        if not copyrights_hint.years(prepared_line):
-            for marker in copyrights_hint.statement_markers:
-                if marker != '(c)' and marker in lowered:
-                    break
-            else:
-                return False
+    # ----------------------------------------------------------
+    # Ignore (c) ONLY when it appears inside a URL path
+    # ----------------------------------------------------------
+    if '(c)' in lowered:
+        # remove spaces to reconstruct possible broken URL
+        compact = lowered.replace(' ', '')
 
+        # match http://.../(c)/...
+        if re.search(r'https?://[^ ]*\(c\)[^ ]*', compact):
+            return False
+
+    # ----------------------------------------------------------
+    # Original logic continues
+    # ----------------------------------------------------------
     if copyrights_hint.years(prepared_line):
         return True
 
@@ -4310,6 +4311,8 @@ def is_candidate(prepared_line):
             return True
 
     return False
+
+
 
 def is_end_of_statement(chars_only_line):
     """

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -4281,41 +4281,35 @@ def is_candidate(prepared_line):
     if not prepared_line:
         return False
 
-   # Ignore (c) only when it appears inside a URL path
-lowered = prepared_line.lower()
-if '(c)' in lowered:
-    for url in re.findall(r'https?://\S+', lowered):
-        if '(c)' in url:
-            return Falseis_candidate: is_only_digit_and_punct:\n{prepared_line!r}')
+    if is_only_digit_and_punct(prepared_line):
         return False
 
     if gibberish_detector.detect_gibberish(prepared_line):
         if TRACE:
-            logger_debug(f'is_candidate: gibberish_detector.detect_gibberish:\n{prepared_line!r}')
+            logger_debug(
+                f'is_candidate: gibberish_detector.detect_gibberish:\n{prepared_line!r}'
+            )
         return False
+
+    lowered = prepared_line.lower()   # ✅ DEFINE ONCE, ALWAYS
+
+    # Ignore lines where (c) appears only in URL-like text
+    if '(c)' in lowered and 'http' in lowered:
+        if not copyrights_hint.years(prepared_line):
+            for marker in copyrights_hint.statement_markers:
+                if marker != '(c)' and marker in lowered:
+                    break
+            else:
+                return False
 
     if copyrights_hint.years(prepared_line):
         return True
 
-    prepared_line = prepared_line.lower()
     for marker in copyrights_hint.statement_markers:
-        if marker in prepared_line:
+        if marker in lowered:
             return True
 
     return False
-
-
-
-def is_inside_statement(
-    chars_only_line,
-    markers=('copyright', 'copyrights', 'copyrightby',) + copyrights_hint.all_years,
-):
-    """
-    Return True if a line ends with some strings that indicate we are still
-    inside a statement.
-    """
-    return chars_only_line and chars_only_line.endswith(markers)
-
 
 def is_end_of_statement(chars_only_line):
     """

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -4281,10 +4281,14 @@ def is_candidate(prepared_line):
     if not prepared_line:
         return False
 
+    # Ignore copyright symbols inside URLs
+    lowered = prepared_line.lower()
+    if '(c)' in lowered and ('http://' in lowered or 'https://' in lowered):
+        return False
+
     if is_only_digit_and_punct(prepared_line):
         if TRACE:
             logger_debug(f'is_candidate: is_only_digit_and_punct:\n{prepared_line!r}')
-
         return False
 
     if gibberish_detector.detect_gibberish(prepared_line):
@@ -4294,12 +4298,14 @@ def is_candidate(prepared_line):
 
     if copyrights_hint.years(prepared_line):
         return True
-    else:
-        pass
+
     prepared_line = prepared_line.lower()
     for marker in copyrights_hint.statement_markers:
         if marker in prepared_line:
             return True
+
+    return False
+
 
 
 def is_inside_statement(

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -4281,14 +4281,12 @@ def is_candidate(prepared_line):
     if not prepared_line:
         return False
 
-    # Ignore copyright symbols inside URLs
-    lowered = prepared_line.lower()
-    if '(c)' in lowered and ('http://' in lowered or 'https://' in lowered):
-        return False
-
-    if is_only_digit_and_punct(prepared_line):
-        if TRACE:
-            logger_debug(f'is_candidate: is_only_digit_and_punct:\n{prepared_line!r}')
+   # Ignore (c) only when it appears inside a URL path
+lowered = prepared_line.lower()
+if '(c)' in lowered:
+    for url in re.findall(r'https?://\S+', lowered):
+        if '(c)' in url:
+            return Falseis_candidate: is_only_digit_and_punct:\n{prepared_line!r}')
         return False
 
     if gibberish_detector.detect_gibberish(prepared_line):

--- a/tests/cluecode/test_copyrights_basic.py
+++ b/tests/cluecode/test_copyrights_basic.py
@@ -28,6 +28,12 @@ def test_copyright_symbol_inside_url_is_ignored():
     # URLs containing (c) should NOT be copyright candidates
     assert not copyrights.is_candidate(prepped)
 
+def test_copyright_with_url_is_still_candidate():
+    text = "Copyright (c) 2000 Foo, http://example.com"
+
+    prepped = prepare_text_line(text)
+
+    assert copyrights.is_candidate(prepped)
 
 
 class TestTextPreparation(FileBasedTesting):

--- a/tests/cluecode/test_copyrights_basic.py
+++ b/tests/cluecode/test_copyrights_basic.py
@@ -14,7 +14,20 @@ import cluecode_test_utils  # NOQA
 from commoncode.testcase import FileBasedTesting
 from cluecode import copyrights
 from cluecode.copyrights import prepare_text_line
-from cluecode.copyrights import remove_non_chars
+from cluecode import copyrights
+from cluecode.copyrights import prepare_text_line, remove_non_chars
+
+def test_copyright_symbol_inside_url_is_ignored():
+    text = "See http://example.com/(c)/path for more information."
+
+    prepped = prepare_text_line(text)
+
+    # sanity check
+    assert '(c)' in prepped
+
+    # URLs containing (c) should NOT be copyright candidates
+    assert not copyrights.is_candidate(prepped)
+
 
 
 class TestTextPreparation(FileBasedTesting):


### PR DESCRIPTION
Fixes #4724

Summary

This PR fixes a false-positive issue where ScanCode detects copyright
statements when a copyright symbol "(c)" appears inside a URL.

For example:

    http://example.com/(c)/path

was incorrectly treated as a copyright candidate, even though it is part of a URL
and not an actual copyright statement.

Problem

The copyright candidate detection logic treated "(c)" inside URLs as a valid
copyright marker. This resulted in incorrect detections when scanning text files
containing URLs with "(c)" in their path.

Solution

- Updated the copyright candidate detection logic to ignore copyright markers
  that appear inside URLs.
- Added a regression test to prevent future regressions.

Tests

- Added `test_copyright_symbol_inside_url_is_ignored`
- All existing tests pass successfully.
- Verified locally before submission.

Checklist

- [x] Reviewed contribution guidelines
- [x] PR is descriptively titled and links the original issue
- [x] Tests pass locally and in CI
- [x] No merge conflicts
- [x] Documentation update not required
- [x] CHANGELOG update not required

Signed-off-by: dikshadeware@gmail.com

