### PR TITLE
Fix the `openssl-exception-lgpl-3.0-plus` primary `spdx_license_key`

### DIFF
--- a/src/licensedcode/data/licenses/openssl-exception-lgpl-3.0-plus.LICENSE
+++ b/src/licensedcode/data/licenses/openssl-exception-lgpl-3.0-plus.LICENSE
@@ -6,9 +6,9 @@ category: Copyleft Limited
 owner: psycopg
 homepage_url: http://initd.org/psycopg/license/
 is_exception: yes
-spdx_license_key: LicenseRef-scancode-openssl-exception-lgpl3.0plus
+spdx_license_key: LicenseRef-scancode-openssl-exception-lgpl-3.0-plus
 other_spdx_license_keys:
-    - LicenseRef-scancode-openssl-exception-lgpl-3.0-plus
+    - LicenseRef-scancode-openssl-exception-lgpl3.0plus
 other_urls:
     - http://www.gnu.org/licenses/lgpl-3.0.txt
 standard_notice: |


### PR DESCRIPTION
The primary `spdx_license_key` should be the more correct dashed variant, and the other older variant should only be kept for backward compatibility.