### PR TITLE
Fix JCalendar LGPL detected as GPL

### DIFF
--- a/src/licensedcode/data/rules/gpl-2.0-plus_60.RULE
+++ b/src/licensedcode/data/rules/gpl-2.0-plus_60.RULE
@@ -6,15 +6,15 @@ notes: there are some confusing references to both LGPL and GPL
 ---
 
 This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
+it under the terms of the {{GNU General Public License}} as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+{{GNU General Public License}} for more details.
 
-You should have received a copy of the GNU Library Public License
+You should have received a copy of the {{GNU Library Public License}}
 along with this program; if not, write to the Free Software
 Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.

--- a/src/licensedcode/data/rules/lgpl-2.0-plus_jcalendar_1.RULE
+++ b/src/licensedcode/data/rules/lgpl-2.0-plus_jcalendar_1.RULE
@@ -1,0 +1,20 @@
+---
+license_expression: lgpl-2.0-plus
+is_license_notice: yes
+relevance: 100
+notes: Matches a common variant where Lesser and version 2 are mixed up
+---
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.

--- a/tests/licensedcode/data/datadriven/lic1/jcalendar_header.txt
+++ b/tests/licensedcode/data/datadriven/lic1/jcalendar_header.txt
@@ -1,0 +1,13 @@
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.

--- a/tests/licensedcode/data/datadriven/lic1/jcalendar_header.txt.yml
+++ b/tests/licensedcode/data/datadriven/lic1/jcalendar_header.txt.yml
@@ -1,0 +1,3 @@
+license_expressions:
+  - lgpl-2.0-plus
+  


### PR DESCRIPTION
Fixes #4513

JCalendar's LGPL header was getting flagged as GPL because the text is very similar to an existing GPL rule (`gpl-2.0-plus_60.RULE`).

Here is what this PR does to fix it:
1) Added required phrases to the old GPL rule so it ignores the JCalendar text
2) Added a new rule (`lgpl-2.0-plus_jcalendar_1.RULE`) to properly catch this specific LGPL variant
3) Added data driven regression tests to make sure it stays fixed

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->
**Before :**
<img width="1271" height="432" alt="image" src="https://github.com/user-attachments/assets/389d3fe8-4302-408b-a17a-32575945afec" />


**After:**
<img width="1364" height="628" alt="image" src="https://github.com/user-attachments/assets/f3c762f5-fb51-4cca-9b0f-37b27fba215b" />

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [ ] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--

