### PR TITLE
Fix unreachable JSON validation code in validate_input_path

### DIFF
--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -192,6 +192,8 @@ def validate_input_path(ctx, param, value):
         if from_json and not is_file(location=inp, follow_symlinks=True):
             # extra JSON validation
             raise click.BadParameter(f"JSON input: {inp!r} is not a file")
+        
+        if from_json and is_file(location=inp, follow_symlinks=True):
             if not inp.lower().endswith(".json"):
                 raise click.BadParameter(f"JSON input: {inp!r} is not a JSON file with a .json extension")
             with open(inp) as js:

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -192,7 +192,6 @@ def validate_input_path(ctx, param, value):
         if from_json and not is_file(location=inp, follow_symlinks=True):
             # extra JSON validation
             raise click.BadParameter(f"JSON input: {inp!r} is not a file")
-        
         if from_json and is_file(location=inp, follow_symlinks=True):
             if not inp.lower().endswith(".json"):
                 raise click.BadParameter(f"JSON input: {inp!r} is not a JSON file with a .json extension")

--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -192,13 +192,16 @@ def validate_input_path(ctx, param, value):
         if from_json and not is_file(location=inp, follow_symlinks=True):
             # extra JSON validation
             raise click.BadParameter(f"JSON input: {inp!r} is not a file")
-        if from_json and is_file(location=inp, follow_symlinks=True):
+        elif from_json:
             if not inp.lower().endswith(".json"):
                 raise click.BadParameter(f"JSON input: {inp!r} is not a JSON file with a .json extension")
-            with open(inp) as js:
-                start = js.read(100).strip()
+            try:
+                with open(inp, encoding='utf-8') as js:
+                    start = js.read(100).strip()
+            except UnicodeDecodeError:
+                raise click.BadParameter(f"JSON input: {inp!r} is not a readable UTF-8 file")
             if not start.startswith("{"):
-                raise click.BadParameter(f"JSON input: {inp!r} is not a well formed JSON file")
+                raise click.BadParameter(f"JSON input: {inp!r} is not well formed JSON file")
 
     return value
 


### PR DESCRIPTION
In `src/scancode/cli.py`, the `validate_input_path` function contained a premature `raise` statement that made the JSON validation checks below it dead/unreachable code. As a result, two important validations were silently never executed:

- Checking that the JSON input file has a `.json` extension
- Checking that the JSON file is well-formed (starts with `{`)

## Root Cause

The `raise click.BadParameter(...)` for "not a file" was placed **before** the extension and content checks, causing Python to exit the block immediately and skip the remaining validations entirely.

## Before (Broken)

```python
if from_json and not is_file(location=inp, follow_symlinks=True):
    raise click.BadParameter(f"JSON input: {inp!r} is not a file")
    if not inp.lower().endswith(".json"):   # ← never reached
        raise click.BadParameter(f"JSON input: {inp!r} is not a JSON file with a .json extension")
    with open(inp) as js:
        start = js.read(100).strip()
    if not start.startswith("{"):           # ← never reached
        raise click.BadParameter(f"JSON input: {inp!r} is not a well formed JSON file")
```

## After (Fixed)

```python
if from_json and not is_file(location=inp, follow_symlinks=True):
    raise click.BadParameter(f"JSON input: {inp!r} is not a file")

if from_json and is_file(location=inp, follow_symlinks=True):
    if not inp.lower().endswith(".json"):
        raise click.BadParameter(f"JSON input: {inp!r} is not a JSON file with a .json extension")
    with open(inp) as js:
        start = js.read(100).strip()
    if not start.startswith("{"):
        raise click.BadParameter(f"JSON input: {inp!r} is not a well formed JSON file")
```

## Impact

Without this fix, users could pass a non-`.json` file or a malformed JSON file as `--from-json` input and ScanCode would proceed without raising an appropriate error, likely causing a confusing failure downstream.

---

### Tasks

- [x] Reviewed [[contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
- [x] PR is descriptively titled and links the original issue above
- [x] Tests pass
- [x] Commits are in a uniquely-named feature branch and has no merge conflicts
- [ ] Updated documentation pages (not applicable)
- [ ] Updated CHANGELOG.rst (not applicable for minor bug fix)