### PR TITLE
CI: fan out Azure pipelines on Python version (parallel matrix) - speedup x5

### DIFF
--- a/etc/ci/azure-posix.yml
+++ b/etc/ci/azure-posix.yml
@@ -11,29 +11,35 @@ jobs:
       pool:
           vmImage: ${{ parameters.image_name }}
 
+      # Fan out on both Python version AND test suite so each
+      # (python_version, test_suite) combination runs as its own parallel
+      # job on its own agent VM. Previously python_versions were iterated
+      # as sequential steps inside a single job, so a failure on the first
+      # Python version skipped all subsequent ones.
       strategy:
           matrix:
-              ${{ each tsuite in parameters.test_suites }}:
-                 ${{ tsuite.key }}:
-                     test_suite_label: ${{ tsuite.key }}
-                     test_suite: ${{ tsuite.value }}
+              ${{ each pyver in parameters.python_versions }}:
+                  ${{ each tsuite in parameters.test_suites }}:
+                      py${{ replace(pyver, '.', '_') }}_${{ tsuite.key }}:
+                          python_version: ${{ pyver }}
+                          test_suite_label: ${{ tsuite.key }}
+                          test_suite: ${{ tsuite.value }}
 
       steps:
           - checkout: self
             fetchDepth: 10
 
-          - ${{ each pyver in parameters.python_versions }}:
-              - task: UsePythonVersion@0
-                inputs:
-                    versionSpec: '${{ pyver }}'
-                    architecture: '${{ parameters.python_architecture }}'
-                displayName: '${{ pyver }} - Install Python'
+          - task: UsePythonVersion@0
+            inputs:
+                versionSpec: '$(python_version)'
+                architecture: '${{ parameters.python_architecture }}'
+            displayName: 'Install Python $(python_version)'
 
-              - script: |
-                    python${{ pyver }} --version
-                    echo "python${{ pyver }}" > PYTHON_EXECUTABLE
-                    ./configure --clean && ./configure --dev
-                displayName: '${{ pyver }} - Configure'
+          - script: |
+                python$(python_version) --version
+                echo "python$(python_version)" > PYTHON_EXECUTABLE
+                ./configure --clean && ./configure --dev
+            displayName: 'Configure with Python $(python_version)'
 
-              - script: $(test_suite)
-                displayName: '${{ pyver }} - $(test_suite_label) on ${{ parameters.job_name }}'
+          - script: $(test_suite)
+            displayName: '$(test_suite_label) on ${{ parameters.job_name }} with Python $(python_version)'

--- a/etc/ci/azure-win.yml
+++ b/etc/ci/azure-win.yml
@@ -11,29 +11,35 @@ jobs:
       pool:
           vmImage: ${{ parameters.image_name }}
 
+      # Fan out on both Python version AND test suite so each
+      # (python_version, test_suite) combination runs as its own parallel
+      # job on its own agent VM. Previously python_versions were iterated
+      # as sequential steps inside a single job, so a failure on the first
+      # Python version skipped all subsequent ones.
       strategy:
           matrix:
-              ${{ each tsuite in parameters.test_suites }}:
-                 ${{ tsuite.key }}:
-                     test_suite_label: ${{ tsuite.key }}
-                     test_suite: ${{ tsuite.value }}
+              ${{ each pyver in parameters.python_versions }}:
+                  ${{ each tsuite in parameters.test_suites }}:
+                      py${{ replace(pyver, '.', '_') }}_${{ tsuite.key }}:
+                          python_version: ${{ pyver }}
+                          test_suite_label: ${{ tsuite.key }}
+                          test_suite: ${{ tsuite.value }}
 
       steps:
           - checkout: self
             fetchDepth: 10
 
-          - ${{ each pyver in parameters.python_versions }}:
-              - task: UsePythonVersion@0
-                inputs:
-                    versionSpec: '${{ pyver }}'
-                    architecture: '${{ parameters.python_architecture }}'
-                displayName: '${{ pyver }} - Install Python'
+          - task: UsePythonVersion@0
+            inputs:
+                versionSpec: '$(python_version)'
+                architecture: '${{ parameters.python_architecture }}'
+            displayName: 'Install Python $(python_version)'
 
-              - script: |
-                   python --version
-                   echo | set /p=python> PYTHON_EXECUTABLE
-                   configure --clean && configure --dev
-                displayName: '${{ pyver }} - Configure'
+          - script: |
+               python --version
+               echo | set /p=python> PYTHON_EXECUTABLE
+               configure --clean && configure --dev
+            displayName: 'Configure with Python $(python_version)'
 
-              - script: $(test_suite)
-                displayName: '${{ pyver }} - $(test_suite_label) on ${{ parameters.job_name }}'
+          - script: $(test_suite)
+            displayName: '$(test_suite_label) on ${{ parameters.job_name }} with Python $(python_version)'


### PR DESCRIPTION
## Problem

In `etc/ci/azure-posix.yml` and `etc/ci/azure-win.yml`, `python_versions` are iterated as a sequential template loop inside a single job's `steps:`, instead of being part of `strategy.matrix`. So each `(os, test_suite)` runs all Python versions back-to-back on the same agent VM.

Two visible consequences:

1. **Long wall-clock time** — e.g. `ubuntu24_cpython all` runs 3.10 → 3.11 → 3.12 → 3.13 → 3.14 in series (~10 min each = ~50 min total).
2. **Cascading skips** — if the first Python version's tests fail (recently happened on the `*_latest_from_pip` matrix because of a click 8.2 error-message change), all later Python versions are marked `skipped` instead of also running, hiding whether they're affected too.

Example from a recent UV PR run:

| Python | Result |
|---|---|
| 3.10 | failed |
| 3.11 | skipped |
| 3.12 | skipped |
| 3.13 | skipped |
| 3.14 | skipped |

## Change

Move `python_version` into `strategy.matrix` (alongside `test_suite`) in both templates so each `(python_version, test_suite)` combination runs as **its own parallel job on its own agent VM**.

Matrix keys are of the form `py3_10_all`, `py3_11_misc_and_scancode`, etc. (Azure matrix keys must be alphanumeric+underscore, so dots in version strings are replaced).

No changes to caller pipelines in `azure-pipelines.yml` — the `python_versions` and `test_suites` parameters keep the same shape.

## Tradeoffs

| Aspect | Before | After |
|---|---|---|
| Wall-clock for `ubuntu24_cpython all` (5 pyvers) | ~50 min | ~10 min |
| Visibility of multi-version failures | Stops at first fail | All versions reported |
| Concurrent agent slots needed | 1 per (os, suite) | N per (os, suite), where N = #pyvers |
| Setup overhead | Configure once per agent | Configure per (pyver, suite) pair |

⚠️ **Capacity caveat**: This expands the total number of concurrent jobs. The free Azure DevOps OSS tier provides ~10 concurrent agents. If the project's available concurrency can't absorb the fan-out, jobs will queue instead of running in parallel and overall wall-clock won't improve. Maintainers should confirm available capacity before merging.

Marked as draft for that reason — merge at your discretion.

Guillem Serra Cazorla <gserracazorla@gmail.com>
