### PR TITLE
feat: add GoWorkHandler to support Go workspace files (go.work)

### DIFF
--- a/src/packagedcode/__init__.py
+++ b/src/packagedcode/__init__.py
@@ -102,6 +102,7 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     godeps.GodepsHandler,
     golang.GoModHandler,
     golang.GoSumHandler,
+    golang.GoWorkHandler,
 
     haxe.HaxelibJsonHandler,
 

--- a/src/packagedcode/go_mod.py
+++ b/src/packagedcode/go_mod.py
@@ -14,6 +14,18 @@ from packageurl import PackageURL
 
 
 @attr.s()
+class GoWorkspace(object):
+    """
+    Represents a parsed go.work file for a Go workspace.
+    A workspace is a collection of multiple Go modules that can be edited together.
+    See https://go.dev/ref/mod#go-work-files for details.
+    """
+    go_version = attr.ib(default=None)
+    use = attr.ib(default=attr.Factory(list))
+    require = attr.ib(default=attr.Factory(list))
+
+
+@attr.s()
 class GoModule(object):
     namespace = attr.ib(default=None)
     name = attr.ib(default=None)
@@ -253,3 +265,102 @@ def parse_gosum(location):
         gosums.append(dep)
 
     return gosums
+
+
+def parse_gowork(location):
+    """
+    Return a GoWorkspace parsed from a go.work file at ``location``.
+
+    Handle go.work files from Go workspaces introduced in Go 1.18.
+    See https://go.dev/ref/mod#go-work-files for details.
+
+    A go.work file specifies a workspace containing multiple modules with:
+    - ``go`` directive: Go version
+    - ``use`` directives: paths to local modules in the workspace
+    - ``require`` directives: external module requirements (like go.mod)
+
+    For example::
+
+        go 1.18
+
+        use (
+            ./mymodule
+            ./tools
+        )
+
+        require (
+            github.com/some/dep v1.2.3
+        )
+    """
+    with io.open(location, encoding='utf-8', closefd=True) as data:
+        lines = data.readlines()
+
+    workspace = GoWorkspace()
+    use_dirs = []
+    require = []
+
+    for i, line in enumerate(lines):
+        line = preprocess(line)
+
+        if not line:
+            continue
+
+        # Parse 'go <version>' directive
+        if line.startswith('go '):
+            workspace.go_version = line[3:].strip()
+            continue
+
+        # Parse multi-line 'use ( ... )' block
+        if line == 'use (' or line.startswith('use ('):
+            for use_line in lines[i + 1:]:
+                use_line = preprocess(use_line)
+                if ')' in use_line:
+                    break
+                if use_line:
+                    use_dirs.append(use_line)
+            continue
+
+        # Parse inline 'use ./path'
+        if line.startswith('use ') and '(' not in line:
+            path = line[4:].strip()
+            if path:
+                use_dirs.append(path)
+            continue
+
+        # Parse multi-line 'require ( ... )' block
+        if line == 'require (' or (line.startswith('require') and '(' in line):
+            for req_line in lines[i + 1:]:
+                req_line = preprocess(req_line)
+                if ')' in req_line:
+                    break
+                if not req_line:
+                    continue
+                parsed_dep = parse_dep_link(req_line)
+                if parsed_dep:
+                    ns_name = parsed_dep.group('ns_name')
+                    namespace, _, name = ns_name.rpartition('/')
+                    version = parsed_dep.group('version')
+                    require.append(GoModule(
+                        namespace=namespace,
+                        name=name,
+                        version=version,
+                    ))
+            continue
+
+        # Parse inline 'require module version'
+        if line.startswith('require ') and '(' not in line:
+            parsed = parse_module(line)
+            if parsed:
+                ns_name = parsed.group('ns_name')
+                namespace, _, name = ns_name.rpartition('/')
+                version = parsed.group('version').strip()
+                require.append(GoModule(
+                    namespace=namespace,
+                    name=name,
+                    version=version,
+                ))
+            continue
+
+    workspace.use = use_dirs
+    workspace.require = require
+    return workspace

--- a/src/packagedcode/golang.py
+++ b/src/packagedcode/golang.py
@@ -22,7 +22,7 @@ Handle Go packages including go.mod and go.sum files.
 # CHECK: https://forum.golangbridge.org/t/url-to-download-package/19811
 
 # TODO: use the LICENSE file convention!
-# TODO: support "vendor" and "workspace" layouts
+# TODO: support "vendor" layout
 
 
 class BaseGoModuleHandler(models.DatafileHandler):
@@ -108,7 +108,7 @@ class GoSumHandler(BaseGoModuleHandler):
     path_patterns = ('*/go.sum',)
     default_package_type = 'golang'
     default_primary_language = 'Go'
-    description = 'Go module cheksums file'
+    description = 'Go module checksums file'
     documentation_url = 'https://go.dev/ref/mod#go-sum-files'
 
     @classmethod
@@ -132,5 +132,56 @@ class GoSumHandler(BaseGoModuleHandler):
             type=cls.default_package_type,
             dependencies=package_dependencies,
             primary_language=cls.default_primary_language,
+        )
+        yield models.PackageData.from_data(package_data, package_only)
+
+
+class GoWorkHandler(models.DatafileHandler):
+    """
+    Handle Go workspace files (go.work) introduced in Go 1.18.
+
+    A go.work file identifies a workspace: a collection of Go modules
+    that can be developed together. It lists ``use`` directives pointing
+    to local module directories, and optional ``require`` directives for
+    external dependencies.
+
+    See https://go.dev/ref/mod#go-work-files for details.
+    """
+    datasource_id = 'go_work'
+    path_patterns = ('*/go.work',)
+    default_package_type = 'golang'
+    default_primary_language = 'Go'
+    description = 'Go workspace file'
+    documentation_url = 'https://go.dev/ref/mod#go-work-files'
+
+    @classmethod
+    def parse(cls, location, package_only=False):
+        workspace = go_mod.parse_gowork(location)
+
+        dependencies = []
+        for req in workspace.require or []:
+            dependencies.append(
+                models.DependentPackage(
+                    purl=req.purl(include_version=True),
+                    extracted_requirement=req.version,
+                    scope='require',
+                    is_runtime=True,
+                    is_optional=False,
+                    is_pinned=False,
+                )
+            )
+
+        extra_data = {}
+        if workspace.go_version:
+            extra_data['go_version'] = workspace.go_version
+        if workspace.use:
+            extra_data['use'] = workspace.use
+
+        package_data = dict(
+            datasource_id=cls.datasource_id,
+            type=cls.default_package_type,
+            primary_language=cls.default_primary_language,
+            dependencies=dependencies,
+            extra_data=extra_data,
         )
         yield models.PackageData.from_data(package_data, package_only)

--- a/tests/packagedcode/data/golang/gowork/sample1/go.work
+++ b/tests/packagedcode/data/golang/gowork/sample1/go.work
@@ -1,0 +1,11 @@
+go 1.21
+
+use (
+	./mymodule
+	./tools/formatter
+)
+
+require (
+	github.com/some/dependency v1.2.3
+	github.com/another/lib v0.9.0
+)

--- a/tests/packagedcode/data/golang/gowork/sample1/output.expected.json
+++ b/tests/packagedcode/data/golang/gowork/sample1/output.expected.json
@@ -1,0 +1,75 @@
+[
+  {
+    "type": "golang",
+    "namespace": null,
+    "name": null,
+    "version": null,
+    "qualifiers": {},
+    "subpath": null,
+    "primary_language": "Go",
+    "description": null,
+    "release_date": null,
+    "parties": [],
+    "keywords": [],
+    "homepage_url": null,
+    "download_url": null,
+    "size": null,
+    "sha1": null,
+    "md5": null,
+    "sha256": null,
+    "sha512": null,
+    "bug_tracking_url": null,
+    "code_view_url": null,
+    "vcs_url": null,
+    "copyright": null,
+    "holder": null,
+    "declared_license_expression": null,
+    "declared_license_expression_spdx": null,
+    "license_detections": [],
+    "other_license_expression": null,
+    "other_license_expression_spdx": null,
+    "other_license_detections": [],
+    "extracted_license_statement": null,
+    "notice_text": null,
+    "source_packages": [],
+    "file_references": [],
+    "is_private": false,
+    "is_virtual": false,
+    "extra_data": {
+      "go_version": "1.21",
+      "use": [
+        "./mymodule",
+        "./tools/formatter"
+      ]
+    },
+    "dependencies": [
+      {
+        "purl": "pkg:golang/github.com/some/dependency@v1.2.3",
+        "extracted_requirement": "v1.2.3",
+        "scope": "require",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": false,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {}
+      },
+      {
+        "purl": "pkg:golang/github.com/another/lib@v0.9.0",
+        "extracted_requirement": "v0.9.0",
+        "scope": "require",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": false,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {}
+      }
+    ],
+    "repository_homepage_url": null,
+    "repository_download_url": null,
+    "api_data_url": null,
+    "datasource_id": "go_work",
+    "purl": null
+  }
+]

--- a/tests/packagedcode/data/golang/gowork/sample2/go.work
+++ b/tests/packagedcode/data/golang/gowork/sample2/go.work
@@ -1,0 +1,3 @@
+go 1.18
+
+use ./myapp

--- a/tests/packagedcode/data/golang/gowork/sample2/output.expected.json
+++ b/tests/packagedcode/data/golang/gowork/sample2/output.expected.json
@@ -1,0 +1,51 @@
+[
+  {
+    "type": "golang",
+    "namespace": null,
+    "name": null,
+    "version": null,
+    "qualifiers": {},
+    "subpath": null,
+    "primary_language": "Go",
+    "description": null,
+    "release_date": null,
+    "parties": [],
+    "keywords": [],
+    "homepage_url": null,
+    "download_url": null,
+    "size": null,
+    "sha1": null,
+    "md5": null,
+    "sha256": null,
+    "sha512": null,
+    "bug_tracking_url": null,
+    "code_view_url": null,
+    "vcs_url": null,
+    "copyright": null,
+    "holder": null,
+    "declared_license_expression": null,
+    "declared_license_expression_spdx": null,
+    "license_detections": [],
+    "other_license_expression": null,
+    "other_license_expression_spdx": null,
+    "other_license_detections": [],
+    "extracted_license_statement": null,
+    "notice_text": null,
+    "source_packages": [],
+    "file_references": [],
+    "is_private": false,
+    "is_virtual": false,
+    "extra_data": {
+      "go_version": "1.18",
+      "use": [
+        "./myapp"
+      ]
+    },
+    "dependencies": [],
+    "repository_homepage_url": null,
+    "repository_download_url": null,
+    "api_data_url": null,
+    "datasource_id": "go_work",
+    "purl": null
+  }
+]

--- a/tests/packagedcode/test_golang.py
+++ b/tests/packagedcode/test_golang.py
@@ -99,3 +99,21 @@ class TestGolang(PackageTester):
         expected_loc = self.get_test_loc('golang/gosum/sample6/output.expected.json')
         package = golang.GoSumHandler.parse(test_file)
         self.check_packages_data(package, expected_loc, regen=REGEN_TEST_FIXTURES)
+
+    def test_gowork_is_package_data_file(self):
+        test_file = self.get_test_loc('golang/gowork/sample1/go.work')
+        assert golang.GoWorkHandler.is_datafile(test_file)
+
+    def test_parse_gowork_sample1(self):
+        """Test go.work with multi-line use block and require dependencies."""
+        test_file = self.get_test_loc('golang/gowork/sample1/go.work')
+        expected_loc = self.get_test_loc('golang/gowork/sample1/output.expected.json')
+        package = golang.GoWorkHandler.parse(test_file)
+        self.check_packages_data(package, expected_loc, regen=REGEN_TEST_FIXTURES)
+
+    def test_parse_gowork_sample2(self):
+        """Test minimal go.work with a single use directive and no require block."""
+        test_file = self.get_test_loc('golang/gowork/sample2/go.work')
+        expected_loc = self.get_test_loc('golang/gowork/sample2/output.expected.json')
+        package = golang.GoWorkHandler.parse(test_file)
+        self.check_packages_data(package, expected_loc, regen=REGEN_TEST_FIXTURES)


### PR DESCRIPTION
## Summary

Go 1.18 introduced [workspaces](https://go.dev/doc/tutorial/workspaces) to enable multi-module development without editing `go.mod` files. This PR adds full support for parsing `go.work` files.

This resolves the `TODO` comment in `golang.py`:
```python
# TODO: support "vendor" and "workspace" layouts
```

## Changes

### `src/packagedcode/go_mod.py`
- Add `GoWorkspace` attr class to hold parsed workspace data
- Add `parse_gowork(location)` function that handles:
  - `go` directive (Go version)
  - `use` directives (local module paths) — both inline and block syntax
  - `require` directives (external dependencies) — both inline and block syntax

### `src/packagedcode/golang.py`
- Add `GoWorkHandler` class with `datasource_id='go_work'`
- Extracts workspace local paths (`use`) and require dependencies
- `use` paths and Go version exposed in `extra_data`
- `require` entries converted to `DependentPackage` objects

### `src/packagedcode/__init__.py`
- Register `GoWorkHandler` in `APPLICATION_PACKAGE_DATAFILE_HANDLERS`

### Tests
- Add 3 tests to `tests/packagedcode/test_golang.py`
- Add 2 test fixtures:
  - `sample1/go.work`: multi-line `use` block + `require` block
  - `sample2/go.work`: minimal workspace with single inline `use`

All 17 existing golang tests continue to pass.

See: https://go.dev/ref/mod#go-work-files