### PR TITLE
minor fix of a typo: "certifified" -> "certified" in license data

### DIFF
--- a/src/licensedcode/data/licenses/apsl-2.0.LICENSE
+++ b/src/licensedcode/data/licenses/apsl-2.0.LICENSE
@@ -7,7 +7,7 @@ owner: Apple
 homepage_url: http://www.opensource.apple.com/license/apsl/
 notes: |
     Per SPDX.org, this version was released 6 August 2003. This license is OSI
-    certifified.
+    certified.
 spdx_license_key: APSL-2.0
 osi_license_key: APSL-2.0
 text_urls:

--- a/src/licensedcode/data/licenses/artistic-2.0.LICENSE
+++ b/src/licensedcode/data/licenses/artistic-2.0.LICENSE
@@ -7,7 +7,7 @@ owner: Perl Foundation
 homepage_url: http://www.perlfoundation.org/
 notes: |
     Per SPDX.org, this version was released 2006 This license is OSI
-    certifified.
+    certified.
 spdx_license_key: Artistic-2.0
 osi_license_key: Artistic-2.0
 text_urls:

--- a/src/licensedcode/data/licenses/attribution.LICENSE
+++ b/src/licensedcode/data/licenses/attribution.LICENSE
@@ -7,7 +7,7 @@ owner: Unspecified
 homepage_url: http://opensource.org/licenses/attribution.php
 notes: |
     Per SPDX.org, this version was released 2002 This license is OSI
-    certifified.
+    certified.
 spdx_license_key: AAL
 text_urls:
     - http://opensource.org/licenses/attribution.php

--- a/src/licensedcode/data/licenses/boost-1.0.LICENSE
+++ b/src/licensedcode/data/licenses/boost-1.0.LICENSE
@@ -7,7 +7,7 @@ owner: Boost
 homepage_url: http://www.boost.org/users/license.html
 notes: |
     Per SPDX.org, this version was released 17 August 2003 This license is OSI
-    certifified.
+    certified.
 spdx_license_key: BSL-1.0
 text_urls:
     - http://www.boost.org/LICENSE_1_0.txt

--- a/src/licensedcode/data/licenses/ca-tosl-1.1.LICENSE
+++ b/src/licensedcode/data/licenses/ca-tosl-1.1.LICENSE
@@ -5,7 +5,7 @@ name: Computer Associates Trusted Open Source License 1.1
 category: Copyleft Limited
 owner: Computer Associates
 homepage_url: http://www.opensource.org/licenses/ca-tosl1.1.php
-notes: Per SPDX.org, this license is OSI certifified.
+notes: Per SPDX.org, this license is OSI certified.
 spdx_license_key: CATOSL-1.1
 osi_license_key: CATOSL-1.1
 text_urls:

--- a/src/licensedcode/data/licenses/cpal-1.0.LICENSE
+++ b/src/licensedcode/data/licenses/cpal-1.0.LICENSE
@@ -5,7 +5,7 @@ name: Common Public Attribution License 1.0
 category: Copyleft
 owner: OSI - Open Source Initiative
 homepage_url: http://www.opensource.org/licenses/cpal_1.0
-notes: Per SPDX.org, this license is OSI certifified.
+notes: Per SPDX.org, this license is OSI certified.
 spdx_license_key: CPAL-1.0
 osi_license_key: CPAL-1.0
 text_urls:

--- a/src/licensedcode/data/licenses/cua-opl-1.0.LICENSE
+++ b/src/licensedcode/data/licenses/cua-opl-1.0.LICENSE
@@ -5,7 +5,7 @@ name: CUA Office Public License 1.0
 category: Copyleft Limited
 owner: OSI - Open Source Initiative
 homepage_url: http://www.opensource.org/licenses/cuaoffice.php
-notes: Per SPDX.org, this license is OSI certifified.
+notes: Per SPDX.org, this license is OSI certified.
 spdx_license_key: CUA-OPL-1.0
 osi_license_key: CUA-OPL-1.0
 text_urls:

--- a/src/licensedcode/data/licenses/ecl-2.0.LICENSE
+++ b/src/licensedcode/data/licenses/ecl-2.0.LICENSE
@@ -6,7 +6,7 @@ category: Permissive
 owner: OSI - Open Source Initiative
 homepage_url: http://www.opensource.org/licenses/ecl2.php
 notes: |
-    Per SPDX.org, this license is OSI certifified. The Educational Community
+    Per SPDX.org, this license is OSI certified. The Educational Community
     License version 2.0 ("ECL") consists of the Apache 2.0 license, modified to
     change the scope of the patent grant in section 3 to be specific to the
     needs of the education communities using this license. The url included in

--- a/src/licensedcode/data/licenses/epl-1.0.LICENSE
+++ b/src/licensedcode/data/licenses/epl-1.0.LICENSE
@@ -6,7 +6,7 @@ category: Copyleft Limited
 owner: Eclipse Foundation
 homepage_url: http://www.eclipse.org/legal/epl-v10.html
 notes: |
-    Per SPDX.org, this license is OSI certifified EPL replaced the CPL on 28
+    Per SPDX.org, this license is OSI certified EPL replaced the CPL on 28
     June 2005.
 spdx_license_key: EPL-1.0
 osi_license_key: EPL-1.0

--- a/tests/licensedcode/data/license_db/license_dump/boost-1.0.LICENSE
+++ b/tests/licensedcode/data/license_db/license_dump/boost-1.0.LICENSE
@@ -7,7 +7,7 @@ owner: Boost
 homepage_url: http://www.boost.org/users/license.html
 notes: |
     Per SPDX.org, this version was released 17 August 2003 This license is OSI
-    certifified.
+    certified.
 spdx_license_key: BSL-1.0
 text_urls:
     - http://www.boost.org/LICENSE_1_0.txt

--- a/tests/licensedcode/data/license_db/license_dump/boost-1.0.html
+++ b/tests/licensedcode/data/license_db/license_dump/boost-1.0.html
@@ -109,7 +109,7 @@
         <dd>
           
             Per <a href="https://SPDX.org" rel="noopener" target="_blank">SPDX.org</a>, this version was released 17 August 2003 This license is OSI
-certifified.
+certified.
 
           
         </dd>

--- a/tests/licensedcode/data/license_db/license_dump/boost-1.0.json
+++ b/tests/licensedcode/data/license_db/license_dump/boost-1.0.json
@@ -5,7 +5,7 @@
   "category": "Permissive",
   "owner": "Boost",
   "homepage_url": "http://www.boost.org/users/license.html",
-  "notes": "Per SPDX.org, this version was released 17 August 2003 This license is OSI\ncertifified.\n",
+  "notes": "Per SPDX.org, this version was released 17 August 2003 This license is OSI\ncertified.\n",
   "spdx_license_key": "BSL-1.0",
   "text_urls": [
     "http://www.boost.org/LICENSE_1_0.txt"

--- a/tests/licensedcode/data/license_db/license_dump/boost-1.0.yml
+++ b/tests/licensedcode/data/license_db/license_dump/boost-1.0.yml
@@ -6,7 +6,7 @@ owner: Boost
 homepage_url: http://www.boost.org/users/license.html
 notes: |
   Per SPDX.org, this version was released 17 August 2003 This license is OSI
-  certifified.
+  certified.
 spdx_license_key: BSL-1.0
 text_urls:
   - http://www.boost.org/LICENSE_1_0.txt

--- a/tests/licensedcode/data/license_db/licenses/boost-1.0.LICENSE
+++ b/tests/licensedcode/data/license_db/licenses/boost-1.0.LICENSE
@@ -7,7 +7,7 @@ owner: Boost
 homepage_url: http://www.boost.org/users/license.html
 notes: |
     Per SPDX.org, this version was released 17 August 2003 This license is OSI
-    certifified.
+    certified.
 spdx_license_key: BSL-1.0
 text_urls:
     - http://www.boost.org/LICENSE_1_0.txt

--- a/tests/licensedcode/data/licenses_reference_reporting/scan-matched-text-with-reference.expected.json
+++ b/tests/licensedcode/data/licenses_reference_reporting/scan-matched-text-with-reference.expected.json
@@ -232,7 +232,7 @@
       "category": "Copyleft Limited",
       "owner": "Perl Foundation",
       "homepage_url": "http://www.perlfoundation.org/",
-      "notes": "Per SPDX.org, this version was released 2006 This license is OSI\ncertifified.\n",
+      "notes": "Per SPDX.org, this version was released 2006 This license is OSI\ncertified.\n",
       "is_builtin": true,
       "is_exception": false,
       "is_unknown": false,

--- a/tests/licensedcode/data/licenses_reference_reporting/scan-with-reference.expected.json
+++ b/tests/licensedcode/data/licenses_reference_reporting/scan-with-reference.expected.json
@@ -222,7 +222,7 @@
       "category": "Copyleft Limited",
       "owner": "Perl Foundation",
       "homepage_url": "http://www.perlfoundation.org/",
-      "notes": "Per SPDX.org, this version was released 2006 This license is OSI\ncertifified.\n",
+      "notes": "Per SPDX.org, this version was released 2006 This license is OSI\ncertified.\n",
       "is_builtin": true,
       "is_exception": false,
       "is_unknown": false,


### PR DESCRIPTION
Just a small fix of a typo. Done via:
```
grep -rl "certifified" . | xargs sed -i 's/certifified/certified/g'
```

This typo does [not seem to originate on spdx side](https://github.com/search?q=org%3Aspdx%20certifified&type=code).