### PR TITLE
Add PEAR package.xml support for ScanCode Toolkit

### DIFF
--- a/src/packagedcode/phpcomposer.py
+++ b/src/packagedcode/phpcomposer.py
@@ -9,6 +9,7 @@
 
 import io
 import json
+import xml.etree.ElementTree as ET
 from functools import partial
 
 from packagedcode import models
@@ -29,6 +30,7 @@ class BasePhpComposerHandler(models.DatafileHandler):
         datafile_name_patterns = (
             'composer.json',
             'composer.lock',
+            'package.xml',
         )
 
         if resource.has_parent():
@@ -206,6 +208,121 @@ class PhpComposerLockHandler(BasePhpComposerHandler):
 
         for package in packages + packages_dev:
             yield package
+
+
+class PhpPearPackageXmlHandler(BasePhpComposerHandler):
+    datasource_id = 'php_pear_package_xml'
+    path_patterns = ('*package.xml',)
+    default_package_type = 'pear'
+    default_primary_language = 'PHP'
+    description = 'PEAR package.xml manifest'
+    documentation_url = 'https://pear.php.net/manual/en/guide.developers.package2.intro.php'
+
+    @classmethod
+    def parse(cls, location, package_only=False):
+        package = build_pear_package_data(location=location, package_only=package_only)
+        if package:
+            yield package
+
+
+PEAR_V2_NS = {'p': 'http://pear.php.net/dtd/package-2.0'}
+PEAR_MAINTAINER_ROLES = (
+    'lead',
+    'developer',
+    'contributor',
+    'helper',
+)
+
+
+def build_pear_package_data(location, package_only=False):
+    """
+    Return a PackageData built from a PEAR package.xml file at ``location``.
+    """
+    root = ET.parse(location).getroot()
+
+    name = find_text(root, 'name')
+    channel = find_text(root, 'channel')
+    summary = find_text(root, 'summary')
+    description = find_text(root, 'description')
+    homepage_url = find_text(root, 'uri')
+    license_statement = find_text(root, 'license')
+    version = find_text(root, 'version/release') or find_text(root, 'release/version')
+
+    package_mapping = dict(
+        datasource_id=PhpPearPackageXmlHandler.datasource_id,
+        type=PhpPearPackageXmlHandler.default_package_type,
+        namespace=channel,
+        name=name,
+        version=version,
+        primary_language=PhpPearPackageXmlHandler.default_primary_language,
+        description=build_description(summary=summary, description=description),
+        homepage_url=homepage_url,
+        extracted_license_statement=license_statement,
+        repository_homepage_url=get_pear_repository_homepage_url(channel=channel, name=name),
+        parties=list(get_pear_parties(root)),
+    )
+    package = models.PackageData.from_data(package_mapping, package_only)
+
+    if not package_only:
+        package.populate_license_fields()
+
+    return package
+
+
+def get_pear_repository_homepage_url(channel, name):
+    if channel and name:
+        return f'https://{channel}/package/{name}'
+    if name:
+        return f'https://pear.php.net/package/{name}'
+
+
+def build_description(summary=None, description=None):
+    summary = summary and summary.strip() or None
+    description = description and description.strip() or None
+
+    if summary and description:
+        if summary == description:
+            return description
+        return f'{summary}\n{description}'
+
+    return description or summary
+
+
+def get_pear_parties(root):
+    for role in PEAR_MAINTAINER_ROLES:
+        for maintainer in findall_elements(root, role):
+            name = find_text(maintainer, 'name') or find_text(maintainer, 'user')
+            email = find_text(maintainer, 'email')
+            if name or email:
+                yield models.Party(
+                    type=models.party_person,
+                    name=name,
+                    email=email,
+                    role=role,
+                )
+
+
+def find_text(element, path):
+    found = find_element(element, path)
+    if found is not None and found.text:
+        text = found.text.strip()
+        return text or None
+
+
+def find_element(element, path):
+    namespaced_path = '/'.join(f'p:{part}' for part in path.split('/'))
+    found = element.find(namespaced_path, PEAR_V2_NS)
+    if found is not None:
+        return found
+    return element.find(path)
+
+
+def findall_elements(element, path):
+    namespaced_path = '/'.join(f'p:{part}' for part in path.split('/'))
+    found = element.findall(namespaced_path, PEAR_V2_NS)
+    if found:
+        return found
+    return element.findall(path)
 
 
 def licensing_mapper(licenses, package, is_private=False):

--- a/tests/packagedcode/data/phpcomposer/pear_basic/package.xml
+++ b/tests/packagedcode/data/phpcomposer/pear_basic/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package version="2.0" xmlns="http://pear.php.net/dtd/package-2.0">
+  <name>Example_Package</name>
+  <channel>pear.php.net</channel>
+  <summary>Example PEAR package</summary>
+  <description>A small test package for ScanCode PEAR parsing.</description>
+  <lead>
+    <name>Jane Doe</name>
+    <user>janedoe</user>
+    <email>jane@example.com</email>
+    <active>yes</active>
+  </lead>
+  <license>MIT</license>
+  <version>
+    <release>1.2.3</release>
+    <api>1.2.0</api>
+  </version>
+</package>

--- a/tests/packagedcode/data/phpcomposer/pear_basic/package.xml.expected
+++ b/tests/packagedcode/data/phpcomposer/pear_basic/package.xml.expected
@@ -1,0 +1,77 @@
+[
+  {
+    "type": "pear",
+    "namespace": "pear.php.net",
+    "name": "Example_Package",
+    "version": "1.2.3",
+    "qualifiers": {},
+    "subpath": null,
+    "primary_language": "PHP",
+    "description": "Example PEAR package\nA small test package for ScanCode PEAR parsing.",
+    "release_date": null,
+    "parties": [
+      {
+        "type": "person",
+        "role": "lead",
+        "name": "Jane Doe",
+        "email": "jane@example.com",
+        "url": null
+      }
+    ],
+    "keywords": [],
+    "homepage_url": null,
+    "download_url": null,
+    "size": null,
+    "sha1": null,
+    "md5": null,
+    "sha256": null,
+    "sha512": null,
+    "bug_tracking_url": null,
+    "code_view_url": null,
+    "vcs_url": null,
+    "copyright": null,
+    "holder": null,
+    "declared_license_expression": "mit",
+    "declared_license_expression_spdx": "MIT",
+    "license_detections": [
+      {
+        "license_expression": "mit",
+        "license_expression_spdx": "MIT",
+        "matches": [
+          {
+            "license_expression": "mit",
+            "license_expression_spdx": "MIT",
+            "from_file": null,
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "1-spdx-id",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
+            "rule_url": null,
+            "matched_text": "MIT"
+          }
+        ],
+        "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf"
+      }
+    ],
+    "other_license_expression": null,
+    "other_license_expression_spdx": null,
+    "other_license_detections": [],
+    "extracted_license_statement": "MIT",
+    "notice_text": null,
+    "source_packages": [],
+    "file_references": [],
+    "is_private": false,
+    "is_virtual": false,
+    "extra_data": {},
+    "dependencies": [],
+    "repository_homepage_url": "https://pear.php.net/package/Example_Package",
+    "repository_download_url": null,
+    "api_data_url": null,
+    "datasource_id": "php_pear_package_xml",
+    "purl": "pkg:pear/pear.php.net/Example_Package@1.2.3"
+  }
+]

--- a/tests/packagedcode/data/phpcomposer/pear_with_uri/package.xml
+++ b/tests/packagedcode/data/phpcomposer/pear_with_uri/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package version="2.0" xmlns="http://pear.php.net/dtd/package-2.0">
+  <name>Net_URL2</name>
+  <channel>pear.example.org</channel>
+  <summary>URL parsing helpers</summary>
+  <description>Utilities for working with URLs in legacy PEAR packages.</description>
+  <uri>https://example.org/pear/Net_URL2</uri>
+  <lead>
+    <user>leaddev</user>
+    <email>lead@example.org</email>
+    <active>yes</active>
+  </lead>
+  <developer>
+    <name>John Smith</name>
+    <email>john.smith@example.org</email>
+    <active>yes</active>
+  </developer>
+  <license>MIT</license>
+  <version>
+    <release>2.0.0</release>
+    <api>2.0.0</api>
+  </version>
+</package>

--- a/tests/packagedcode/data/phpcomposer/pear_with_uri/package.xml.expected
+++ b/tests/packagedcode/data/phpcomposer/pear_with_uri/package.xml.expected
@@ -1,0 +1,84 @@
+[
+  {
+    "type": "pear",
+    "namespace": "pear.example.org",
+    "name": "Net_URL2",
+    "version": "2.0.0",
+    "qualifiers": {},
+    "subpath": null,
+    "primary_language": "PHP",
+    "description": "URL parsing helpers\nUtilities for working with URLs in legacy PEAR packages.",
+    "release_date": null,
+    "parties": [
+      {
+        "type": "person",
+        "role": "lead",
+        "name": "leaddev",
+        "email": "lead@example.org",
+        "url": null
+      },
+      {
+        "type": "person",
+        "role": "developer",
+        "name": "John Smith",
+        "email": "john.smith@example.org",
+        "url": null
+      }
+    ],
+    "keywords": [],
+    "homepage_url": "https://example.org/pear/Net_URL2",
+    "download_url": null,
+    "size": null,
+    "sha1": null,
+    "md5": null,
+    "sha256": null,
+    "sha512": null,
+    "bug_tracking_url": null,
+    "code_view_url": null,
+    "vcs_url": null,
+    "copyright": null,
+    "holder": null,
+    "declared_license_expression": "mit",
+    "declared_license_expression_spdx": "MIT",
+    "license_detections": [
+      {
+        "license_expression": "mit",
+        "license_expression_spdx": "MIT",
+        "matches": [
+          {
+            "license_expression": "mit",
+            "license_expression_spdx": "MIT",
+            "from_file": null,
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "1-spdx-id",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
+            "rule_url": null,
+            "matched_text": "MIT"
+          }
+        ],
+        "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf"
+      }
+    ],
+    "other_license_expression": null,
+    "other_license_expression_spdx": null,
+    "other_license_detections": [],
+    "extracted_license_statement": "MIT",
+    "notice_text": null,
+    "source_packages": [],
+    "file_references": [],
+    "is_private": false,
+    "is_virtual": false,
+    "extra_data": {},
+    "dependencies": [],
+    "repository_homepage_url": "https://pear.example.org/package/Net_URL2",
+    "repository_download_url": null,
+    "api_data_url": null,
+    "datasource_id": "php_pear_package_xml",
+    "purl": "pkg:pear/pear.example.org/Net_URL2@2.0.0"
+  }
+]

--- a/tests/packagedcode/test_phpcomposer.py
+++ b/tests/packagedcode/test_phpcomposer.py
@@ -86,3 +86,19 @@ class TestPHPcomposer(PackageTester):
         expected_loc = self.get_test_loc('phpcomposer/composer.lock-expected.json')
         packages = phpcomposer.PhpComposerLockHandler.parse(test_file)
         self.check_packages_data(packages, expected_loc, regen=REGEN_TEST_FIXTURES)
+
+    def test_is_manifest_php_pear_package_xml(self):
+        test_file = self.get_test_loc('phpcomposer/pear_basic/package.xml')
+        assert phpcomposer.PhpPearPackageXmlHandler.is_datafile(test_file)
+
+    def test_parse_php_pear_package_xml_basic(self):
+        test_file = self.get_test_loc('phpcomposer/pear_basic/package.xml')
+        expected_loc = self.get_test_loc('phpcomposer/pear_basic/package.xml.expected')
+        packages = phpcomposer.PhpPearPackageXmlHandler.parse(test_file)
+        self.check_packages_data(packages, expected_loc, regen=REGEN_TEST_FIXTURES)
+
+    def test_parse_php_pear_package_xml_with_uri_and_multiple_parties(self):
+        test_file = self.get_test_loc('phpcomposer/pear_with_uri/package.xml')
+        expected_loc = self.get_test_loc('phpcomposer/pear_with_uri/package.xml.expected')
+        packages = phpcomposer.PhpPearPackageXmlHandler.parse(test_file)
+        self.check_packages_data(packages, expected_loc, regen=REGEN_TEST_FIXTURES)


### PR DESCRIPTION
This PR adds support for parsing PEAR package.xml files in ScanCode Toolkit, addressing issue #4841.

## Changes
- Added PhpPearPackageXmlHandler class in src/packagedcode/phpcomposer.py
- Implemented XML parsing for PEAR v2.0 package.xml format
- Added support for extracting package metadata including name, version, description, license, maintainers, and repository information
- Created comprehensive test fixtures and unit tests
- Added namespace-aware XML parsing helpers

## Testing
- All existing tests pass
- Added 3 new test cases covering basic and advanced PEAR XML parsing scenarios
- Test fixtures include sample PEAR package.xml files with expected JSON outputs

## Files Changed
- src/packagedcode/phpcomposer.py: Added PEAR handler and parsing functions
- 	ests/packagedcode/test_phpcomposer.py: Added PEAR-specific tests
- 	ests/packagedcode/data/phpcomposer/pear_basic/package.xml: Test fixture
- 	ests/packagedcode/data/phpcomposer/pear_basic/package.xml.expected: Expected output
- 	ests/packagedcode/data/phpcomposer/pear_with_uri/package.xml: Advanced test fixture
- 	ests/packagedcode/data/phpcomposer/pear_with_uri/package.xml.expected: Expected output

This implementation follows the existing patterns in ScanCode Toolkit and integrates seamlessly with the packagedcode module.
