### PR TITLE
Fix detection of copyright statements without year in copyright declarations

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -2948,6 +2948,9 @@ GRAMMAR = """
 
     COPYRIGHT: {<COPY> <COPY> <NNP>+}        #1800
 
+    # Copyright holder without year (e.g., Copyright The OpenTelemetry Authors)
+    COPYRIGHT: {<COPY>+ <NNP|NAME> <NNP|NAME|COMPANY>+ <AUTHS>?}
+
     # Copyright (c) 2003+ Evgeniy Polyakov <johnpol@2ka.mxt.ru>
     COPYRIGHT: {<COPY> <COPY> <YR-PLUS> <NAME|NAME-EMAIL|NAME-YEAR>+}        #1801
 


### PR DESCRIPTION

Fixes #4722

## Description

This PR fixes detection of copyright statements that do not include a year in the declaration.

Previously, ScanCode required a year to be present alongside the copyright keyword. As a result, valid copyright statements such as:

- `Copyright The OpenTelemetry Authors`
- `(c) The OpenTelemetry Authors`

were not detected.

This update adjusts the copyright detection grammar to allow copyright declarations without a year component, while preserving existing behavior for statements that include years.

After this change, such statements are correctly identified and extracted.

---

## How to Reproduce (Before Fix)

Example file:

```go
// Copyright The OpenTelemetry Authors
````

Run:

```bash
./scancode --json-pp result.json -c version.go
```

Previously returned:

```json
"copyrights": []
```

---

## After This Fix

The same scan now correctly detects:

```json
{
  "copyright": "Copyright The OpenTelemetry Authors"
}
```

---

## Notes

* Only the copyright detection logic was updated.
* No unrelated files were modified.
* Existing detection behavior for copyright statements with years remains unchanged.

---

## Checklist

* [x] Reviewed contribution guidelines
* [x] PR is descriptively titled and links the original issue
* [x] Tests pass 
* [x] Commits are in a uniquely named feature branch and have no merge conflicts
* [ ] Documentation update not required
* [ ] CHANGELOG update not required unless requested

```

