### PR TITLE
Add support for vcpkg portfile manifests

### DIFF
--- a/src/packagedcode/__init__.py
+++ b/src/packagedcode/__init__.py
@@ -82,6 +82,7 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
     conan.ConanDataHandler,
 
     vcpkg.VcpkgJsonHandler,
+    vcpkg.VcpkgPortfileHandler,
     vcpkg.VcpkgControlHandler,
 
     cran.CranDescriptionFileHandler,

--- a/src/packagedcode/__init__.py
+++ b/src/packagedcode/__init__.py
@@ -38,6 +38,7 @@ from packagedcode import readme
 from packagedcode import rpm
 from packagedcode import rubygems
 from packagedcode import swift
+from packagedcode import vcpkg
 from packagedcode import win_pe
 from packagedcode import windows
 
@@ -79,6 +80,9 @@ APPLICATION_PACKAGE_DATAFILE_HANDLERS = [
 
     conan.ConanFileHandler,
     conan.ConanDataHandler,
+
+    vcpkg.VcpkgJsonHandler,
+    vcpkg.VcpkgControlHandler,
 
     cran.CranDescriptionFileHandler,
 

--- a/src/packagedcode/vcpkg.py
+++ b/src/packagedcode/vcpkg.py
@@ -9,6 +9,8 @@
 import io
 import json
 import logging
+import os
+import re
 
 from debian_inspector import debcon
 from packageurl import PackageURL
@@ -173,6 +175,89 @@ class VcpkgJsonHandler(models.DatafileHandler):
                 return
 
         package_data = cls._parse(manifest_data, package_only)
+        if package_data:
+            yield package_data
+
+
+class VcpkgPortfileHandler(models.DatafileHandler):
+    datasource_id = "vcpkg_portfile"
+    path_patterns = (
+        "*/portfile.cmake",
+        "portfile.cmake",
+    )
+    default_package_type = "vcpkg"
+    default_primary_language = "C++"
+    description = "vcpkg portfile"
+    documentation_url = "https://learn.microsoft.com/en-us/vcpkg/maintainers/ports"
+
+    @classmethod
+    def _parse(cls, portfile_data, location=None, package_only=False):
+        if not isinstance(portfile_data, str):
+            return
+
+        name = None
+        if location:
+            name = os.path.basename(os.path.dirname(location)) or None
+
+        version = None
+        port_version = None
+        homepage_url = None
+        description = None
+
+        for line in portfile_data.splitlines():
+            raw_line = line.split("#", 1)[0].strip()
+            if not raw_line:
+                continue
+
+            match = re.match(r"^set\(\s*([A-Za-z0-9_]+)\s*(.+)\)$", raw_line)
+            if not match:
+                continue
+
+            key = match.group(1).upper()
+            value = match.group(2).strip()
+            if value.startswith('"') and value.endswith('"') and len(value) >= 2:
+                value = value[1:-1]
+            elif value.startswith("'") and value.endswith("'") and len(value) >= 2:
+                value = value[1:-1]
+
+            if key == "VERSION":
+                version = value
+            elif key == "PORT_VERSION":
+                port_version = value
+            elif key == "HOMEPAGE":
+                homepage_url = value
+            elif key == "DESCRIPTION":
+                description = value
+
+        if not name:
+            return
+
+        qualifiers = {}
+        if port_version not in (None, ""):
+            qualifiers["port_version"] = str(port_version)
+
+        package_data = dict(
+            datasource_id=cls.datasource_id,
+            type=cls.default_package_type,
+            name=name,
+            version=version,
+            qualifiers=qualifiers or None,
+            primary_language=cls.default_primary_language,
+            description=description,
+            homepage_url=homepage_url,
+        )
+        return models.PackageData.from_data(package_data, package_only)
+
+    @classmethod
+    def parse(cls, location, package_only=False):
+        with io.open(location, encoding="utf-8") as loc:
+            try:
+                portfile_data = loc.read()
+            except Exception as e:
+                logger.warning(f"Failed to parse portfile at {location}: {e}")
+                return
+
+        package_data = cls._parse(portfile_data, location=location, package_only=package_only)
         if package_data:
             yield package_data
 

--- a/src/packagedcode/vcpkg.py
+++ b/src/packagedcode/vcpkg.py
@@ -1,0 +1,268 @@
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# ScanCode is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/scancode-toolkit for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+import io
+import json
+import logging
+
+from debian_inspector import debcon
+from packageurl import PackageURL
+
+from packagedcode import models
+
+"""
+Handle vcpkg package manifests (vcpkg.json) and legacy CONTROL files.
+https://learn.microsoft.com/en-us/vcpkg/reference/vcpkg-json
+https://learn.microsoft.com/en-us/vcpkg/maintainers/ports
+"""
+
+logger = logging.getLogger(__name__)
+
+
+class VcpkgJsonHandler(models.DatafileHandler):
+    datasource_id = "vcpkg_json"
+    path_patterns = (
+        "*/vcpkg.json",
+        "vcpkg.json",
+    )
+    default_package_type = "vcpkg"
+    default_primary_language = "C++"
+    description = "vcpkg package manifest"
+    documentation_url = "https://learn.microsoft.com/en-us/vcpkg/reference/vcpkg-json"
+
+    @classmethod
+    def _parse(cls, manifest_data, package_only=False):
+        if not isinstance(manifest_data, dict):
+            return
+
+        name = manifest_data.get("name")
+        if not name:
+            return
+
+        version = (
+            manifest_data.get("version-string")
+            or manifest_data.get("version")
+            or manifest_data.get("version-date")
+            or manifest_data.get("version-semver")
+        )
+
+        port_version = manifest_data.get("port-version")
+        qualifiers = {}
+        if port_version is not None:
+            qualifiers["port_version"] = str(port_version)
+
+        description = manifest_data.get("description")
+        if isinstance(description, list):
+            description = "\n".join(description)
+
+        homepage_url = manifest_data.get("homepage")
+        documentation_url = manifest_data.get("documentation")
+
+        extracted_license_statement = manifest_data.get("license")
+
+        parties = []
+        maintainers = manifest_data.get("maintainers")
+        if maintainers:
+            if isinstance(maintainers, str):
+                maintainers = [maintainers]
+            if isinstance(maintainers, list):
+                for m in maintainers:
+                    if isinstance(m, str):
+                        parties.append(models.Party(name=m, role="maintainer"))
+                    elif isinstance(m, dict) and m.get("name"):
+                        parties.append(
+                            models.Party(
+                                name=m.get("name"),
+                                email=m.get("email"),
+                                url=m.get("homepage"),
+                                role="maintainer",
+                            )
+                        )
+
+        dependencies = []
+        deps = manifest_data.get("dependencies") or []
+        for dep in deps:
+            dep_name = None
+            req = None
+            if isinstance(dep, str):
+                dep_name = dep
+            elif isinstance(dep, dict):
+                dep_name = dep.get("name")
+                req = (
+                    dep.get("version>=")
+                    or dep.get("version")
+                    or dep.get("version-string")
+                )
+                if req and not str(req).startswith(">=") and dep.get("version>="):
+                    req = f">= {req}"
+
+            if dep_name:
+                dependencies.append(
+                    models.DependentPackage(
+                        purl=PackageURL(type="vcpkg", name=dep_name).to_string(),
+                        extracted_requirement=str(req) if req is not None else None,
+                        scope="dependencies",
+                        is_runtime=True,
+                        is_optional=False,
+                    )
+                )
+
+        features = manifest_data.get("features") or {}
+        if isinstance(features, dict):
+            for feature_name, feature_data in features.items():
+                if isinstance(feature_data, dict):
+                    feature_deps = feature_data.get("dependencies") or []
+                    for dep in feature_deps:
+                        dep_name = None
+                        req = None
+                        if isinstance(dep, str):
+                            dep_name = dep
+                        elif isinstance(dep, dict):
+                            dep_name = dep.get("name")
+                            req = dep.get("version>=") or dep.get("version")
+                            if req and not str(req).startswith(">=") and dep.get("version>="):
+                                req = f">= {req}"
+                        if dep_name:
+                            dependencies.append(
+                                models.DependentPackage(
+                                    purl=PackageURL(
+                                        type="vcpkg", name=dep_name
+                                    ).to_string(),
+                                    extracted_requirement=str(req) if req is not None else None,
+                                    scope=f"features:{feature_name}",
+                                    is_runtime=True,
+                                    is_optional=True,
+                                )
+                            )
+
+        extra_data = {}
+        if documentation_url:
+            extra_data["documentation"] = documentation_url
+        supports = manifest_data.get("supports")
+        if supports:
+            extra_data["supports"] = supports
+
+        package_data = dict(
+            datasource_id=cls.datasource_id,
+            type=cls.default_package_type,
+            name=name,
+            version=version,
+            qualifiers=qualifiers or None,
+            primary_language=cls.default_primary_language,
+            description=description,
+            homepage_url=homepage_url,
+            extracted_license_statement=extracted_license_statement,
+            parties=parties,
+            dependencies=dependencies,
+            extra_data=extra_data or None,
+        )
+        return models.PackageData.from_data(package_data, package_only)
+
+    @classmethod
+    def parse(cls, location, package_only=False):
+        with io.open(location, encoding="utf-8") as loc:
+            try:
+                manifest_data = json.load(loc)
+            except Exception as e:
+                logger.warning(f"Failed to parse vcpkg.json at {location}: {e}")
+                return
+
+        package_data = cls._parse(manifest_data, package_only)
+        if package_data:
+            yield package_data
+
+
+class VcpkgControlHandler(models.DatafileHandler):
+    datasource_id = "vcpkg_control"
+    path_patterns = (
+        "*/CONTROL",
+        "CONTROL",
+    )
+    default_package_type = "vcpkg"
+    default_primary_language = "C++"
+    description = "vcpkg legacy port CONTROL file"
+    documentation_url = "https://learn.microsoft.com/en-us/vcpkg/maintainers/ports"
+
+    @classmethod
+    def parse(cls, location, package_only=False):
+        try:
+            paragraphs = list(debcon.get_paragraphs_data_from_file(location))
+        except Exception as e:
+            logger.warning(f"Failed to parse CONTROL file at {location}: {e}")
+            return
+
+        if not paragraphs:
+            return
+
+        main_para = paragraphs[0]
+        name = main_para.get("source") or main_para.get("package")
+        if not name:
+            return
+
+        version = main_para.get("version")
+        port_version = main_para.get("port-version")
+        qualifiers = {}
+        if port_version is not None:
+            qualifiers["port_version"] = str(port_version)
+
+        description = main_para.get("description")
+        homepage_url = main_para.get("homepage")
+
+        dependencies = []
+        build_depends = main_para.get("build-depends")
+        if build_depends:
+            for dep_str in build_depends.split(","):
+                dep_str = dep_str.strip()
+                if not dep_str:
+                    continue
+                dep_name = dep_str.split()[0]
+                dependencies.append(
+                    models.DependentPackage(
+                        purl=PackageURL(type="vcpkg", name=dep_name).to_string(),
+                        extracted_requirement=None,
+                        scope="dependencies",
+                        is_runtime=True,
+                        is_optional=False,
+                    )
+                )
+
+        for feature_para in paragraphs[1:]:
+            feature_name = feature_para.get("feature")
+            if not feature_name:
+                continue
+            feature_deps = feature_para.get("build-depends")
+            if feature_deps:
+                for dep_str in feature_deps.split(","):
+                    dep_str = dep_str.strip()
+                    if not dep_str:
+                        continue
+                    dep_name = dep_str.split()[0]
+                    dependencies.append(
+                        models.DependentPackage(
+                            purl=PackageURL(type="vcpkg", name=dep_name).to_string(),
+                            extracted_requirement=None,
+                            scope=f"features:{feature_name}",
+                            is_runtime=True,
+                            is_optional=True,
+                        )
+                    )
+
+        package_data = dict(
+            datasource_id=cls.datasource_id,
+            type=cls.default_package_type,
+            name=name,
+            version=version,
+            qualifiers=qualifiers or None,
+            primary_language=cls.default_primary_language,
+            description=description,
+            homepage_url=homepage_url,
+            dependencies=dependencies,
+        )
+        package_obj = models.PackageData.from_data(package_data, package_only)
+        if package_obj:
+            yield package_obj

--- a/tests/packagedcode/data/vcpkg/CONTROL
+++ b/tests/packagedcode/data/vcpkg/CONTROL
@@ -1,0 +1,10 @@
+Source: zlib
+Version: 1.2.11
+Port-Version: 2
+Description: A Massively Spiffy Yet Delicately Unobtrusive Compression Library
+Homepage: https://zlib.net/
+Build-Depends: openssl, curl
+
+Feature: minizip
+Description: Minizip contrib library
+Build-Depends: bzip2

--- a/tests/packagedcode/data/vcpkg/CONTROL-expected.json
+++ b/tests/packagedcode/data/vcpkg/CONTROL-expected.json
@@ -1,0 +1,82 @@
+[
+  {
+    "type": "vcpkg",
+    "namespace": null,
+    "name": "zlib",
+    "version": "1.2.11",
+    "qualifiers": {
+      "port_version": "2"
+    },
+    "subpath": null,
+    "primary_language": "C++",
+    "description": "A Massively Spiffy Yet Delicately Unobtrusive Compression Library",
+    "release_date": null,
+    "parties": [],
+    "keywords": [],
+    "homepage_url": "https://zlib.net/",
+    "download_url": null,
+    "size": null,
+    "sha1": null,
+    "md5": null,
+    "sha256": null,
+    "sha512": null,
+    "bug_tracking_url": null,
+    "code_view_url": null,
+    "vcs_url": null,
+    "copyright": null,
+    "holder": null,
+    "declared_license_expression": null,
+    "declared_license_expression_spdx": null,
+    "license_detections": [],
+    "other_license_expression": null,
+    "other_license_expression_spdx": null,
+    "other_license_detections": [],
+    "extracted_license_statement": null,
+    "notice_text": null,
+    "source_packages": [],
+    "file_references": [],
+    "is_private": false,
+    "is_virtual": false,
+    "extra_data": {},
+    "dependencies": [
+      {
+        "purl": "pkg:vcpkg/openssl",
+        "extracted_requirement": null,
+        "scope": "dependencies",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": false,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {}
+      },
+      {
+        "purl": "pkg:vcpkg/curl",
+        "extracted_requirement": null,
+        "scope": "dependencies",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": false,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {}
+      },
+      {
+        "purl": "pkg:vcpkg/bzip2",
+        "extracted_requirement": null,
+        "scope": "features:minizip",
+        "is_runtime": true,
+        "is_optional": true,
+        "is_pinned": false,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {}
+      }
+    ],
+    "repository_homepage_url": null,
+    "repository_download_url": null,
+    "api_data_url": null,
+    "datasource_id": "vcpkg_control",
+    "purl": "pkg:vcpkg/zlib@1.2.11?port_version=2"
+  }
+]

--- a/tests/packagedcode/data/vcpkg/ports/hello/portfile.cmake
+++ b/tests/packagedcode/data/vcpkg/ports/hello/portfile.cmake
@@ -1,0 +1,5 @@
+# Sample vcpkg portfile for regression testing
+set(VERSION "1.2.3")
+set(PORT_VERSION 2)
+set(HOMEPAGE "https://example.com/hello")
+set(DESCRIPTION "A sample vcpkg port")

--- a/tests/packagedcode/data/vcpkg/ports/hello/vcpkg.json
+++ b/tests/packagedcode/data/vcpkg/ports/hello/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "hello",
+  "version-string": "1.2.3",
+  "port-version": 2,
+  "description": "A sample vcpkg port",
+  "homepage": "https://example.com/hello",
+  "license": "MIT"
+}

--- a/tests/packagedcode/data/vcpkg/vcpkg-end-to-end-expected.json
+++ b/tests/packagedcode/data/vcpkg/vcpkg-end-to-end-expected.json
@@ -1,12 +1,441 @@
 {
-  "packages": [],
-  "dependencies": [],
+  "packages": [
+    {
+      "type": "vcpkg",
+      "namespace": null,
+      "name": "zlib",
+      "version": "1.2.11",
+      "qualifiers": {
+        "port_version": "2"
+      },
+      "subpath": null,
+      "primary_language": "C++",
+      "description": "A Massively Spiffy Yet Delicately Unobtrusive Compression Library",
+      "release_date": null,
+      "parties": [],
+      "keywords": [],
+      "homepage_url": "https://zlib.net/",
+      "download_url": null,
+      "size": null,
+      "sha1": null,
+      "md5": null,
+      "sha256": null,
+      "sha512": null,
+      "bug_tracking_url": null,
+      "code_view_url": null,
+      "vcs_url": null,
+      "copyright": null,
+      "holder": null,
+      "declared_license_expression": null,
+      "declared_license_expression_spdx": null,
+      "license_detections": [],
+      "other_license_expression": null,
+      "other_license_expression_spdx": null,
+      "other_license_detections": [],
+      "extracted_license_statement": null,
+      "notice_text": null,
+      "source_packages": [],
+      "is_private": false,
+      "is_virtual": false,
+      "extra_data": {},
+      "repository_homepage_url": null,
+      "repository_download_url": null,
+      "api_data_url": null,
+      "package_uid": "pkg:vcpkg/zlib@1.2.11?port_version=2&uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_paths": [
+        "CONTROL"
+      ],
+      "datasource_ids": [
+        "vcpkg_control"
+      ],
+      "purl": "pkg:vcpkg/zlib@1.2.11?port_version=2"
+    },
+    {
+      "type": "vcpkg",
+      "namespace": null,
+      "name": "fmt",
+      "version": "8.1.1",
+      "qualifiers": {
+        "port_version": "1"
+      },
+      "subpath": null,
+      "primary_language": "C++",
+      "description": "Formatting library for C++",
+      "release_date": null,
+      "parties": [
+        {
+          "type": null,
+          "role": "maintainer",
+          "name": "fmt maintainers <fmt@example.com>",
+          "email": null,
+          "url": null
+        }
+      ],
+      "keywords": [],
+      "homepage_url": "https://github.com/fmtlib/fmt",
+      "download_url": null,
+      "size": null,
+      "sha1": null,
+      "md5": null,
+      "sha256": null,
+      "sha512": null,
+      "bug_tracking_url": null,
+      "code_view_url": null,
+      "vcs_url": null,
+      "copyright": null,
+      "holder": null,
+      "declared_license_expression": "mit",
+      "declared_license_expression_spdx": "MIT",
+      "license_detections": [
+        {
+          "license_expression": "mit",
+          "license_expression_spdx": "MIT",
+          "matches": [
+            {
+              "license_expression": "mit",
+              "license_expression_spdx": "MIT",
+              "from_file": "vcpkg/vcpkg.json",
+              "start_line": 1,
+              "end_line": 1,
+              "matcher": "1-spdx-id",
+              "score": 100.0,
+              "matched_length": 1,
+              "match_coverage": 100.0,
+              "rule_relevance": 100,
+              "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
+              "rule_url": null,
+              "matched_text": "MIT"
+            }
+          ],
+          "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf"
+        }
+      ],
+      "other_license_expression": null,
+      "other_license_expression_spdx": null,
+      "other_license_detections": [],
+      "extracted_license_statement": "MIT",
+      "notice_text": null,
+      "source_packages": [],
+      "is_private": false,
+      "is_virtual": false,
+      "extra_data": {},
+      "repository_homepage_url": null,
+      "repository_download_url": null,
+      "api_data_url": null,
+      "package_uid": "pkg:vcpkg/fmt@8.1.1?port_version=1&uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_paths": [
+        "vcpkg.json"
+      ],
+      "datasource_ids": [
+        "vcpkg_json"
+      ],
+      "purl": "pkg:vcpkg/fmt@8.1.1?port_version=1"
+    },
+    {
+      "type": "vcpkg",
+      "namespace": null,
+      "name": "hello",
+      "version": "1.2.3",
+      "qualifiers": {
+        "port_version": "2"
+      },
+      "subpath": null,
+      "primary_language": "C++",
+      "description": "A sample vcpkg port",
+      "release_date": null,
+      "parties": [],
+      "keywords": [],
+      "homepage_url": "https://example.com/hello",
+      "download_url": null,
+      "size": null,
+      "sha1": null,
+      "md5": null,
+      "sha256": null,
+      "sha512": null,
+      "bug_tracking_url": null,
+      "code_view_url": null,
+      "vcs_url": null,
+      "copyright": null,
+      "holder": null,
+      "declared_license_expression": null,
+      "declared_license_expression_spdx": null,
+      "license_detections": [],
+      "other_license_expression": null,
+      "other_license_expression_spdx": null,
+      "other_license_detections": [],
+      "extracted_license_statement": null,
+      "notice_text": null,
+      "source_packages": [],
+      "is_private": false,
+      "is_virtual": false,
+      "extra_data": {},
+      "repository_homepage_url": null,
+      "repository_download_url": null,
+      "api_data_url": null,
+      "package_uid": "pkg:vcpkg/hello@1.2.3?port_version=2&uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_paths": [
+        "ports/hello/portfile.cmake"
+      ],
+      "datasource_ids": [
+        "vcpkg_portfile"
+      ],
+      "purl": "pkg:vcpkg/hello@1.2.3?port_version=2"
+    },
+    {
+      "type": "vcpkg",
+      "namespace": null,
+      "name": "hello",
+      "version": "1.2.3",
+      "qualifiers": {
+        "port_version": "2"
+      },
+      "subpath": null,
+      "primary_language": "C++",
+      "description": "A sample vcpkg port",
+      "release_date": null,
+      "parties": [],
+      "keywords": [],
+      "homepage_url": "https://example.com/hello",
+      "download_url": null,
+      "size": null,
+      "sha1": null,
+      "md5": null,
+      "sha256": null,
+      "sha512": null,
+      "bug_tracking_url": null,
+      "code_view_url": null,
+      "vcs_url": null,
+      "copyright": null,
+      "holder": null,
+      "declared_license_expression": "mit",
+      "declared_license_expression_spdx": "MIT",
+      "license_detections": [
+        {
+          "license_expression": "mit",
+          "license_expression_spdx": "MIT",
+          "matches": [
+            {
+              "license_expression": "mit",
+              "license_expression_spdx": "MIT",
+              "from_file": "vcpkg/ports/hello/vcpkg.json",
+              "start_line": 1,
+              "end_line": 1,
+              "matcher": "1-spdx-id",
+              "score": 100.0,
+              "matched_length": 1,
+              "match_coverage": 100.0,
+              "rule_relevance": 100,
+              "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
+              "rule_url": null,
+              "matched_text": "MIT"
+            }
+          ],
+          "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf"
+        }
+      ],
+      "other_license_expression": null,
+      "other_license_expression_spdx": null,
+      "other_license_detections": [],
+      "extracted_license_statement": "MIT",
+      "notice_text": null,
+      "source_packages": [],
+      "is_private": false,
+      "is_virtual": false,
+      "extra_data": {},
+      "repository_homepage_url": null,
+      "repository_download_url": null,
+      "api_data_url": null,
+      "package_uid": "pkg:vcpkg/hello@1.2.3?port_version=2&uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_paths": [
+        "ports/hello/vcpkg.json"
+      ],
+      "datasource_ids": [
+        "vcpkg_json"
+      ],
+      "purl": "pkg:vcpkg/hello@1.2.3?port_version=2"
+    }
+  ],
+  "dependencies": [
+    {
+      "purl": "pkg:vcpkg/openssl",
+      "extracted_requirement": null,
+      "scope": "dependencies",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_pinned": false,
+      "is_direct": true,
+      "resolved_package": {},
+      "extra_data": {},
+      "dependency_uid": "pkg:vcpkg/openssl?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:vcpkg/zlib@1.2.11?port_version=2&uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_path": "CONTROL",
+      "datasource_id": "vcpkg_control"
+    },
+    {
+      "purl": "pkg:vcpkg/curl",
+      "extracted_requirement": null,
+      "scope": "dependencies",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_pinned": false,
+      "is_direct": true,
+      "resolved_package": {},
+      "extra_data": {},
+      "dependency_uid": "pkg:vcpkg/curl?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:vcpkg/zlib@1.2.11?port_version=2&uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_path": "CONTROL",
+      "datasource_id": "vcpkg_control"
+    },
+    {
+      "purl": "pkg:vcpkg/bzip2",
+      "extracted_requirement": null,
+      "scope": "features:minizip",
+      "is_runtime": true,
+      "is_optional": true,
+      "is_pinned": false,
+      "is_direct": true,
+      "resolved_package": {},
+      "extra_data": {},
+      "dependency_uid": "pkg:vcpkg/bzip2?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:vcpkg/zlib@1.2.11?port_version=2&uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_path": "CONTROL",
+      "datasource_id": "vcpkg_control"
+    },
+    {
+      "purl": "pkg:vcpkg/zlib",
+      "extracted_requirement": null,
+      "scope": "dependencies",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_pinned": false,
+      "is_direct": true,
+      "resolved_package": {},
+      "extra_data": {},
+      "dependency_uid": "pkg:vcpkg/zlib?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:vcpkg/fmt@8.1.1?port_version=1&uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_path": "vcpkg.json",
+      "datasource_id": "vcpkg_json"
+    },
+    {
+      "purl": "pkg:vcpkg/boost-system",
+      "extracted_requirement": ">= 1.75.0",
+      "scope": "dependencies",
+      "is_runtime": true,
+      "is_optional": false,
+      "is_pinned": false,
+      "is_direct": true,
+      "resolved_package": {},
+      "extra_data": {},
+      "dependency_uid": "pkg:vcpkg/boost-system?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:vcpkg/fmt@8.1.1?port_version=1&uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_path": "vcpkg.json",
+      "datasource_id": "vcpkg_json"
+    },
+    {
+      "purl": "pkg:vcpkg/boost-core",
+      "extracted_requirement": null,
+      "scope": "features:header-only",
+      "is_runtime": true,
+      "is_optional": true,
+      "is_pinned": false,
+      "is_direct": true,
+      "resolved_package": {},
+      "extra_data": {},
+      "dependency_uid": "pkg:vcpkg/boost-core?uuid=fixed-uid-done-for-testing-5642512d1758",
+      "for_package_uid": "pkg:vcpkg/fmt@8.1.1?port_version=1&uuid=fixed-uid-done-for-testing-5642512d1758",
+      "datafile_path": "vcpkg.json",
+      "datasource_id": "vcpkg_json"
+    }
+  ],
   "files": [
     {
       "path": "CONTROL",
       "type": "file",
-      "package_data": [],
-      "for_packages": [],
+      "package_data": [
+        {
+          "type": "vcpkg",
+          "namespace": null,
+          "name": "zlib",
+          "version": "1.2.11",
+          "qualifiers": {
+            "port_version": "2"
+          },
+          "subpath": null,
+          "primary_language": "C++",
+          "description": "A Massively Spiffy Yet Delicately Unobtrusive Compression Library",
+          "release_date": null,
+          "parties": [],
+          "keywords": [],
+          "homepage_url": "https://zlib.net/",
+          "download_url": null,
+          "size": null,
+          "sha1": null,
+          "md5": null,
+          "sha256": null,
+          "sha512": null,
+          "bug_tracking_url": null,
+          "code_view_url": null,
+          "vcs_url": null,
+          "copyright": null,
+          "holder": null,
+          "declared_license_expression": null,
+          "declared_license_expression_spdx": null,
+          "license_detections": [],
+          "other_license_expression": null,
+          "other_license_expression_spdx": null,
+          "other_license_detections": [],
+          "extracted_license_statement": null,
+          "notice_text": null,
+          "source_packages": [],
+          "file_references": [],
+          "is_private": false,
+          "is_virtual": false,
+          "extra_data": {},
+          "dependencies": [
+            {
+              "purl": "pkg:vcpkg/openssl",
+              "extracted_requirement": null,
+              "scope": "dependencies",
+              "is_runtime": true,
+              "is_optional": false,
+              "is_pinned": false,
+              "is_direct": true,
+              "resolved_package": {},
+              "extra_data": {}
+            },
+            {
+              "purl": "pkg:vcpkg/curl",
+              "extracted_requirement": null,
+              "scope": "dependencies",
+              "is_runtime": true,
+              "is_optional": false,
+              "is_pinned": false,
+              "is_direct": true,
+              "resolved_package": {},
+              "extra_data": {}
+            },
+            {
+              "purl": "pkg:vcpkg/bzip2",
+              "extracted_requirement": null,
+              "scope": "features:minizip",
+              "is_runtime": true,
+              "is_optional": true,
+              "is_pinned": false,
+              "is_direct": true,
+              "resolved_package": {},
+              "extra_data": {}
+            }
+          ],
+          "repository_homepage_url": null,
+          "repository_download_url": null,
+          "api_data_url": null,
+          "datasource_id": "vcpkg_control",
+          "purl": "pkg:vcpkg/zlib@1.2.11?port_version=2"
+        }
+      ],
+      "for_packages": [
+        "pkg:vcpkg/zlib@1.2.11?port_version=2&uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
       "scan_errors": []
     },
     {
@@ -14,6 +443,155 @@
       "type": "file",
       "package_data": [],
       "for_packages": [],
+      "scan_errors": []
+    },
+    {
+      "path": "ports",
+      "type": "directory",
+      "package_data": [],
+      "for_packages": [],
+      "scan_errors": []
+    },
+    {
+      "path": "ports/hello",
+      "type": "directory",
+      "package_data": [],
+      "for_packages": [],
+      "scan_errors": []
+    },
+    {
+      "path": "ports/hello/portfile.cmake",
+      "type": "file",
+      "package_data": [
+        {
+          "type": "vcpkg",
+          "namespace": null,
+          "name": "hello",
+          "version": "1.2.3",
+          "qualifiers": {
+            "port_version": "2"
+          },
+          "subpath": null,
+          "primary_language": "C++",
+          "description": "A sample vcpkg port",
+          "release_date": null,
+          "parties": [],
+          "keywords": [],
+          "homepage_url": "https://example.com/hello",
+          "download_url": null,
+          "size": null,
+          "sha1": null,
+          "md5": null,
+          "sha256": null,
+          "sha512": null,
+          "bug_tracking_url": null,
+          "code_view_url": null,
+          "vcs_url": null,
+          "copyright": null,
+          "holder": null,
+          "declared_license_expression": null,
+          "declared_license_expression_spdx": null,
+          "license_detections": [],
+          "other_license_expression": null,
+          "other_license_expression_spdx": null,
+          "other_license_detections": [],
+          "extracted_license_statement": null,
+          "notice_text": null,
+          "source_packages": [],
+          "file_references": [],
+          "is_private": false,
+          "is_virtual": false,
+          "extra_data": {},
+          "dependencies": [],
+          "repository_homepage_url": null,
+          "repository_download_url": null,
+          "api_data_url": null,
+          "datasource_id": "vcpkg_portfile",
+          "purl": "pkg:vcpkg/hello@1.2.3?port_version=2"
+        }
+      ],
+      "for_packages": [
+        "pkg:vcpkg/hello@1.2.3?port_version=2&uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
+      "scan_errors": []
+    },
+    {
+      "path": "ports/hello/vcpkg.json",
+      "type": "file",
+      "package_data": [
+        {
+          "type": "vcpkg",
+          "namespace": null,
+          "name": "hello",
+          "version": "1.2.3",
+          "qualifiers": {
+            "port_version": "2"
+          },
+          "subpath": null,
+          "primary_language": "C++",
+          "description": "A sample vcpkg port",
+          "release_date": null,
+          "parties": [],
+          "keywords": [],
+          "homepage_url": "https://example.com/hello",
+          "download_url": null,
+          "size": null,
+          "sha1": null,
+          "md5": null,
+          "sha256": null,
+          "sha512": null,
+          "bug_tracking_url": null,
+          "code_view_url": null,
+          "vcs_url": null,
+          "copyright": null,
+          "holder": null,
+          "declared_license_expression": "mit",
+          "declared_license_expression_spdx": "MIT",
+          "license_detections": [
+            {
+              "license_expression": "mit",
+              "license_expression_spdx": "MIT",
+              "matches": [
+                {
+                  "license_expression": "mit",
+                  "license_expression_spdx": "MIT",
+                  "from_file": "vcpkg/ports/hello/vcpkg.json",
+                  "start_line": 1,
+                  "end_line": 1,
+                  "matcher": "1-spdx-id",
+                  "score": 100.0,
+                  "matched_length": 1,
+                  "match_coverage": 100.0,
+                  "rule_relevance": 100,
+                  "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
+                  "rule_url": null,
+                  "matched_text": "MIT"
+                }
+              ],
+              "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf"
+            }
+          ],
+          "other_license_expression": null,
+          "other_license_expression_spdx": null,
+          "other_license_detections": [],
+          "extracted_license_statement": "MIT",
+          "notice_text": null,
+          "source_packages": [],
+          "file_references": [],
+          "is_private": false,
+          "is_virtual": false,
+          "extra_data": null,
+          "dependencies": [],
+          "repository_homepage_url": null,
+          "repository_download_url": null,
+          "api_data_url": null,
+          "datasource_id": "vcpkg_json",
+          "purl": "pkg:vcpkg/hello@1.2.3?port_version=2"
+        }
+      ],
+      "for_packages": [
+        "pkg:vcpkg/hello@1.2.3?port_version=2&uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
       "scan_errors": []
     },
     {
@@ -26,8 +604,122 @@
     {
       "path": "vcpkg.json",
       "type": "file",
-      "package_data": [],
-      "for_packages": [],
+      "package_data": [
+        {
+          "type": "vcpkg",
+          "namespace": null,
+          "name": "fmt",
+          "version": "8.1.1",
+          "qualifiers": {
+            "port_version": "1"
+          },
+          "subpath": null,
+          "primary_language": "C++",
+          "description": "Formatting library for C++",
+          "release_date": null,
+          "parties": [
+            {
+              "type": null,
+              "role": "maintainer",
+              "name": "fmt maintainers <fmt@example.com>",
+              "email": null,
+              "url": null
+            }
+          ],
+          "keywords": [],
+          "homepage_url": "https://github.com/fmtlib/fmt",
+          "download_url": null,
+          "size": null,
+          "sha1": null,
+          "md5": null,
+          "sha256": null,
+          "sha512": null,
+          "bug_tracking_url": null,
+          "code_view_url": null,
+          "vcs_url": null,
+          "copyright": null,
+          "holder": null,
+          "declared_license_expression": "mit",
+          "declared_license_expression_spdx": "MIT",
+          "license_detections": [
+            {
+              "license_expression": "mit",
+              "license_expression_spdx": "MIT",
+              "matches": [
+                {
+                  "license_expression": "mit",
+                  "license_expression_spdx": "MIT",
+                  "from_file": "vcpkg/vcpkg.json",
+                  "start_line": 1,
+                  "end_line": 1,
+                  "matcher": "1-spdx-id",
+                  "score": 100.0,
+                  "matched_length": 1,
+                  "match_coverage": 100.0,
+                  "rule_relevance": 100,
+                  "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
+                  "rule_url": null,
+                  "matched_text": "MIT"
+                }
+              ],
+              "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf"
+            }
+          ],
+          "other_license_expression": null,
+          "other_license_expression_spdx": null,
+          "other_license_detections": [],
+          "extracted_license_statement": "MIT",
+          "notice_text": null,
+          "source_packages": [],
+          "file_references": [],
+          "is_private": false,
+          "is_virtual": false,
+          "extra_data": null,
+          "dependencies": [
+            {
+              "purl": "pkg:vcpkg/zlib",
+              "extracted_requirement": null,
+              "scope": "dependencies",
+              "is_runtime": true,
+              "is_optional": false,
+              "is_pinned": false,
+              "is_direct": true,
+              "resolved_package": {},
+              "extra_data": {}
+            },
+            {
+              "purl": "pkg:vcpkg/boost-system",
+              "extracted_requirement": ">= 1.75.0",
+              "scope": "dependencies",
+              "is_runtime": true,
+              "is_optional": false,
+              "is_pinned": false,
+              "is_direct": true,
+              "resolved_package": {},
+              "extra_data": {}
+            },
+            {
+              "purl": "pkg:vcpkg/boost-core",
+              "extracted_requirement": null,
+              "scope": "features:header-only",
+              "is_runtime": true,
+              "is_optional": true,
+              "is_pinned": false,
+              "is_direct": true,
+              "resolved_package": {},
+              "extra_data": {}
+            }
+          ],
+          "repository_homepage_url": null,
+          "repository_download_url": null,
+          "api_data_url": null,
+          "datasource_id": "vcpkg_json",
+          "purl": "pkg:vcpkg/fmt@8.1.1?port_version=1"
+        }
+      ],
+      "for_packages": [
+        "pkg:vcpkg/fmt@8.1.1?port_version=1&uuid=fixed-uid-done-for-testing-5642512d1758"
+      ],
       "scan_errors": []
     },
     {

--- a/tests/packagedcode/data/vcpkg/vcpkg-end-to-end-expected.json
+++ b/tests/packagedcode/data/vcpkg/vcpkg-end-to-end-expected.json
@@ -1,0 +1,41 @@
+{
+  "packages": [],
+  "dependencies": [],
+  "files": [
+    {
+      "path": "CONTROL",
+      "type": "file",
+      "package_data": [],
+      "for_packages": [],
+      "scan_errors": []
+    },
+    {
+      "path": "CONTROL-expected.json",
+      "type": "file",
+      "package_data": [],
+      "for_packages": [],
+      "scan_errors": []
+    },
+    {
+      "path": "vcpkg-end-to-end-expected.json",
+      "type": "file",
+      "package_data": [],
+      "for_packages": [],
+      "scan_errors": []
+    },
+    {
+      "path": "vcpkg.json",
+      "type": "file",
+      "package_data": [],
+      "for_packages": [],
+      "scan_errors": []
+    },
+    {
+      "path": "vcpkg.json-expected.json",
+      "type": "file",
+      "package_data": [],
+      "for_packages": [],
+      "scan_errors": []
+    }
+  ]
+}

--- a/tests/packagedcode/data/vcpkg/vcpkg.json
+++ b/tests/packagedcode/data/vcpkg/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "fmt",
+  "version-string": "8.1.1",
+  "port-version": 1,
+  "description": "Formatting library for C++",
+  "homepage": "https://github.com/fmtlib/fmt",
+  "license": "MIT",
+  "maintainers": [
+    "fmt maintainers <fmt@example.com>"
+  ],
+  "dependencies": [
+    "zlib",
+    {
+      "name": "boost-system",
+      "version>=": "1.75.0"
+    }
+  ],
+  "features": {
+    "header-only": {
+      "description": "Header-only version of fmt",
+      "dependencies": [
+        "boost-core"
+      ]
+    }
+  }
+}

--- a/tests/packagedcode/data/vcpkg/vcpkg.json-expected.json
+++ b/tests/packagedcode/data/vcpkg/vcpkg.json-expected.json
@@ -1,0 +1,113 @@
+[
+  {
+    "type": "vcpkg",
+    "namespace": null,
+    "name": "fmt",
+    "version": "8.1.1",
+    "qualifiers": {
+      "port_version": "1"
+    },
+    "subpath": null,
+    "primary_language": "C++",
+    "description": "Formatting library for C++",
+    "release_date": null,
+    "parties": [
+      {
+        "type": null,
+        "role": "maintainer",
+        "name": "fmt maintainers <fmt@example.com>",
+        "email": null,
+        "url": null
+      }
+    ],
+    "keywords": [],
+    "homepage_url": "https://github.com/fmtlib/fmt",
+    "download_url": null,
+    "size": null,
+    "sha1": null,
+    "md5": null,
+    "sha256": null,
+    "sha512": null,
+    "bug_tracking_url": null,
+    "code_view_url": null,
+    "vcs_url": null,
+    "copyright": null,
+    "holder": null,
+    "declared_license_expression": "mit",
+    "declared_license_expression_spdx": "MIT",
+    "license_detections": [
+      {
+        "license_expression": "mit",
+        "license_expression_spdx": "MIT",
+        "matches": [
+          {
+            "license_expression": "mit",
+            "license_expression_spdx": "MIT",
+            "from_file": null,
+            "start_line": 1,
+            "end_line": 1,
+            "matcher": "1-spdx-id",
+            "score": 100.0,
+            "matched_length": 1,
+            "match_coverage": 100.0,
+            "rule_relevance": 100,
+            "rule_identifier": "spdx-license-identifier-mit-5da48780aba670b0860c46d899ed42a0f243ff06",
+            "rule_url": null,
+            "matched_text": "MIT"
+          }
+        ],
+        "identifier": "mit-a822f434-d61f-f2b1-c792-8b8cb9e7b9bf"
+      }
+    ],
+    "other_license_expression": null,
+    "other_license_expression_spdx": null,
+    "other_license_detections": [],
+    "extracted_license_statement": "MIT",
+    "notice_text": null,
+    "source_packages": [],
+    "file_references": [],
+    "is_private": false,
+    "is_virtual": false,
+    "extra_data": null,
+    "dependencies": [
+      {
+        "purl": "pkg:vcpkg/zlib",
+        "extracted_requirement": null,
+        "scope": "dependencies",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": false,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {}
+      },
+      {
+        "purl": "pkg:vcpkg/boost-system",
+        "extracted_requirement": ">= 1.75.0",
+        "scope": "dependencies",
+        "is_runtime": true,
+        "is_optional": false,
+        "is_pinned": false,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {}
+      },
+      {
+        "purl": "pkg:vcpkg/boost-core",
+        "extracted_requirement": null,
+        "scope": "features:header-only",
+        "is_runtime": true,
+        "is_optional": true,
+        "is_pinned": false,
+        "is_direct": true,
+        "resolved_package": {},
+        "extra_data": {}
+      }
+    ],
+    "repository_homepage_url": null,
+    "repository_download_url": null,
+    "api_data_url": null,
+    "datasource_id": "vcpkg_json",
+    "purl": "pkg:vcpkg/fmt@8.1.1?port_version=1"
+  }
+]

--- a/tests/packagedcode/test_vcpkg.py
+++ b/tests/packagedcode/test_vcpkg.py
@@ -34,6 +34,11 @@ class TestVcpkg(PackageTester):
         packages = vcpkg.VcpkgControlHandler.parse(test_file)
         self.check_packages_data(packages, expected_loc, regen=REGEN_TEST_FIXTURES)
 
+    def test_parse_vcpkg_portfile(self):
+        test_file = self.get_test_loc("vcpkg/ports/hello/portfile.cmake")
+        packages = vcpkg.VcpkgPortfileHandler.parse(test_file)
+        self.assertEqual(len(list(packages)), 1)
+
     def test_package_scan_vcpkg_end_to_end(self):
         test_dir = self.get_test_loc("vcpkg")
         result_file = self.get_temp_file("json")

--- a/tests/packagedcode/test_vcpkg.py
+++ b/tests/packagedcode/test_vcpkg.py
@@ -1,0 +1,57 @@
+# Copyright (c) nexB Inc. and others. All rights reserved.
+# ScanCode is a trademark of nexB Inc.
+# SPDX-License-Identifier: Apache-2.0
+# See http://www.apache.org/licenses/LICENSE-2.0 for the license text.
+# See https://github.com/nexB/scancode-toolkit for support or download.
+# See https://aboutcode.org for more information about nexB OSS projects.
+#
+
+import os.path
+
+from packages_test_utils import PackageTester
+from packagedcode import vcpkg
+from scancode.cli_test_utils import check_json_scan
+from scancode.cli_test_utils import run_scan_click
+from scancode_config import REGEN_TEST_FIXTURES
+
+
+class TestVcpkg(PackageTester):
+    test_data_dir = os.path.join(os.path.dirname(__file__), "data")
+
+    def test_parse_vcpkg_json(self):
+        test_file = self.get_test_loc("vcpkg/vcpkg.json")
+        expected_loc = self.get_test_loc(
+            "vcpkg/vcpkg.json-expected.json", must_exist=not REGEN_TEST_FIXTURES
+        )
+        packages = vcpkg.VcpkgJsonHandler.parse(test_file)
+        self.check_packages_data(packages, expected_loc, regen=REGEN_TEST_FIXTURES)
+
+    def test_parse_vcpkg_control(self):
+        test_file = self.get_test_loc("vcpkg/CONTROL")
+        expected_loc = self.get_test_loc(
+            "vcpkg/CONTROL-expected.json", must_exist=not REGEN_TEST_FIXTURES
+        )
+        packages = vcpkg.VcpkgControlHandler.parse(test_file)
+        self.check_packages_data(packages, expected_loc, regen=REGEN_TEST_FIXTURES)
+
+    def test_package_scan_vcpkg_end_to_end(self):
+        test_dir = self.get_test_loc("vcpkg")
+        result_file = self.get_temp_file("json")
+        expected_file = self.get_test_loc(
+            "vcpkg/vcpkg-end-to-end-expected.json", must_exist=not REGEN_TEST_FIXTURES
+        )
+        run_scan_click(
+            [
+                "--package",
+                "--strip-root",
+                "--processes",
+                "-1",
+                test_dir,
+                "--json",
+                result_file,
+            ]
+        )
+        check_json_scan(
+            expected_file, result_file, remove_uuid=True, regen=REGEN_TEST_FIXTURES
+        )
+


### PR DESCRIPTION
## Summary
- add a dedicated vcpkg portfile parser for portfile.cmake manifests
- register the new handler in the packagedcode parser registry
- add regression coverage and update the vcpkg end-to-end fixture

## Testing
- python -m pytest -q tests/packagedcode/test_vcpkg.py