### PR TITLE
Add rule to detect Happy Bunny OR MIT dual-license

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Next release
 --------------
 
+- Fix detection of "Happy Bunny License or MIT License" dual-license
+  statement to correctly use OR instead of AND
+  https://github.com/aboutcode-org/scancode-toolkit/issues/4982
+
 v3.5.0 - 2026-01-15
 -------------------
 

--- a/src/licensedcode/data/rules/happy-bunny_or_mit_1.RULE
+++ b/src/licensedcode/data/rules/happy-bunny_or_mit_1.RULE
@@ -1,0 +1,7 @@
+---
+license_expression: happy-bunny OR mit
+is_license_notice: yes
+relevance: 100
+---
+
+licensed under The {{Happy Bunny License or MIT}} License


### PR DESCRIPTION
<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

The PR adds a new rule to detect Happy Bunny OR MIT license. I am not sure if CHANGELOG required changes for this PR, please let me know if it is not needed and I will remove it.

Thanks in advance for your review!


Fixes #4982

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [X] Updated documentation pages (if applicable)
* [X] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->
