### PR TITLE
Add required phrase markers to 5 license rules

### DIFF
--- a/src/licensedcode/data/rules/jasper-2.0_3.RULE
+++ b/src/licensedcode/data/rules/jasper-2.0_3.RULE
@@ -4,4 +4,4 @@ is_license_reference: yes
 relevance: 100
 ---
 
-JasPer License Version 2.0
+{{JasPer}} License Version 2.0

--- a/src/licensedcode/data/rules/lgpl-2.1_221.RULE
+++ b/src/licensedcode/data/rules/lgpl-2.1_221.RULE
@@ -4,4 +4,4 @@ is_license_notice: yes
 relevance: 100
 ---
 
-Licensed under the GNU LGPL v2.1
+Licensed under the {{GNU LGPL}} v2.1

--- a/src/licensedcode/data/rules/libpng_8.RULE
+++ b/src/licensedcode/data/rules/libpng_8.RULE
@@ -4,4 +4,4 @@ is_license_notice: yes
 relevance: 100
 ---
 
-This code is released under the libpng license.
+This code is released under the {{libpng}} license.

--- a/src/licensedcode/data/rules/mit_705.RULE
+++ b/src/licensedcode/data/rules/mit_705.RULE
@@ -4,4 +4,4 @@ is_license_reference: yes
 relevance: 100
 ---
 
-MIT Open Source License.
+{{MIT}} Open Source License.

--- a/src/licensedcode/data/rules/mpl-2.0_44.RULE
+++ b/src/licensedcode/data/rules/mpl-2.0_44.RULE
@@ -4,4 +4,4 @@ is_license_reference: yes
 relevance: 100
 ---
 
-the Mozilla Public License 2
+the {{Mozilla Public License}} 2


### PR DESCRIPTION
Adds {{required phrase}} markers to 5 license reference/notice rules 
that were missing them, preventing false-positive detections when the 
scanned text does not contain the identifying license name.

- mit_705.RULE — mark {{MIT}}
- jasper-2.0_3.RULE — mark {{JasPer}}
- libpng_8.RULE — mark {{libpng}}
- mpl-2.0_44.RULE — mark {{Mozilla Public License}}
- lgpl-2.1_221.RULE — mark {{GNU LGPL}}

Related to #2878