### PR TITLE
Resolve Issue #4229: "Author not detected in C++ file".

### DIFF
--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -2356,6 +2356,10 @@ PATTERNS = [
     # catch all other as Nouns
     ############################################################################
 
+    # Dot-separated proper names like Frankie.Chu (used as author handles)
+    # Changes made by Aditya issue no. #4229 regarding to Author detection
+    (r'^[A-Z][a-z]+\.[A-Z][a-z]+$', 'NAME'),
+
     # nouns (default)
     (r'.+', 'NN'),
 ]
@@ -4447,6 +4451,11 @@ remove_ascii_decorations = re.compile(r'[\-_\*!]{2,}|/{3,}|[=!]{4,}').sub
 
 fold_consecutive_quotes = re.compile(r"'\"{2,}").sub
 
+# normalize "Author:" (and variants) not followed by a space so that
+# "Author:Name" becomes "Author: Name" and can be properly tokenized.
+# Changes made by Aditya issue no. #4229 regarding to Author detection
+normalize_author_colon = re.compile(r'(?i)\b(authors?)\s*:\s*(?=\S)').sub
+
 # less common rem comment line prefix in dos
 # less common dnl comment line prefix in autotools am/in
 remove_weird_comment_markers = re.compile(r'^(rem|\@rem|dnl)\s+').sub
@@ -4502,6 +4511,12 @@ def prepare_text_line(line):
     line = remove_code_comment_markers(line)
     if TRACE_TOK:
         logger_debug('    prepare_text_line: after remove_code_comment_markers: ' + repr(line))
+
+    # normalize "Author:Name" to "Author: Name"
+    # Changes made by Aditya issue no. #4229 regarding to Author detection
+    line = normalize_author_colon(r'\1: ', line)
+    if TRACE_TOK:
+        logger_debug('    prepare_text_line: after normalize_author_colon: ' + repr(line))
 
     line = (line
         # C and C++ style comment markers

--- a/tests/cluecode/data/authors/author_no_space_after_colon.cpp
+++ b/tests/cluecode/data/authors/author_no_space_after_colon.cpp
@@ -1,0 +1,4 @@
+// Changes made by Aditya issue no. #4229 regarding to Author detection
+// Date:9 April,2012
+// Author:Frankie.Chu
+// IDE Arduino-1.0

--- a/tests/cluecode/data/authors/author_no_space_after_colon.cpp.yml
+++ b/tests/cluecode/data/authors/author_no_space_after_colon.cpp.yml
@@ -1,0 +1,9 @@
+# Changes made by Aditya issue no. #4229 regarding to Author detection
+what:
+  - authors
+  - authors_summary
+authors:
+  - Frankie.Chu
+authors_summary:
+  - value: Frankie.Chu
+    count: 1

--- a/tests/cluecode/test_copyrights_basic.py
+++ b/tests/cluecode/test_copyrights_basic.py
@@ -78,6 +78,18 @@ class TestTextPreparation(FileBasedTesting):
         result = prepare_text_line(cp)
         assert result == 'Jason Hunter <jhunter AT jdom DOT org'
 
+    def test_prepare_text_line_normalizes_author_colon_no_space(self):
+        # Changes made by Aditya issue no. #4229 regarding to Author detection
+        cp = '// Author:Frankie.Chu'
+        result = prepare_text_line(cp)
+        assert 'Author: Frankie.Chu' in result
+
+    def test_prepare_text_line_normalizes_author_colon_with_space(self):
+        # Ensure we don't break the case where there is already a space
+        cp = '// Author: Frankie.Chu'
+        result = prepare_text_line(cp)
+        assert 'Author: Frankie.Chu' in result
+
     def test_is_end_of_statement(self):
         line = '''          "All rights reserved\\n"'''
         prepped_line = prepare_text_line(line)


### PR DESCRIPTION
Fix author detection when "Author:" tag lacks trailing space (Issue #4229)
[
  Input-
from cluecode.copyrights import detect_copyrights_from_lines
lines = [
    (1, '// Date:9 April,2012'),
    (2, '// Author:Frankie.Chu'),
    (3, '// IDE Arduino-1.0')
]
results = list(detect_copyrights_from_lines(lines))
for r in results:
    print(f'- {r.author} (Found on line {r.start_line})')

  output-
  Input Lines:
[(1, '// Date:9 April,2012'), (2, '// Author:Frankie.Chu'), (3, '// IDE Arduino-1.0')]
Detected Authors:
- Frankie.Chu (Found on line 2)
]

Changes made by Aditya regarding to Author detection (Issue #4229):

1. Token Normalization (`src/cluecode/copyrights.py`):
   - Added a `normalize_author_colon` regex hook in the `prepare_text_line` pipeline to identify "Author:" or "author:" tags that are not immediately followed by whitespace.
   - Automatically injects a space to ensure `Author:Name` becomes `Author: Name`, allowing the tokenization engine to correctly isolate the author keyword from the name.

2. Lexer enhancements (`src/cluecode/copyrights.py`):
   - Added a new grammar lexer rule `(r'^[A-Z][a-z]+\.[A-Z][a-z]+$', 'NAME')`.
   - Correctly identifies `Name.Name` handle structures (like `Frankie.Chu`) as proper `NAME` entities instead of generic nouns (`NN`), allowing the existing NLP author detection grammar to successfully extract them.

3. Testing (`tests/cluecode/test_copyrights_basic.py` & `tests/cluecode/data/authors/`):
   - Added basic tokenization tests to verify `prepare_text_line` correctly normalizes spacing after colons without breaking existing correct formats.
   - Added a data-driven test (`author_no_space_after_colon.cpp` and its YAML) mimicking the exact reported edge-case to prevent future regressions.

Fixes #4229 
