### PR TITLE
fix: add support for Project and CentralTransitive in NuGet parser

### DIFF
--- a/src/packagedcode/nuget.py
+++ b/src/packagedcode/nuget.py
@@ -237,6 +237,10 @@ class NugetPackagesLockHandler(models.DatafileHandler):
                     is_direct = True
                 elif package_type == "Transitive":
                     is_direct = False
+                elif package_type == "CentralTransitive":
+                    is_direct = False
+                elif package_type == "Project":
+                    is_direct = True
                 else:
                     raise Exception(f"Unknown package type: {package_type} for package {package_name} in {location}")
                     

--- a/tests/packagedcode/data/nuget/packages.lock.with_project_and_central_transitive.json
+++ b/tests/packagedcode/data/nuget/packages.lock.with_project_and_central_transitive.json
@@ -1,0 +1,30 @@
+{
+    "version": 2,
+    "dependencies": {
+      "net8.0": {
+        "Example.Direct": {
+          "type": "Direct",
+          "requested": "[1.0.0, )",
+          "resolved": "1.0.0",
+          "contentHash": "abc123=="
+        },
+        "Example.Transitive": {
+          "type": "Transitive",
+          "resolved": "2.0.0",
+          "contentHash": "def456=="
+        },
+        "Example.CentralTransitive": {
+          "type": "CentralTransitive",
+          "requested": "[3.0.0, )",
+          "resolved": "3.0.0",
+          "contentHash": "ghi789=="
+        },
+        "example.project.reference": {
+          "type": "Project",
+          "dependencies": {
+            "Example.Direct": "[1.0.0, )"
+          }
+        }
+      }
+    }
+  }


### PR DESCRIPTION
## Summary

Adds support for `Project` and `CentralTransitive` dependency types in the NuGet `packages.lock.json` parser.

## Problem

NuGet lockfiles can contain dependency types beyond `Direct` and `Transitive`:
- `Project`: Local project references (e.g., `<ProjectReference>`)
- `CentralTransitive`: Transitive dependencies managed via Central Package Management

The parser raised an exception for these unknown types:
```
Unknown package type: Project
Unknown package type: CentralTransitive
```

This caused parsing to abort for valid NuGet lockfiles generated by projects using project references or Central Package Management.

## Changes

- `src/packagedcode/nuget.py`: Added handling for `Project` (is_direct=True) and `CentralTransitive` (is_direct=False) types
- Added test fixture with these dependency types

## Testing

Added `packages.lock.with_project_and_central_transitive.json` test fixture containing all four dependency types.

Fixes #5106
