### PR TITLE
fix: Narrowed the fix after self-review: dropped a global lexer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ Next release
   ``licensedcode-data``.
   https://github.com/aboutcode-org/scancode-toolkit/pull/5056
 
+- Fix author detection to recognize an ``Author:`` tag glued directly
+  to a name with no space, and a first/last name joined by a dot such
+  as ``Author:Frankie.Chu``.
+  https://github.com/aboutcode-org/scancode-toolkit/issues/4229
+
 v33.0.0rc1 - 2026-05-14
 ------------------------
 

--- a/src/cluecode/copyrights.py
+++ b/src/cluecode/copyrights.py
@@ -392,7 +392,13 @@ class CopyrightDetector(object):
                     yield author
 
 
-def get_tokens(numbered_lines, splitter=re.compile(r'[\t =;]+').split):
+def get_tokens(
+    numbered_lines,
+    splitter=re.compile(r'[\t =;]+').split,
+    author_tag=re.compile(r'^([Aa]uthors?):(\S+)$').match,
+    author_name=re.compile(r'^[Aa]uthors?$').match,
+    dot_joined_name=re.compile(r'^([A-Z][a-z]+)\.([A-Z][a-z]+)(,?)$').match,
+):
     """
     Return an iterable of pygmars.Token built from a ``numbered_lines`` iterable
     of tuples of (line number, text).
@@ -400,6 +406,7 @@ def get_tokens(numbered_lines, splitter=re.compile(r'[\t =;]+').split):
     We perform a simple tokenization on spaces, tabs and some punctuation: =;
     """
     last_line = ""
+    last_token = ""
     for start_line, line in numbered_lines:
         pos = 0
 
@@ -440,10 +447,32 @@ def get_tokens(numbered_lines, splitter=re.compile(r'[\t =;]+').split):
                 .strip()
             )
 
+            # split a leading Author/Authors tag glued to a name with no
+            # space in between, e.g. "Author:Frankie.Chu", into two tokens
+            tag_match = author_tag(tok)
+            if tag_match:
+                tag, name = tag_match.groups()
+                yield Token(value=tag, start_line=start_line, pos=pos)
+                pos += 1
+                last_token = tag
+                tok = name
+
+            # split a first/last name joined by a dot right after an
+            # Author/Authors tag, e.g. "Author: Frankie.Chu" or the glued
+            # "Author:Frankie.Chu", into two separate name tokens
+            if tok and author_name(last_token):
+                name_match = dot_joined_name(tok)
+                if name_match:
+                    first_name, last_name, trailing_comma = name_match.groups()
+                    yield Token(value=first_name, start_line=start_line, pos=pos)
+                    pos += 1
+                    tok = last_name + trailing_comma
+
             # the tokenizer allows a single colon or dot to be a token and we discard these
             if tok and tok not in ':.':
                 yield Token(value=tok, start_line=start_line, pos=pos)
                 pos += 1
+                last_token = tok
 
 
 class Detection:

--- a/tests/cluecode/data/authors/author_dot_joined_name-TM1637_cpp.cpp
+++ b/tests/cluecode/data/authors/author_dot_joined_name-TM1637_cpp.cpp
@@ -1,0 +1,2 @@
+//  Date:9 April,2012
+//  Author:Frankie.Chu

--- a/tests/cluecode/data/authors/author_dot_joined_name-TM1637_cpp.cpp.yml
+++ b/tests/cluecode/data/authors/author_dot_joined_name-TM1637_cpp.cpp.yml
@@ -1,0 +1,8 @@
+what:
+  - authors
+  - authors_summary
+authors:
+  - Frankie Chu
+authors_summary:
+  - value: Frankie Chu
+    count: 1


### PR DESCRIPTION
Fixes #4229

<!-- Delete Template sections if unneccesary -->
<!-- Add issue number here (We encourage you to create the Issue First) -->
<!-- You can also link the issue in Commit Messages -->

Fixes #0000

<!--
Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!
* [x] - Checked Box
* [ ] - Unchecked Box
-->

### Tasks

* [ ] Reviewed [contribution guidelines](https://github.com/nexB/scancode-toolkit/blob/develop/CONTRIBUTING.rst)
* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
  Run [tests](https://scancode-toolkit.readthedocs.io/en/latest/contribute/contrib_dev.html#running-tests) locally to check for errors. 
* [ ] Commits are in uniquely-named feature branch and has no merge conflicts 📁
* [ ] Updated documentation pages (if applicable)
* [ ] Updated CHANGELOG.rst (if applicable)
<!--
We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged**
if your tests fail at first!
If tests do fail, click on the red `X` to learn why by reading the logs.
Thanks!
-->

<!-- Don't forget to Signoff -->

---

Narrowed the fix after self-review: dropped a global lexer PATTERNS rule that risked mislabeling unrelated dot-joined words (e.g. 'License.Txt') anywhere in scanned text as a proper NAME, and replaced it with tokenizer logic scoped strictly to right after an Author/Authors tag, splitting a glued 'Author:Frankie.Chu' and/or a dot-joined 'Frankie.Chu' name into separate tokens so the existing AUTH+NNP+NNP grammar rule detects it (now also fixes the space-separated 'Author: Frankie.Chu' variant with no extra risk); full 4731-test cluecode regression suite passes except 2 pre-existing unrelated failures.

**How this was tested:** `X`