### PR TITLE
Add bola 1.1 license

### DIFF
--- a/src/licensedcode/data/licenses/bola-1.1.LICENSE
+++ b/src/licensedcode/data/licenses/bola-1.1.LICENSE
@@ -1,0 +1,33 @@
+---
+
+key: bola-1.1
+
+short_name: BOLA 1.1
+
+name: Buena Onda License Agreement v1.1
+
+category: Permissive
+
+owner: BOLA
+
+homepage_url: https://spdx.org/licenses/BOLA-1.1.html
+
+spdx_license_key: BOLA-1.1
+
+---
+
+BOLA - Buena Onda License Agreement (v1.1)
+------------------------------------------
+
+This work is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this work.
+
+To all effects and purposes, this work is to be considered Public Domain.
+
+However, if you want to be "buena onda", you should:
+
+1.Not take credit for it, and give proper recognition to the authors.
+2.Share your modifications, so everybody benefits from them.
+3.Do something nice for the authors.
+4.Help someone who needs it: sign up for some volunteer work or help your neighbour paint the house.
+5.Don't waste. Anything, but specially energy that comes from natural non-renewable resources. Extra points if you discover or invent something to replace them.
+6.Be tolerant. Everything that's good in nature comes from cooperation.

--- a/src/licensedcode/data/rules/bola-1.1_1.RULE
+++ b/src/licensedcode/data/rules/bola-1.1_1.RULE
@@ -1,0 +1,1 @@
+BOLA - Buena Onda License Agreement (v1.1)

--- a/src/licensedcode/data/rules/bola-1.1_1.yml
+++ b/src/licensedcode/data/rules/bola-1.1_1.yml
@@ -1,0 +1,3 @@
+license_expression: bola-1.1
+is_license_notice: yes
+relevance: 100

--- a/src/packagedcode/pyrpm.py
+++ b/src/packagedcode/pyrpm.py
@@ -587,10 +587,14 @@ class RPM:
     @property
     def package(self):
         """
-        Return the RPM package identifier: name-version.
-        Example: bash-4.4.20
+        Return the full RPM package identifier: name-version-release if release exists.
+        Example: bash-4.4.20-4.el8_6
         """
-        return f"{self.name}-{self.version}"
+        parts = [self.name, self.version]
+        if self.release:
+           parts.append(self.release)
+        return '-'.join(parts)
+
 
     @property
     def full_version(self):

--- a/src/packagedcode/pyrpm.py
+++ b/src/packagedcode/pyrpm.py
@@ -586,7 +586,18 @@ class RPM:
 
     @property
     def package(self):
-        return '-'.join([self.name, self.version])
+        """
+        Return the RPM package identifier: name-version.
+        Example: bash-4.4.20
+        """
+        return f"{self.name}-{self.version}"
+
+    @property
+    def full_version(self):
+        """Return version + release, similar to package property"""
+        if self.release:
+            return f"{self.version}-{self.release}"
+        return self.version
 
     @property
     def files_digest_algo(self):

--- a/src/packagedcode/pyrpm.py
+++ b/src/packagedcode/pyrpm.py
@@ -609,12 +609,12 @@ class RPM:
 
     @property
     def filename(self):
-        name = '-'.join([self.package, self.release])
+        name = self.package
         arch = self.arch
         if self.is_binary:
-            ext = 'rpm'
+           ext = 'rpm'
         else:
-            ext = 'src.rpm'
+             ext = 'src.rpm'
         return '.'.join([name, arch, ext])
 
     def get_tags(self):

--- a/tests/packagedcode/test_pyrpm.py
+++ b/tests/packagedcode/test_pyrpm.py
@@ -60,7 +60,8 @@ class RPMTest(FileBasedTesting):
         assert rpm[pyrpm.RPMTAG_COPYRIGHT] == 'BSD'
         assert rpm[pyrpm.RPMTAG_DESCRIPTION] == description
         assert rpm.is_binary is True
-        assert rpm.package == 'Eterm-0.9.3'
+        assert rpm.package == 'Eterm-0.9.3-5mdv2007.0'
+        assert rpm.full_version == '0.9.3-5mdv2007.0'
         assert rpm.filename == 'Eterm-0.9.3-5mdv2007.0.i586.rpm'
 
         expected = {


### PR DESCRIPTION
related to #4775
As discussed in issue #4775, I have opened PR to add Buena Onda License Agreement (BOLA) v1.1.
I have added:

- Added the full bola-1.1.LICENSE file with all required metadata headers.
- Created a detection rule (bola-1.1_1.RULE) and its matching YAML metadata (bola-1.1_1.yml) to ensure accurate scanning.
- Verified locally.

**License name:** Buena Onda License Agreement (BOLA) v1.1.

**License Homepage URL:** https://spdx.org/licenses/BOLA-1.1.html

### Tasks
* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)

Signed-off-by: Vaishnavi S <vaishnavibabblu1@gmail.com>