### PR TITLE
Fix licensedcode-data optional extra

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,6 +15,7 @@ The following organizations or individuals have contributed to ScanCode:
 - Aryan Kenchappagol @aryanxk02
 - Avi Aryan @aviaryan
 - Aviral Verma @avirlrma
+- Ayush @macayu17
 - Ayan Sinha Mahapatra @AyanSinhaMahapatra
 - Ayush Jain @aj4ayushjain
 - Bruno Oliveira @nicoddemus

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Next release
 --------------
 
+- Fix the optional ``licenses`` extra dependency typo to install
+  ``licensedcode-data``.
+  https://github.com/aboutcode-org/scancode-toolkit/pull/5056
+
 v33.0.0rc1 - 2026-05-14
 ------------------------
 

--- a/pyproject-scancode-toolkit-mini.toml
+++ b/pyproject-scancode-toolkit-mini.toml
@@ -111,7 +111,7 @@ Homepage = "https://github.com/nexB/scancode-toolkit"
 
 [project.optional-dependencies]
 licenses = [
-    "licensecode-data",
+    "licensedcode-data",
 ]
 
 # no impact but added for symmetry with the mini config

--- a/pyproject-scancode-toolkit.toml
+++ b/pyproject-scancode-toolkit.toml
@@ -111,7 +111,7 @@ Homepage = "https://github.com/nexB/scancode-toolkit"
 
 [project.optional-dependencies]
 licenses = [
-    "licensecode-data",
+    "licensedcode-data",
 ]
 
 # no impact but added for symmetry with the other pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ Homepage = "https://github.com/nexB/scancode-toolkit"
 [project.optional-dependencies]
 # no impact but added for symmetry with the other pyproject.toml
 licenses = [
-    "licensecode-data",
+    "licensedcode-data",
     "licensedcode-index",
 ]
 


### PR DESCRIPTION
Reference:
 - #5053

This PR fixes the optional `licenses` extra dependency typo from `licensecode-data` to `licensedcode-data` in the ScanCode pyproject files.

### Testing

* `venv\Scripts\python.exe -m pip check`
* metadata validation script for the `licenses` extra and release-wheel default dependencies
* `git diff --check upstream/develop`

### Tasks

* [x] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [x] PR is descriptively titled and links the original issue above
* [x] Commits are in uniquely-named feature branch and has no merge conflicts
* [ ] Updated documentation pages (if applicable)
* [x] Updated CHANGELOG.rst (if applicable)