### PR TITLE
Fix incorrect timing parameter passed to run_scanners

### DIFF
--- a/src/scancode/cli.py
+++ b/src/scancode/cli.py
@@ -966,7 +966,7 @@ def run_scan(
             codebase=codebase,
             processes=processes,
             timeout=timeout,
-            timing=timeout,
+            timing=timing,
             quiet=quiet,
             verbose=verbose,
             kwargs=requested_options,

--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -786,8 +786,6 @@ def test_scan_with_timing_json_return_timings_for_each_scanner():
     check_timings(expected, file_results)
 
 
-@pytest.mark.scanslow
-@pytest.mark.skipif(on_windows, reason='Somehow this test fails for now on Python 3')
 def test_scan_without_timing_flag_does_not_collect_scan_timings():
     test_dir = test_env.extract_test_tar('timing/basic.tgz')
     result_file = test_env.get_temp_file('json')
@@ -800,6 +798,7 @@ def test_scan_without_timing_flag_does_not_collect_scan_timings():
             assert not res.get('scan_timings'), (
                 'scan_timings should be empty when --timing is not passed'
             )
+
             
 def test_scan_with_timing_jsonpp_return_timings_for_each_scanner():
     test_dir = test_env.extract_test_tar('timing/basic.tgz')

--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -788,6 +788,19 @@ def test_scan_with_timing_json_return_timings_for_each_scanner():
 
 @pytest.mark.scanslow
 @pytest.mark.skipif(on_windows, reason='Somehow this test fails for now on Python 3')
+def test_scan_without_timing_flag_does_not_collect_scan_timings():
+    test_dir = test_env.extract_test_tar('timing/basic.tgz')
+    result_file = test_env.get_temp_file('json')
+    args = ['--email', '--url', '--license', '--copyright', '--info',
+            '--package', '--json', result_file, test_dir]
+    run_scan_click(args)
+    file_results = load_json_result(result_file)['files']
+    for res in file_results:
+        if res['type'] == 'file':
+            assert not res.get('scan_timings'), (
+                'scan_timings should be empty when --timing is not passed'
+            )
+            
 def test_scan_with_timing_jsonpp_return_timings_for_each_scanner():
     test_dir = test_env.extract_test_tar('timing/basic.tgz')
     result_file = test_env.get_temp_file('json')


### PR DESCRIPTION
# Fix `timing=timeout` typo in `run_scanners` call in `run_scan`

The `run_scanners` call was passing `timeout` (a float, default 120.0) as the `timing` argument instead of the `timing` boolean flag. This caused per-file scan timings to always be collected regardless of the `--timing` CLI option.

### Tasks
* [x] Reviewed [[contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [[tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests)](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors.
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [x] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable)