### PR TITLE
Make 'no such option' assertion tolerant of newer click error format

### DIFF
--- a/tests/scancode/test_cli.py
+++ b/tests/scancode/test_cli.py
@@ -730,7 +730,12 @@ def test_scan_errors_out_with_unknown_option():
     test_file = test_env.get_test_loc('license_text/test.txt')
     args = ['--json--info', test_file]
     result = run_scan_click(args, expected_rc=2)
-    assert 'Error: No such option: --json--info'.lower() in result.output.lower()
+    # Accept both the old and new click error message formats:
+    #   click < 8.2:  "Error: No such option: --json--info"
+    #   click >= 8.2: "Error: No such option '--json--info'. (Did you mean ...)"
+    output = result.output.lower()
+    assert 'no such option' in output
+    assert '--json--info' in output
 
 
 def test_scan_to_json_without_FILE_does_not_write_to_next_option():


### PR DESCRIPTION
Fixes the `*_latest_from_pip` CI matrix (ubuntu22/24, macos14, win2019/2022) which currently fails on `develop` because click 8.2 changed the unknown-option error message format:

- click < 8.2:  `Error: No such option: --foo`
- click >= 8.2: `Error: No such option '--foo'. (Did you mean ...)`

The test now asserts the stable substrings (`no such option`, `--json--info`) instead of the exact phrasing, so it works with both versions.

Verified locally: passes with click 8.3.1.