### PR TITLE
Fix handling of git-authenticated npm dependencies being misdetected as aliases 

### DIFF
--- a/src/packagedcode/npm.py
+++ b/src/packagedcode/npm.py
@@ -380,7 +380,14 @@ class BaseNpmHandler(models.DatafileHandler):
                     if '_' in metadata:
                         requirement, _extra = metadata.split('_')
 
-                if ':' in requirement and '@' in requirement:
+                if (
+    ':' in requirement
+    and '@' in requirement
+    and not requirement.startswith(
+        ('git+', 'git:', 'git@', 'http://', 'https://', 'ssh://')
+    )
+):
+
                     # dependencies with requirements like this are aliases and should be reported
                     aliased_package, _, constraint = requirement.rpartition('@')
                     _, _, aliased_package_name = aliased_package.rpartition(':')
@@ -1848,7 +1855,15 @@ def deps_mapper(deps, package, field_name, is_direct=True):
         if not name:
             continue
 
-        if ':' in requirement and '@' in requirement:
+        if (
+    ':' in requirement
+    and '@' in requirement
+    and not requirement.startswith(
+        ('git+', 'git:', 'git@', 'http://', 'https://', 'ssh://')
+    )
+):
+
+
             # dependencies with requirements like this are aliases and should be reported
             aliased_package, _, requirement = requirement.rpartition('@')
             _, _, aliased_package_name = aliased_package.rpartition(':')

--- a/tests/packagedcode/test_npm.py
+++ b/tests/packagedcode/test_npm.py
@@ -16,7 +16,23 @@ from packages_test_utils import PackageTester
 from scancode_config import REGEN_TEST_FIXTURES
 from scancode.cli_test_utils import run_scan_click
 from scancode.cli_test_utils import check_json_scan
+from packagedcode.npm import NpmPackageJsonHandler
 
+
+def test_git_authenticated_dependency_keeps_declared_name():
+    package_json = {
+        "name": "example",
+        "version": "1.0.0",
+        "dependencies": {
+            "private-lib": "git+ssh://git@github.com:org/repo.git#v1.0.0"
+        }
+    }
+
+    package = NpmPackageJsonHandler._parse(package_json)
+
+    deps = package.dependencies
+    assert len(deps) == 1
+    assert deps[0].purl == "pkg:npm/private-lib"
 
 class TestNpm(PackageTester):
     test_data_dir = os.path.join(os.path.dirname(__file__), 'data')


### PR DESCRIPTION
Fixes #4753

### Summary

Fix incorrect alias detection for git-authenticated npm dependencies.

Dependencies like:

"private-lib": "git+ssh://git@github.com:org/repo.git#v1.0.0"

were incorrectly treated as alias dependencies because the logic only checked for ":" and "@" in the requirement string.

This change excludes git-based URLs (git+, git:, git@, ssh://, http://, https://) from alias detection.

### Changes

- Updated alias detection condition in:
  - BaseNpmHandler.update_dependencies_by_purl
  - deps_mapper
- Added test to ensure declared dependency name is preserved.

### Tasks

* [x] Reviewed contribution guidelines
* [x] PR is descriptively titled and links the original issue
* [x] Tests pass locally
* [x] Feature branch created from develop
* [ ] Updated documentation (not applicable)
* [ ] Updated CHANGELOG (if required by maintainers)
