### PR TITLE
Reproduce license cache inheritance failure #4709

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,6 +33,7 @@ The following organizations or individuals have contributed to ScanCode:
 - François Granade @farialima
 - Frank Viernau @fviernau
 - Gaurang Rao @Gaupeng
+- Hakan Dilek @hakandilek
 - Hanif Ali @hanif-ali
 - Horie Issei @is2ei
 - James Ward @jamesward

--- a/tests/scancode/test_pool.py
+++ b/tests/scancode/test_pool.py
@@ -1,0 +1,48 @@
+#
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# ScanCode is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/scancode-toolkit for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+import multiprocessing
+
+import pytest
+
+from commoncode.system import on_linux
+from licensedcode import cache
+from scancode.pool import get_pool
+
+
+PARENT_CACHE_SENTINEL = 'parent-warmed-license-cache'
+
+
+def _get_worker_license_cache_state():
+    """
+    Return the worker's license cache singleton state and multiprocessing start
+    method.
+    """
+    from licensedcode import cache
+
+    return cache._LICENSE_CACHE, multiprocessing.get_start_method()
+
+
+@pytest.mark.skipif(not on_linux, reason='Linux-only multiprocessing default')
+def test_license_cache_warmup_is_inherited_by_pool_workers(monkeypatch):
+    """
+    ScanCode warms the license cache before creating its process pool so forked
+    child processes inherit the loaded index instead of loading private copies.
+    """
+    monkeypatch.setattr(cache, '_LICENSE_CACHE', PARENT_CACHE_SENTINEL)
+
+    with get_pool(processes=1) as scan_pool:
+        worker_cache_state, worker_start_method = scan_pool.apply(
+            _get_worker_license_cache_state,
+        )
+
+    assert worker_cache_state == PARENT_CACHE_SENTINEL, (
+        'Pool worker did not inherit the parent-warmed license cache. '
+        f'Worker start method was {worker_start_method!r}.'
+    )


### PR DESCRIPTION
## Summary

Add a lightweight reproducer for the multiprocessing license-cache
inheritance failure reported in #4709, and a possible fix following a short
discussion.

Root cause: ScanCode warms the license cache in the parent process before
creating its worker pool. Linux Python 3.13 uses `fork`, so workers inherit
the warmed cache through copy-on-write. Python 3.14 uses `forkserver` by
default, so workers start without that state and load private copies of the
license index.

## Reproducer

The test substitutes a small sentinel for the real license cache and creates
a worker through the production `scancode.pool.get_pool()` function.

This exercises the same inheritance boundary without:

- Loading the approximately 1 GB license index
- Measuring unstable RSS values
- Requiring a large input scan
- Consuming significant memory or runtime

Expected behavior on the current code:

| Platform | Python | Start method | Result |
|----------|--------|--------------|--------|
| Linux | 3.13 | `fork` | Pass |
| Linux | 3.14 | `forkserver` | Fail |
| macOS/Windows | Any | `spawn` | Skipped |

The test is collected by the
[`core_tests / misc_and_scancode`](https://github.com/aboutcode-org/scancode-toolkit/blob/develop/azure-pipelines.yml#L14-L25)
job defined in `azure-pipelines.yml`, running on Ubuntu 24.04 with Python
3.14.

## Scope

This Draft PR initially contains only the reproducer and no production fix.

I would like maintainer feedback on the preferred fix direction before
adding one.

Tests do not currently pass on Linux Python 3.14. This failure is
intentional while the PR is a Draft and demonstrates the regression.

Reproduces #4709.

## Verification

```bash
venv/bin/pytest -vvs tests/scancode/test_pool.py
```
