### PR TITLE
fix: remove cal-1.0_10.RULE to prevent false positive on C calibration macros

### DIFF
--- a/src/licensedcode/data/rules/cal-1.0_10.RULE
+++ b/src/licensedcode/data/rules/cal-1.0_10.RULE
@@ -1,8 +1,0 @@
----
-license_expression: cal-1.0
-is_license_reference: yes
-is_required_phrase: yes
-relevance: 100
----
-
-CAL-1.0


### PR DESCRIPTION

Fixes #4740
## Problem

`cal-1.0_10.RULE` matched bare `CAL-1.0` which tokenizes to only 3 tokens
(`cal`, `1`, `0`). This caused false positive CAL-1.0 license detections
in Linux kernel driver files that contain C calibration macros like:

    #define BBDC_CAL  (1 << 0)  /* DC cal BB Start */

Affected files include `drivers/iio/adc/ad9361.h`, `ad6676.h` and
`frequency/ad9517.c` from the Analog Devices Linux tree — all correctly
licensed under GPL-2.0, not CAL-1.0.

Reference: https://github.com/analogdevicesinc/linux/blob/main/drivers/iio/adc/ad9361.h

## Fix

Remove `cal-1.0_10.RULE` since `cal-1.0_5.RULE` already correctly handles
`SPDX-License-Identifier: CAL-1.0` detections. The bare `CAL-1.0` pattern
is too short (3 tokens) and ambiguous to reliably detect the license without
causing false positives in hardware/embedded code.

## Verification

Before: both `gpl-2.0` and `cal-1.0` detected in `ad9361.h`
After: only `gpl-2.0` detected 

Checklist
* [x] Reviewed contribution guidelines
* [x] PR is descriptively titled and links the original issue
* [x] Tests pass
* [x] Commits are in uniquely-named feature branch with no merge conflicts
* [ ] Updated documentation pages (not applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
