### PR TITLE
Fix typo: rename datasource_id from rpm_spefile to rpm_specfile

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -84,6 +84,7 @@ The following organizations or individuals have contributed to ScanCode:
 - Sharikzama @ZamaSharik
 - Shrijal Acharya @OctoPie23
 - Shivam Chauhan @chashiv
+- Shivam Sharma @shivamshrma09
 - Shivam Sandbhor @sbs2001
 - Steven Esser @majurg
 - Sushant Gupta @susg

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Next release
 --------------
 
+- Fix typo in ``RpmSpecfileHandler``: rename ``datasource_id`` from
+  ``rpm_spefile`` to ``rpm_specfile``.
+  https://github.com/aboutcode-org/scancode-toolkit/issues/4869
+
 v3.5.0 - 2026-01-15
 -------------------
 

--- a/src/packagedcode/rpm.py
+++ b/src/packagedcode/rpm.py
@@ -270,7 +270,7 @@ class RpmInstalledBdbDatabaseHandler(BaseRpmInstalledDatabaseHandler):
 
 # TODO: implement me!!@
 class RpmSpecfileHandler(models.NonAssemblableDatafileHandler):
-    datasource_id = 'rpm_spefile'
+    datasource_id = 'rpm_specfile'
     path_patterns = ('*.spec',)
     default_package_type = 'rpm'
     default_package_namespace = 'TBD'


### PR DESCRIPTION
Fixes #4869

The datasource_id in RpmSpecfileHandler was misspelled as 
'rpm_spefile' instead of 'rpm_specfile'. This fixes the typo.
